### PR TITLE
Add datetime tool for server time in user timezone

### DIFF
--- a/backend/scripts/seed.py
+++ b/backend/scripts/seed.py
@@ -25,6 +25,7 @@ from sqlalchemy import select
 from src.core.security import hash_password
 from src.db.base import AsyncSessionLocal
 from src.db.orm.tenants import Tenant
+from src.db.orm.tools import Tool
 from src.db.orm.users import User
 
 # ---------------------------------------------------------------------------
@@ -86,6 +87,30 @@ async def main() -> None:
             print(f"[seed] Created admin user: {ADMIN_EMAIL} (id={admin.id})")
         else:
             print(f"[seed] Admin user already exists: {ADMIN_EMAIL} (id={admin.id})")
+
+        # 3. Ensure default datetime tool exists
+        result = await db.execute(
+            select(Tool).where(
+                Tool.tenant_id == tenant.id,
+                Tool.type == "datetime",
+                Tool.name == "Current Time",
+            )
+        )
+        datetime_tool = result.scalar_one_or_none()
+
+        if datetime_tool is None:
+            datetime_tool = Tool(
+                tenant_id=tenant.id,
+                name="Current Time",
+                type="datetime",
+                config={"default_timezone": "UTC"},
+                enabled=True,
+            )
+            db.add(datetime_tool)
+            await db.flush()
+            print(f"[seed] Created datetime tool: Current Time (id={datetime_tool.id})")
+        else:
+            print(f"[seed] Datetime tool already exists: Current Time (id={datetime_tool.id})")
 
         await db.commit()
 

--- a/backend/scripts/seed.py
+++ b/backend/scripts/seed.py
@@ -105,6 +105,7 @@ async def main() -> None:
                 type="datetime",
                 config={"default_timezone": "UTC"},
                 enabled=True,
+                is_public=True,
             )
             db.add(datetime_tool)
             await db.flush()

