### PR TITLE
Enable follow-up questions in model and bump version to 1.0.2

### DIFF
--- a/backend/src/api/admin.py
+++ b/backend/src/api/admin.py
@@ -619,6 +619,8 @@ async def update_model(
     update_kwargs: dict = {}
     if body.name is not None:
         update_kwargs["name"] = body.name
+    if body.model_id is not None:
+        update_kwargs["model_id"] = body.model_id
     if body.provider is not None:
         update_kwargs["provider"] = body.provider
     if body.api_key is not None:
@@ -637,6 +639,8 @@ async def update_model(
         update_kwargs["routing_priority"] = body.routing_priority
     if body.thinking_enabled is not None:
         update_kwargs["thinking_enabled"] = body.thinking_enabled
+    if body.follow_up_questions_enabled is not None:
+        update_kwargs["follow_up_questions_enabled"] = body.follow_up_questions_enabled
     if body.context_length is not None:
         update_kwargs["context_length"] = body.context_length
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -41,7 +41,7 @@ async def lifespan(app: FastAPI):
     yield
 
 
-app = FastAPI(title="PH Agent Hub", version="1.0.1", lifespan=lifespan)
+app = FastAPI(title="PH Agent Hub", version="1.0.2", lifespan=lifespan)
 
 # ---------------------------------------------------------------------------
 # Middleware

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ph-agent-hub-frontend",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000 --host",

--- a/infrastructure/nginx.conf
+++ b/infrastructure/nginx.conf
@@ -31,7 +31,7 @@ http {
         # ── API Proxy ──────────────────────────────────────────────────────
         # SSE requires buffering off, long timeouts, and HTTP/1.1 keep-alive.
         location /api/ {
-            proxy_pass http://backend/;
+            proxy_pass http://backend/api/;
 
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
This update allows enabling and disabling follow-up questions in the model, addressing issue #75. Additionally, the version has been bumped to 1.0.2, and the Nginx API proxy path has been updated for proper routing.