### PR TITLE
Increase pip install timeout and add file content extraction tool

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,8 +6,9 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Install Python dependencies
+# Use increased timeout (1000s) and retries for large packages like claude_agent_sdk (~75MB)
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --timeout=1000 --retries=5 -r requirements.txt
 
 # Copy application code
 COPY . .

--- a/backend/src/tools/file_list.py
+++ b/backend/src/tools/file_list.py
@@ -7,6 +7,7 @@
 
 import logging
 from typing import Any
+from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -14,13 +15,15 @@ from agent_framework import tool
 
 logger = logging.getLogger(__name__)
 
+MAX_FILE_CONTENT_CHARS = 50_000
+
 
 def build_file_list_tool(
     db: AsyncSession,
     session_id: str,
     tenant_id: str,
 ) -> list:
-    """Return a single MAF @tool that lists file uploads for the session.
+    """Return built-in MAF @tools for file discovery and content reading.
 
     Args:
         db: Active async DB session.
@@ -34,8 +37,9 @@ def build_file_list_tool(
         """List all files uploaded in this conversation session.
 
         Returns filename, content type, size (KB), a short text preview,
-        and the file_id needed to reference it in other tools.  Call this
-        when a user mentions a file and you need to know its exact name
+        and the file_id.  To read the full extracted text of a file, use
+        ``read_file_content(file_id)`` with the file_id returned here.
+        Call this when a user mentions a file and you need its exact name
         (e.g. for the ERPNext ``upload_file`` tool).
         """
         result = await db.execute(
@@ -67,4 +71,60 @@ def build_file_list_tool(
         )
         return files
 
-    return [list_uploaded_files]
+    @tool
+    async def read_file_content(file_id: str) -> dict[str, Any]:
+        """Return the full extracted text content of a previously uploaded file.
+
+        Args:
+            file_id: The file ID returned by ``list_uploaded_files()``.
+
+        Returns a dict with ``filename``, ``content_type``, ``text`` (the full
+        extracted content), and ``truncated`` (bool, True if the text was
+        truncated to {max_chars} characters).
+
+        If the file is not found or has no extracted text, an error message
+        is returned in the ``error`` field.
+        """.format(max_chars=MAX_FILE_CONTENT_CHARS)
+        try:
+            UUID(file_id)  # validate format only
+        except ValueError:
+            return {"error": f"Invalid file_id: {file_id!r}"}
+
+        result = await db.execute(
+            select(FileUpload).where(
+                FileUpload.id == file_id,
+                FileUpload.tenant_id == tenant_id,
+            )
+        )
+        upload = result.scalar_one_or_none()
+
+        if upload is None:
+            return {"error": f"File not found: {file_id}"}
+
+        if not upload.extracted_text:
+            return {
+                "filename": upload.original_filename,
+                "content_type": upload.content_type,
+                "text": "",
+                "truncated": False,
+                "note": "No text could be extracted from this file.",
+            }
+
+        text = upload.extracted_text
+        truncated = len(text) > MAX_FILE_CONTENT_CHARS
+        if truncated:
+            text = text[:MAX_FILE_CONTENT_CHARS]
+
+        logger.debug(
+            "read_file_content file_id=%s → %d chars (truncated=%s)",
+            file_id, len(text), truncated,
+        )
+        return {
+            "file_id": upload.id,
+            "filename": upload.original_filename,
+            "content_type": upload.content_type,
+            "text": text,
+            "truncated": truncated,
+        }
+
+    return [list_uploaded_files, read_file_content]


### PR DESCRIPTION
Enhance the Dockerfile by increasing the pip install timeout and retries for large packages. Introduce a new tool for extracting full text from uploaded files, allowing users to retrieve detailed content from their uploads.