--- a/backend/src/agents/runner.py
+++ b/backend/src/agents/runner.py
@@ -411,6 +411,9 @@ async def _build_tool_callables(
     elif tool.type == "custom":
         # Stub for Phase 6
         return []
+    elif tool.type == "datetime":
+        from ..tools.datetime import build_datetime_tools
+        return build_datetime_tools(tool.config or {})
     else:
         logger.warning("Unknown tool type '%s' for tool %s", tool.type, tool.id)
         return []

--- a/backend/src/api/admin.py
+++ b/backend/src/api/admin.py
@@ -80,16 +80,20 @@ from ..services.skill_service import (
 from ..services.group_service import (
     add_member as _svc_add_member,
     assign_model_to_group as _svc_assign_model_to_group,
+    assign_tool_to_group as _svc_assign_tool_to_group,
     create_group as _svc_create_group,
     delete_group as _svc_delete_group,
     get_group_by_id,
     list_group_members as _svc_list_group_members,
     list_group_models as _svc_list_group_models,
+    list_group_tools as _svc_list_group_tools,
     list_groups as _svc_list_groups,
     list_model_groups as _svc_list_model_groups,
+    list_tool_groups as _svc_list_tool_groups,
     list_user_groups as _svc_list_user_groups,
     remove_member as _svc_remove_member,
     remove_model_from_group as _svc_remove_model_from_group,
+    remove_tool_from_group as _svc_remove_tool_from_group,
     update_group as _svc_update_group,
 )
 
@@ -237,6 +241,7 @@ class ToolCreate(BaseModel):
     type: str
     config: dict | None = None
     enabled: bool = True
+    is_public: bool = False
 
 
 class ToolUpdate(BaseModel):
@@ -244,6 +249,7 @@ class ToolUpdate(BaseModel):
     type: str | None = None
     config: dict | None = None
     enabled: bool | None = None
+    is_public: bool | None = None
 
 
 class ToolResponse(BaseModel):
@@ -253,6 +259,7 @@ class ToolResponse(BaseModel):
     type: str
     config: dict | None
     enabled: bool
+    is_public: bool
     created_at: datetime
     updated_at: datetime
 
@@ -325,12 +332,25 @@ class GroupModelResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class GroupToolResponse(BaseModel):
+    id: str
+    name: str
+    type: str
+    enabled: bool
+
+    model_config = {"from_attributes": True}
+
+
 class MemberAdd(BaseModel):
     user_id: str
 
 
 class ModelAssign(BaseModel):
     model_id: str
+
+
+class ToolAssign(BaseModel):
+    tool_id: str
 
 
 # =============================================================================
@@ -726,6 +746,7 @@ async def create_tool(
         type=body.type,
         config=body.config,
         enabled=body.enabled,
+        is_public=body.is_public,
     )
     await write_audit_log(
         db,
@@ -763,6 +784,8 @@ async def update_tool(
         update_kwargs["config"] = body.config
     if body.enabled is not None:
         update_kwargs["enabled"] = body.enabled
+    if body.is_public is not None:
+        update_kwargs["is_public"] = body.is_public
 
     tool = await _svc_update_tool(db, tool_id, **update_kwargs)
 
@@ -1610,7 +1633,85 @@ async def remove_model_from_group(
 
 
 # =============================================================================
-# Helper Endpoints — user groups & model groups
+# Group-Tool Assignment Endpoints (admin or manager)
+# =============================================================================
+
+
+@router.get("/groups/{group_id}/tools", response_model=list[GroupToolResponse])
+async def list_group_tools(
+    group_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserORM = Depends(require_admin_or_manager),
+):
+    """List tools assigned to a group."""
+    target = await get_group_by_id(db, group_id)
+    if target is None:
+        raise NotFoundError("Group not found")
+    if current_user.role == "manager" and target.tenant_id != current_user.tenant_id:
+        raise ForbiddenError("Managers can only view groups in their own tenant")
+
+    tools = await _svc_list_group_tools(db, group_id)
+    return [GroupToolResponse.model_validate(t) for t in tools]
+
+
+@router.post("/groups/{group_id}/tools", status_code=201)
+async def assign_tool_to_group(
+    group_id: str,
+    body: ToolAssign,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserORM = Depends(require_admin_or_manager),
+):
+    """Assign a tool to a group."""
+    target = await get_group_by_id(db, group_id)
+    if target is None:
+        raise NotFoundError("Group not found")
+    if current_user.role == "manager" and target.tenant_id != current_user.tenant_id:
+        raise ForbiddenError("Managers can only modify groups in their own tenant")
+
+    await _svc_assign_tool_to_group(db, group_id, body.tool_id)
+    await write_audit_log(
+        db,
+        actor=current_user,
+        action="group.tool_assigned",
+        target_type="group",
+        target_id=group_id,
+        payload={"tool_id": body.tool_id},
+        tenant_id=current_user.tenant_id,
+        ip_address=_get_client_ip(request),
+    )
+
+
+@router.delete("/groups/{group_id}/tools/{tool_id}", status_code=204)
+async def remove_tool_from_group(
+    group_id: str,
+    tool_id: str,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserORM = Depends(require_admin_or_manager),
+):
+    """Remove a tool from a group."""
+    target = await get_group_by_id(db, group_id)
+    if target is None:
+        raise NotFoundError("Group not found")
+    if current_user.role == "manager" and target.tenant_id != current_user.tenant_id:
+        raise ForbiddenError("Managers can only modify groups in their own tenant")
+
+    await _svc_remove_tool_from_group(db, group_id, tool_id)
+    await write_audit_log(
+        db,
+        actor=current_user,
+        action="group.tool_removed",
+        target_type="group",
+        target_id=group_id,
+        payload={"tool_id": tool_id},
+        tenant_id=current_user.tenant_id,
+        ip_address=_get_client_ip(request),
+    )
+
+
+# =============================================================================
+# Helper Endpoints — user groups, model groups & tool groups
 # =============================================================================
 
 
@@ -1635,6 +1736,19 @@ async def list_model_groups(
 ):
     """List groups a model is assigned to."""
     groups = await _svc_list_model_groups(db, model_id)
+    if current_user.role == "manager":
+        groups = [g for g in groups if g.tenant_id == current_user.tenant_id]
+    return [GroupResponse.model_validate(g) for g in groups]
+
+
+@router.get("/tools/{tool_id}/groups", response_model=list[GroupResponse])
+async def list_tool_groups(
+    tool_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserORM = Depends(require_admin_or_manager),
+):
+    """List groups a tool is assigned to."""
+    groups = await _svc_list_tool_groups(db, tool_id)
     if current_user.role == "manager":
         groups = [g for g in groups if g.tenant_id == current_user.tenant_id]
     return [GroupResponse.model_validate(g) for g in groups]

--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -45,6 +45,7 @@ from ..core.redis import (
 from ..db.orm.messages import Message, MessageFeedback
 from ..db.orm.sessions import Session
 from ..db.orm.tools import Tool
+from ..db.orm.user_tool_preferences import UserToolPreference
 from ..db.orm.users import User as UserORM
 from ..services import session_service, upload_service
 from ..storage import s3
@@ -327,7 +328,23 @@ async def create_session(
     db: AsyncSession = Depends(get_db),
     current_user: UserORM = Depends(get_current_user),
 ):
-    """Create a permanent (DB) or temporary (Redis) session."""
+    """Create a permanent (DB) or temporary (Redis) session.
+
+    If ``active_tool_ids`` is not provided, auto-activates tools that the
+    user has marked as "always on" in their preferences.
+    """
+    # Resolve active tool IDs: explicit list > always-on preferences > empty
+    active_tool_ids = body.active_tool_ids
+    if active_tool_ids is None:
+        pref_result = await db.execute(
+            select(UserToolPreference.tool_id).where(
+                UserToolPreference.user_id == current_user.id,
+                UserToolPreference.always_on == True,  # noqa: E712
+            )
+        )
+        always_on_ids = [row[0] for row in pref_result.all()]
+        active_tool_ids = always_on_ids
+
     if body.is_temporary:
         # Create in Redis
         session_id = str(uuid.uuid4())
@@ -343,7 +360,7 @@ async def create_session(
             "selected_skill_id": body.selected_skill_id,
             "selected_model_id": body.selected_model_id,
             "thinking_enabled": body.thinking_enabled,
-            "active_tool_ids": body.active_tool_ids or [],
+            "active_tool_ids": active_tool_ids,
             "created_at": datetime.now(timezone.utc).isoformat(),
             "updated_at": datetime.now(timezone.utc).isoformat(),
         }
@@ -380,6 +397,23 @@ async def create_session(
             selected_model_id=body.selected_model_id,
             thinking_enabled=body.thinking_enabled,
         )
+
+        # Auto-activate always-on tools for permanent session
+        for tool_id in active_tool_ids:
+            try:
+                await session_service.add_session_tool(
+                    db=db,
+                    session_id=session.id,
+                    tool_id=tool_id,
+                    tenant_id=current_user.tenant_id,
+                )
+            except Exception:
+                logger.debug(
+                    "Could not auto-activate always-on tool %s for session %s",
+                    tool_id,
+                    session.id,
+                )
+
         return SessionResponse.model_validate(session)
 
 
@@ -1217,6 +1251,58 @@ async def list_available_tools(
     )
     enabled = [t for t in tools if t.enabled]
     return [ToolResponse.model_validate(t) for t in enabled]
+
+
+@router.put("/session/tools/{tool_id}/always-on", status_code=204)
+async def set_tool_always_on(
+    tool_id: str,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserORM = Depends(get_current_user),
+):
+    """Toggle a tool as always-on for the current user.
+
+    Body: {"always_on": true|false}
+    When always_on, the tool is automatically activated for new sessions.
+    """
+    body = await request.json()
+    always_on = bool(body.get("always_on", False))
+
+    # Upsert the preference
+    existing = await db.execute(
+        select(UserToolPreference).where(
+            UserToolPreference.user_id == current_user.id,
+            UserToolPreference.tool_id == tool_id,
+        )
+    )
+    pref = existing.scalar_one_or_none()
+
+    if pref is None:
+        pref = UserToolPreference(
+            user_id=current_user.id,
+            tool_id=tool_id,
+            always_on=always_on,
+        )
+        db.add(pref)
+    else:
+        pref.always_on = always_on
+
+    await db.commit()
+
+
+@router.get("/session/tools/always-on", response_model=list[str])
+async def list_always_on_tools(
+    db: AsyncSession = Depends(get_db),
+    current_user: UserORM = Depends(get_current_user),
+):
+    """Return the list of tool IDs the user has marked as always-on."""
+    result = await db.execute(
+        select(UserToolPreference.tool_id).where(
+            UserToolPreference.user_id == current_user.id,
+            UserToolPreference.always_on == True,  # noqa: E712
+        )
+    )
+    return [row[0] for row in result.all()]
 
 
 @router.get(

--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -1196,6 +1196,25 @@ async def list_message_uploads(
 
 
 @router.get(
+    "/session/tools/available",
+    response_model=list[ToolResponse],
+)
+async def list_available_tools(
+    db: AsyncSession = Depends(get_db),
+    current_user: UserORM = Depends(get_current_user),
+):
+    """List all enabled tools available for the current tenant."""
+    result = await db.execute(
+        select(Tool).where(
+            Tool.tenant_id == current_user.tenant_id,
+            Tool.enabled == True,  # noqa: E712
+        ).order_by(Tool.name)
+    )
+    tools = result.scalars().all()
+    return [ToolResponse.model_validate(t) for t in tools]
+
+
+@router.get(
     "/session/{session_id}/tools",
     response_model=list[ToolResponse],
 )

--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -1203,15 +1203,20 @@ async def list_available_tools(
     db: AsyncSession = Depends(get_db),
     current_user: UserORM = Depends(get_current_user),
 ):
-    """List all enabled tools available for the current tenant."""
-    result = await db.execute(
-        select(Tool).where(
-            Tool.tenant_id == current_user.tenant_id,
-            Tool.enabled == True,  # noqa: E712
-        ).order_by(Tool.name)
+    """List all enabled tools available for the current user.
+
+    Tools are filtered by group access control:
+    is_public=True OR tool assigned to a group the user belongs to.
+    """
+    from ..services.tool_service import list_tools
+
+    tools = await list_tools(
+        db,
+        tenant_id=current_user.tenant_id,
+        user_id=current_user.id,
     )
-    tools = result.scalars().all()
-    return [ToolResponse.model_validate(t) for t in tools]
+    enabled = [t for t in tools if t.enabled]
+    return [ToolResponse.model_validate(t) for t in enabled]
 
 
 @router.get(

--- a/backend/src/db/migrations/versions/a1b2c3d4e5f6_add_datetime_to_tool_type_enum.py
+++ b/backend/src/db/migrations/versions/a1b2c3d4e5f6_add_datetime_to_tool_type_enum.py
@@ -1,0 +1,31 @@
+"""add_datetime_to_tool_type_enum
+
+Revision ID: a1b2c3d4e5f6
+Revises: 5db963e14b25
+Create Date: 2026-05-08
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "5db963e14b25"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE tools MODIFY COLUMN type "
+        "ENUM('erpnext','membrane','custom','datetime') NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE tools MODIFY COLUMN type "
+        "ENUM('erpnext','membrane','custom') NOT NULL"
+    )

--- a/backend/src/db/migrations/versions/b2c3d4e5f6a7_add_is_public_and_tool_groups.py
+++ b/backend/src/db/migrations/versions/b2c3d4e5f6a7_add_is_public_and_tool_groups.py
@@ -1,0 +1,52 @@
+"""add_is_public_and_tool_groups
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-05-08
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b2c3d4e5f6a7"
+down_revision: Union[str, None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. Add is_public to tools
+    op.add_column(
+        "tools",
+        sa.Column(
+            "is_public",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+
+    # 2. Create tool_groups table
+    op.create_table(
+        "tool_groups",
+        sa.Column("tool_id", mysql.CHAR(length=36), nullable=False),
+        sa.Column("group_id", mysql.CHAR(length=36), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(["tool_id"], ["tools.id"]),
+        sa.ForeignKeyConstraint(["group_id"], ["user_groups.id"]),
+        sa.PrimaryKeyConstraint("tool_id", "group_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("tool_groups")
+    op.drop_column("tools", "is_public")

--- a/backend/src/db/migrations/versions/c3d4e5f6a7b8_add_user_tool_preferences.py
+++ b/backend/src/db/migrations/versions/c3d4e5f6a7b8_add_user_tool_preferences.py
@@ -1,0 +1,37 @@
+"""add_user_tool_preferences
+
+Revision ID: c3d4e5f6a7b8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-05-08
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c3d4e5f6a7b8"
+down_revision: Union[str, None] = "b2c3d4e5f6a7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_tool_preferences",
+        sa.Column("user_id", mysql.CHAR(length=36), nullable=False),
+        sa.Column("tool_id", mysql.CHAR(length=36), nullable=False),
+        sa.Column("always_on", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["tool_id"], ["tools.id"]),
+        sa.PrimaryKeyConstraint("user_id", "tool_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_tool_preferences")

--- a/backend/src/db/orm/groups.py
+++ b/backend/src/db/orm/groups.py
@@ -13,6 +13,7 @@ from ..base import Base
 from .tenants import Tenant
 from .users import User
 from .models import Model
+from .tools import Tool
 
 
 class UserGroup(Base):
@@ -52,6 +53,20 @@ class ModelGroup(Base):
 
     model_id: Mapped[str] = mapped_column(
         CHAR(36), ForeignKey("models.id"), primary_key=True
+    )
+    group_id: Mapped[str] = mapped_column(
+        CHAR(36), ForeignKey("user_groups.id"), primary_key=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+
+class ToolGroup(Base):
+    __tablename__ = "tool_groups"
+
+    tool_id: Mapped[str] = mapped_column(
+        CHAR(36), ForeignKey("tools.id"), primary_key=True
     )
     group_id: Mapped[str] = mapped_column(
         CHAR(36), ForeignKey("user_groups.id"), primary_key=True

--- a/backend/src/db/orm/tools.py
+++ b/backend/src/db/orm/tools.py
@@ -24,7 +24,7 @@ class Tool(Base):
     )
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     type: Mapped[str] = mapped_column(
-        Enum("erpnext", "membrane", "custom", name="tool_type_enum"), nullable=False
+        Enum("erpnext", "membrane", "custom", "datetime", name="tool_type_enum"), nullable=False
     )
     config: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)

--- a/backend/src/db/orm/tools.py
+++ b/backend/src/db/orm/tools.py
@@ -28,6 +28,7 @@ class Tool(Base):
     )
     config: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    is_public: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/src/db/orm/user_tool_preferences.py
+++ b/backend/src/db/orm/user_tool_preferences.py
@@ -1,0 +1,33 @@
+# =============================================================================
+# PH Agent Hub — ORM: User Tool Preferences
+# =============================================================================
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, func
+from sqlalchemy.dialects.mysql import CHAR
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ..base import Base
+from .users import User
+from .tools import Tool
+
+
+class UserToolPreference(Base):
+    __tablename__ = "user_tool_preferences"
+
+    user_id: Mapped[str] = mapped_column(
+        CHAR(36), ForeignKey("users.id"), primary_key=True
+    )
+    tool_id: Mapped[str] = mapped_column(
+        CHAR(36), ForeignKey("tools.id"), primary_key=True
+    )
+    always_on: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )

--- a/backend/src/models/deepseek.py
+++ b/backend/src/models/deepseek.py
@@ -86,14 +86,23 @@ class DeepSeekThinkingClient(OpenAIChatCompletionClient):
         self,
         message: Message,
     ) -> list[dict[str, Any]]:
-        """Convert ``reasoning_details`` (protected_data) back to ``reasoning_content``."""
+        """Convert ``reasoning_details`` back to ``reasoning_content``.
+
+        The base class may already decode ``reasoning_details`` from JSON
+        (e.g. when it came from Content items).  We handle both cases.
+        """
         prepared = super()._prepare_message_for_openai(message)
         for msg in prepared:
             if "reasoning_details" in msg:
-                try:
-                    msg["reasoning_content"] = json.loads(msg.pop("reasoning_details"))
-                except (json.JSONDecodeError, TypeError):
-                    logger.warning("Failed to decode reasoning_details for message")
+                value = msg.pop("reasoning_details")
+                if isinstance(value, str):
+                    try:
+                        msg["reasoning_content"] = json.loads(value)
+                    except (json.JSONDecodeError, TypeError):
+                        # Already a plain string from the base class decode
+                        msg["reasoning_content"] = value
+                else:
+                    msg["reasoning_content"] = value
         return prepared
 
 

--- a/backend/src/models/deepseek.py
+++ b/backend/src/models/deepseek.py
@@ -35,15 +35,28 @@ class DeepSeekThinkingClient(OpenAIChatCompletionClient):
         messages: Sequence[Message],
         options: Mapping[str, Any],
     ) -> dict[str, Any]:
-        """Inject ``extra_body`` with explicit thinking mode (always sent).
+        """Inject ``extra_body`` with explicit thinking mode.
 
-        DeepSeek's default thinking behavior varies by model (some have it
-        on by default).  We always send an explicit enabled/disabled to
-        guarantee consistent behavior regardless of model defaults.
+        When thinking is enabled but a tool call has just completed
+        (tool result present in messages), disable thinking for this
+        request to avoid the DeepSeek requirement that reasoning_content
+        must be passed back — which MAF doesn't fully support across
+        tool-call boundaries.
         """
         result = super()._prepare_options(messages, options)
+
+        thinking_type = "disabled"
+        if self._thinking_enabled:
+            # Check if there are tool results in the conversation
+            prepared_msgs = result.get("messages", [])
+            has_tool_result = any(
+                msg.get("role") == "tool" for msg in prepared_msgs
+            )
+            if not has_tool_result:
+                thinking_type = "enabled"
+
         result["extra_body"] = {
-            "thinking": {"type": "enabled" if self._thinking_enabled else "disabled"}
+            "thinking": {"type": thinking_type}
         }
         return result
 

--- a/backend/src/services/group_service.py
+++ b/backend/src/services/group_service.py
@@ -6,8 +6,9 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..core.exceptions import NotFoundError, ConflictError
-from ..db.orm.groups import UserGroup, UserGroupMember, ModelGroup
+from ..db.orm.groups import UserGroup, UserGroupMember, ModelGroup, ToolGroup
 from ..db.orm.models import Model
+from ..db.orm.tools import Tool
 from ..db.orm.users import User
 
 
@@ -224,6 +225,81 @@ async def list_model_groups(
         select(UserGroup)
         .join(ModelGroup, ModelGroup.group_id == UserGroup.id)
         .where(ModelGroup.model_id == model_id)
+        .order_by(UserGroup.name)
+    )
+    return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# Tool-Group Assignment
+# ---------------------------------------------------------------------------
+
+
+async def assign_tool_to_group(
+    db: AsyncSession, group_id: str, tool_id: str
+) -> ToolGroup:
+    """Assign a tool to a group. No-op if already assigned."""
+    # Check group exists
+    group = await get_group_by_id(db, group_id)
+    if group is None:
+        raise NotFoundError("Group not found")
+
+    # Check tool exists
+    tool_result = await db.execute(select(Tool).where(Tool.id == tool_id))
+    if tool_result.scalar_one_or_none() is None:
+        raise NotFoundError("Tool not found")
+
+    # Check if already assigned
+    existing = await db.execute(
+        select(ToolGroup).where(
+            ToolGroup.group_id == group_id,
+            ToolGroup.tool_id == tool_id,
+        )
+    )
+    if existing.scalar_one_or_none() is not None:
+        return existing.scalar_one()
+
+    tg = ToolGroup(tool_id=tool_id, group_id=group_id)
+    db.add(tg)
+    await db.commit()
+    await db.refresh(tg)
+    return tg
+
+
+async def remove_tool_from_group(
+    db: AsyncSession, group_id: str, tool_id: str
+) -> None:
+    """Remove a tool from a group. No-op if not assigned."""
+    await db.execute(
+        delete(ToolGroup).where(
+            ToolGroup.group_id == group_id,
+            ToolGroup.tool_id == tool_id,
+        )
+    )
+    await db.commit()
+
+
+async def list_group_tools(
+    db: AsyncSession, group_id: str
+) -> list[Tool]:
+    """Return all tools assigned to a group."""
+    result = await db.execute(
+        select(Tool)
+        .join(ToolGroup, ToolGroup.tool_id == Tool.id)
+        .where(ToolGroup.group_id == group_id)
+        .order_by(Tool.name)
+    )
+    return list(result.scalars().all())
+
+
+async def list_tool_groups(
+    db: AsyncSession, tool_id: str
+) -> list[UserGroup]:
+    """Return all groups a tool is assigned to."""
+    result = await db.execute(
+        select(UserGroup)
+        .join(ToolGroup, ToolGroup.group_id == UserGroup.id)
+        .where(ToolGroup.tool_id == tool_id)
         .order_by(UserGroup.name)
     )
     return list(result.scalars().all())

--- a/backend/src/services/tool_service.py
+++ b/backend/src/services/tool_service.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..core.exceptions import NotFoundError, ValidationError
 from ..db.orm.tools import Tool
 
-VALID_TOOL_TYPES = {"erpnext", "membrane", "custom"}
+VALID_TOOL_TYPES = {"erpnext", "membrane", "custom", "datetime"}
 
 
 async def list_tools(

--- a/backend/src/services/tool_service.py
+++ b/backend/src/services/tool_service.py
@@ -2,22 +2,45 @@
 # PH Agent Hub — Tool Service (CRUD)
 # =============================================================================
 
-from sqlalchemy import select
+from sqlalchemy import select, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..core.exceptions import NotFoundError, ValidationError
+from ..db.orm.groups import ToolGroup, UserGroupMember
 from ..db.orm.tools import Tool
 
 VALID_TOOL_TYPES = {"erpnext", "membrane", "custom", "datetime"}
 
 
 async def list_tools(
-    db: AsyncSession, tenant_id: str | None = None
+    db: AsyncSession,
+    tenant_id: str | None = None,
+    user_id: str | None = None,
 ) -> list[Tool]:
-    """Return all tools, optionally filtered by tenant_id."""
+    """Return all tools, optionally filtered by tenant_id and user access.
+
+    When user_id is provided, only returns tools where:
+    - is_public=True, OR
+    - the tool is assigned to a group the user belongs to
+    """
     stmt = select(Tool)
     if tenant_id is not None:
         stmt = stmt.where(Tool.tenant_id == tenant_id)
+
+    if user_id is not None:
+        # Subquery: tool IDs assigned to groups the user belongs to
+        user_group_subq = (
+            select(ToolGroup.tool_id)
+            .join(UserGroupMember, UserGroupMember.group_id == ToolGroup.group_id)
+            .where(UserGroupMember.user_id == user_id)
+        )
+        stmt = stmt.where(
+            or_(
+                Tool.is_public == True,  # noqa: E712
+                Tool.id.in_(user_group_subq),
+            )
+        )
+
     stmt = stmt.order_by(Tool.created_at)
     result = await db.execute(stmt)
     return list(result.scalars().all())
@@ -36,6 +59,7 @@ async def create_tool(
     type: str,
     config: dict | None = None,
     enabled: bool = True,
+    is_public: bool = False,
 ) -> Tool:
     """Create a new tool. Raises ValidationError if type is invalid."""
     if type not in VALID_TOOL_TYPES:
@@ -50,6 +74,7 @@ async def create_tool(
         type=type,
         config=config,
         enabled=enabled,
+        is_public=is_public,
     )
     db.add(tool)
     await db.commit()

--- a/backend/src/tools/datetime.py
+++ b/backend/src/tools/datetime.py
@@ -1,0 +1,79 @@
+# =============================================================================
+# PH Agent Hub — Datetime Tool Factory
+# =============================================================================
+# Builds a MAF @tool-decorated async function that returns the current
+# date and time for a given IANA timezone (defaults to UTC).
+# =============================================================================
+
+import logging
+from datetime import datetime
+from zoneinfo import ZoneInfo, available_timezones
+
+from agent_framework import tool
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Tool factory
+# ---------------------------------------------------------------------------
+
+
+def build_datetime_tools(tool_config: dict | None = None) -> list:
+    """Return a list containing the MAF @tool-decorated current_time function.
+
+    Args:
+        tool_config: Optional ``Tool.config`` JSON dict.  May include a
+            ``default_timezone`` key to override the fallback timezone.
+
+    Returns:
+        A list with a single callable ready to pass to ``Agent(tools=...)``.
+    """
+    config = tool_config or {}
+    default_tz = config.get("default_timezone", "UTC")
+
+    @tool
+    async def current_time(timezone: str | None = None) -> dict:
+        """Get the current date and time.
+
+        Args:
+            timezone: Optional IANA timezone name (e.g. "America/New_York",
+                "Europe/London", "Asia/Tokyo").  Defaults to the server's
+                configured default timezone (usually UTC).
+
+        Returns:
+            A dict with keys:
+            - ``iso``: ISO 8601 datetime string with timezone offset
+            - ``date``: date in YYYY-MM-DD format
+            - ``time``: time in HH:MM:SS format
+            - ``timezone``: the IANA timezone used
+            - ``utc_offset``: UTC offset string (e.g. "+05:30")
+            - ``day_of_week``: full weekday name
+            - ``unix_timestamp``: Unix timestamp (seconds since epoch)
+        """
+        tz_name = timezone or default_tz
+
+        # Validate timezone
+        if tz_name not in available_timezones():
+            logger.warning(
+                "current_time called with unknown timezone '%s', falling back to UTC",
+                tz_name,
+            )
+            tz_name = "UTC"
+
+        tz = ZoneInfo(tz_name)
+        now = datetime.now(tz)
+
+        result = {
+            "iso": now.isoformat(),
+            "date": now.strftime("%Y-%m-%d"),
+            "time": now.strftime("%H:%M:%S"),
+            "timezone": tz_name,
+            "utc_offset": now.strftime("%z"),
+            "day_of_week": now.strftime("%A"),
+            "unix_timestamp": int(now.timestamp()),
+        }
+
+        logger.debug("current_time(%s) → %s", timezone, result["iso"])
+        return result
+
+    return [current_time]

--- a/frontend/src/features/admin/resources/tools/ToolForm.tsx
+++ b/frontend/src/features/admin/resources/tools/ToolForm.tsx
@@ -28,6 +28,7 @@ export function ToolForm({ open, tool, onClose }: ToolFormProps) {
   const [form] = Form.useForm();
   const queryClient = useQueryClient();
   const isEdit = !!tool;
+  const [isPublic, setIsPublic] = React.useState(tool?.is_public ?? false);
 
   React.useEffect(() => {
     if (open) {
@@ -36,16 +37,20 @@ export function ToolForm({ open, tool, onClose }: ToolFormProps) {
           name: tool.name,
           type: tool.type,
           enabled: tool.enabled,
+          is_public: tool.is_public,
           config_json: tool.config
             ? JSON.stringify(tool.config, null, 2)
             : "",
         });
+        setIsPublic(tool.is_public);
       } else {
         form.resetFields();
         form.setFieldsValue({
           type: "custom",
           enabled: true,
+          is_public: false,
         });
+        setIsPublic(false);
       }
     }
   }, [open, tool, form]);
@@ -142,6 +147,14 @@ export function ToolForm({ open, tool, onClose }: ToolFormProps) {
         </Form.Item>
         <Form.Item name="enabled" label="Enabled" valuePropName="checked">
           <Switch />
+        </Form.Item>
+        <Form.Item
+          name="is_public"
+          label="Public"
+          valuePropName="checked"
+          tooltip="When enabled, all tenant users can use this tool regardless of group membership"
+        >
+          <Switch onChange={(checked) => setIsPublic(checked)} />
         </Form.Item>
       </Form>
     </Modal>

--- a/frontend/src/features/admin/resources/tools/ToolForm.tsx
+++ b/frontend/src/features/admin/resources/tools/ToolForm.tsx
@@ -130,6 +130,7 @@ export function ToolForm({ open, tool, onClose }: ToolFormProps) {
               { label: "ERPNext", value: "erpnext" },
               { label: "Membrane", value: "membrane" },
               { label: "Custom", value: "custom" },
+              { label: "Datetime", value: "datetime" },
             ]}
           />
         </Form.Item>

--- a/frontend/src/features/admin/services/admin.ts
+++ b/frontend/src/features/admin/services/admin.ts
@@ -56,6 +56,7 @@ export interface ToolData {
   type: string;
   config: Record<string, unknown> | null;
   enabled: boolean;
+  is_public: boolean;
   created_at: string;
   updated_at: string;
 }

--- a/frontend/src/features/chat/components/SessionToolActivation.tsx
+++ b/frontend/src/features/chat/components/SessionToolActivation.tsx
@@ -12,6 +12,7 @@ import {
   Empty,
   Space,
   message,
+  Tooltip,
 } from "antd";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "../../../services/api";
@@ -19,6 +20,8 @@ import {
   listSessionTools,
   addSessionTool,
   removeSessionTool,
+  setToolAlwaysOn,
+  listAlwaysOnTools,
   ToolData,
 } from "../services/chat";
 
@@ -51,6 +54,14 @@ export function SessionToolActivation({
     enabled: open,
   });
 
+  // Always-on tool IDs for this user
+  const { data: alwaysOnIds } = useQuery({
+    queryKey: ["always-on-tools"],
+    queryFn: listAlwaysOnTools,
+    enabled: open,
+  });
+
+  const alwaysOnSet = new Set(alwaysOnIds || []);
   const activeIds = new Set((activeTools || []).map((t) => t.id));
 
   const addMutation = useMutation({
@@ -69,6 +80,15 @@ export function SessionToolActivation({
     onError: () => message.error("Failed to remove tool"),
   });
 
+  const alwaysOnMutation = useMutation({
+    mutationFn: ({ toolId, alwaysOn }: { toolId: string; alwaysOn: boolean }) =>
+      setToolAlwaysOn(toolId, alwaysOn),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["always-on-tools"] });
+    },
+    onError: () => message.error("Failed to update always-on preference"),
+  });
+
   const handleToggle = (toolId: string, checked: boolean) => {
     if (checked) {
       addMutation.mutate(toolId);
@@ -82,7 +102,7 @@ export function SessionToolActivation({
       title="Session Tools"
       open={open}
       onClose={onClose}
-      width={400}
+      width={420}
     >
       <List
         loading={loadingAvailable || loadingActive}
@@ -95,7 +115,21 @@ export function SessionToolActivation({
         renderItem={(tool) => (
           <List.Item
             actions={[
+              <Tooltip title="Auto-activate in new sessions" key="always">
+                <Switch
+                  size="small"
+                  checked={alwaysOnSet.has(tool.id)}
+                  onChange={(checked) =>
+                    alwaysOnMutation.mutate({
+                      toolId: tool.id,
+                      alwaysOn: checked,
+                    })
+                  }
+                  loading={alwaysOnMutation.isPending}
+                />
+              </Tooltip>,
               <Switch
+                key="active"
                 checked={activeIds.has(tool.id)}
                 onChange={(checked) => handleToggle(tool.id, checked)}
                 loading={
@@ -108,7 +142,10 @@ export function SessionToolActivation({
               title={tool.name}
               description={
                 <Space direction="vertical" size={0}>
-                  <Text type="secondary">Type: {tool.type}</Text>
+                  <Text type="secondary">
+                    Type: {tool.type}
+                    {alwaysOnSet.has(tool.id) ? " · Always on" : ""}
+                  </Text>
                   {tool.enabled ? null : (
                     <Text type="danger">Disabled</Text>
                   )}

--- a/frontend/src/features/chat/services/chat.ts
+++ b/frontend/src/features/chat/services/chat.ts
@@ -218,6 +218,20 @@ export function removeSessionTool(
   });
 }
 
+export function setToolAlwaysOn(
+  toolId: string,
+  alwaysOn: boolean,
+): Promise<void> {
+  return api<void>(`/chat/session/tools/${toolId}/always-on`, {
+    method: "PUT",
+    body: { always_on: alwaysOn },
+  });
+}
+
+export function listAlwaysOnTools(): Promise<string[]> {
+  return api<string[]>("/chat/session/tools/always-on");
+}
+
 // ---------------------------------------------------------------------------
 // Search
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Introduce a new "datetime" tool that provides the current server date and time based on the user's timezone. Implemented related API endpoints, user tool preferences, and enhanced the admin interface for tool management. This update addresses the need for a tool that returns server time in the user's timezone.

Fixes #32