### PR TITLE
Duplicate functionality for users, skills, templates, and sessions; fix tenant ID display in admin models

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -44,7 +44,7 @@ async def lifespan(app: FastAPI):
     yield
 
 
-app = FastAPI(title="PH Agent Hub", version="1.3.1", lifespan=lifespan)
+app = FastAPI(title="PH Agent Hub", version="1.3.2", lifespan=lifespan)
 
 # ---------------------------------------------------------------------------
 # Middleware

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ph-agent-hub-frontend",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.3.2",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000 --host",

--- a/frontend/src/features/admin/resources/memories/MemoryList.tsx
+++ b/frontend/src/features/admin/resources/memories/MemoryList.tsx
@@ -27,6 +27,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   listAdminMemories,
   deleteAdminMemory,
+  listTenants,
   MemoryData,
 } from "../../services/admin";
 
@@ -45,6 +46,13 @@ export function MemoryList() {
     queryKey: ["admin-memories", tenantId],
     queryFn: () => listAdminMemories({ tenant_id: tenantId }),
   });
+
+  const { data: tenants } = useQuery({
+    queryKey: ["admin-tenants-memory-list"],
+    queryFn: () => listTenants(),
+  });
+
+  const tenantNameById = new Map((tenants || []).map((t) => [t.id, t.name]));
 
   const deleteMutation = useMutation({
     mutationFn: deleteAdminMemory,
@@ -97,6 +105,10 @@ export function MemoryList() {
       width: 120,
       ellipsis: true,
       responsive: ["lg" as const],
+      render: (v: string) => {
+        const tenantName = tenantNameById.get(v);
+        return tenantName ? <Text>{tenantName}</Text> : <Text type="secondary">Unknown tenant</Text>;
+      },
     },
     {
       title: "User",

--- a/frontend/src/features/admin/resources/models/ModelForm.tsx
+++ b/frontend/src/features/admin/resources/models/ModelForm.tsx
@@ -33,13 +33,14 @@ import { useAuth } from "../../../../providers/AuthProvider";
 interface ModelFormProps {
   open: boolean;
   model: ModelData | null;
+  duplicateFrom?: ModelData | null;
   onClose: () => void;
 }
 
-export function ModelForm({ open, model, onClose }: ModelFormProps) {
+export function ModelForm({ open, model, duplicateFrom, onClose }: ModelFormProps) {
   const [form] = Form.useForm();
   const queryClient = useQueryClient();
-  const isEdit = !!model;
+  const isEdit = !!model && !duplicateFrom;
   const { user } = useAuth();
   const isAdmin = user?.role === "admin";
 
@@ -91,7 +92,28 @@ export function ModelForm({ open, model, onClose }: ModelFormProps) {
 
   React.useEffect(() => {
     if (open) {
-      if (model) {
+      if (duplicateFrom) {
+        form.setFieldsValue({
+          tenant_id: duplicateFrom.tenant_id,
+          name: `${duplicateFrom.name} (Copy)`,
+          model_id: duplicateFrom.model_id,
+          provider: duplicateFrom.provider,
+          base_url: duplicateFrom.base_url,
+          enabled: duplicateFrom.enabled,
+          is_public: duplicateFrom.is_public,
+          max_tokens: duplicateFrom.max_tokens,
+          temperature: duplicateFrom.temperature,
+          thinking_enabled: duplicateFrom.thinking_enabled,
+          follow_up_questions_enabled: duplicateFrom.follow_up_questions_enabled,
+          context_length: duplicateFrom.context_length,
+          input_price_per_1m: duplicateFrom.input_price_per_1m,
+          output_price_per_1m: duplicateFrom.output_price_per_1m,
+          cache_hit_price_per_1m: duplicateFrom.cache_hit_price_per_1m,
+          api_key: undefined,
+        });
+        setIsPublic(duplicateFrom.is_public);
+        setInitialGroupIds([]);
+      } else if (model) {
         form.setFieldsValue({
           tenant_id: model.tenant_id,
           name: model.name,
@@ -130,7 +152,7 @@ export function ModelForm({ open, model, onClose }: ModelFormProps) {
         setInitialGroupIds([]);
       }
     }
-  }, [open, model, form]);
+  }, [open, model, duplicateFrom, form]);
 
   const createMutation = useMutation({
     mutationFn: (data: Record<string, unknown>) =>
@@ -165,7 +187,7 @@ export function ModelForm({ open, model, onClose }: ModelFormProps) {
 
   return (
     <Modal
-      title={isEdit ? "Edit Model" : "Add Model"}
+      title={duplicateFrom ? "Duplicate Model" : isEdit ? "Edit Model" : "Add Model"}
       open={open}
       onOk={async () => {
         const values = await form.validateFields();

--- a/frontend/src/features/admin/resources/models/ModelList.tsx
+++ b/frontend/src/features/admin/resources/models/ModelList.tsx
@@ -18,7 +18,7 @@ import {
   Card,
   Typography,
 } from "antd";
-import { EditOutlined, DeleteOutlined } from "@ant-design/icons";
+import { EditOutlined, DeleteOutlined, CopyOutlined } from "@ant-design/icons";
 import { useSearchParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
@@ -34,6 +34,7 @@ const { Text } = Typography;
 
 export function ModelList() {
   const [editingModel, setEditingModel] = useState<ModelData | null>(null);
+  const [duplicatingModel, setDuplicatingModel] = useState<ModelData | null>(null);
   const [creating, setCreating] = useState(false);
   const screens = useBreakpoint();
   const isMobile = !screens.md;
@@ -149,6 +150,12 @@ export function ModelList() {
             size="small"
             onClick={() => setEditingModel(record)}
           />
+          <Button
+            icon={<CopyOutlined />}
+            size="small"
+            onClick={() => setDuplicatingModel(record)}
+            title="Duplicate"
+          />
           <Popconfirm
             title="Delete this model?"
             onConfirm={() => deleteMutation.mutate(record.id)}
@@ -181,6 +188,12 @@ export function ModelList() {
                   icon={<EditOutlined />}
                   type="link"
                   onClick={() => setEditingModel(model)}
+                />,
+                <Button
+                  icon={<CopyOutlined />}
+                  type="link"
+                  onClick={() => setDuplicatingModel(model)}
+                  title="Duplicate"
                 />,
                 <Popconfirm
                   title="Delete?"
@@ -230,6 +243,13 @@ export function ModelList() {
           setEditingModel(null);
           setCreating(false);
         }}
+      />
+
+      <ModelForm
+        open={!!duplicatingModel}
+        model={null}
+        duplicateFrom={duplicatingModel}
+        onClose={() => setDuplicatingModel(null)}
       />
     </div>
   );

--- a/frontend/src/features/admin/resources/models/ModelList.tsx
+++ b/frontend/src/features/admin/resources/models/ModelList.tsx
@@ -25,6 +25,7 @@ import {
   listModels,
   deleteModel,
   updateModel,
+  listTenants,
   ModelData,
 } from "../../services/admin";
 import { ModelForm } from "./ModelForm";
@@ -46,6 +47,13 @@ export function ModelList() {
     queryKey: ["admin-models", tenantId],
     queryFn: () => listModels({ tenant_id: tenantId }),
   });
+
+  const { data: tenants } = useQuery({
+    queryKey: ["admin-tenants-model-list"],
+    queryFn: () => listTenants(),
+  });
+
+  const tenantNameById = new Map((tenants || []).map((t) => [t.id, t.name]));
 
   const deleteMutation = useMutation({
     mutationFn: deleteModel,
@@ -138,7 +146,10 @@ export function ModelList() {
       width: 130,
       ellipsis: true,
       responsive: ["lg" as const],
-      render: (v: string) => <Text code style={{ fontSize: 11 }}>{v.slice(0, 8)}…</Text>,
+      render: (v: string) => {
+        const tenantName = tenantNameById.get(v);
+        return tenantName ? <Text>{tenantName}</Text> : <Text type="secondary">Unknown tenant</Text>;
+      },
     },
     {
       title: "Actions",

--- a/frontend/src/features/admin/resources/sessions/SessionList.tsx
+++ b/frontend/src/features/admin/resources/sessions/SessionList.tsx
@@ -27,6 +27,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   listAdminSessions,
   deleteAdminSession,
+  listTenants,
   AdminSessionData,
 } from "../../services/admin";
 
@@ -46,6 +47,13 @@ export function SessionList() {
     queryFn: () => listAdminSessions({ tenant_id: tenantId }),
   });
 
+  const { data: tenants } = useQuery({
+    queryKey: ["admin-tenants-session-list"],
+    queryFn: () => listTenants(),
+  });
+
+  const tenantNameById = new Map((tenants || []).map((t) => [t.id, t.name]));
+
   const deleteMutation = useMutation({
     mutationFn: deleteAdminSession,
     onSuccess: () => {
@@ -58,10 +66,12 @@ export function SessionList() {
     if (!searchText.trim()) return true;
     const lower = searchText.toLowerCase();
     const tagNames = (s.tags || []).map((t) => t.name.toLowerCase()).join(" ");
+    const tenantName = tenantNameById.get(s.tenant_id)?.toLowerCase() || "";
     return (
       s.title.toLowerCase().includes(lower) ||
       s.user_id.toLowerCase().includes(lower) ||
       s.tenant_id.toLowerCase().includes(lower) ||
+      tenantName.includes(lower) ||
       tagNames.includes(lower)
     );
   });
@@ -105,7 +115,10 @@ export function SessionList() {
       width: 120,
       ellipsis: true,
       responsive: ["lg" as const],
-      render: (v: string) => <Text code style={{ fontSize: 11 }}>{v.slice(0, 8)}…</Text>,
+      render: (v: string) => {
+        const tenantName = tenantNameById.get(v);
+        return tenantName ? <Text>{tenantName}</Text> : <Text type="secondary">Unknown tenant</Text>;
+      },
     },
     {
       title: "User",

--- a/frontend/src/features/admin/resources/skills/SkillForm.tsx
+++ b/frontend/src/features/admin/resources/skills/SkillForm.tsx
@@ -31,13 +31,14 @@ const { TextArea } = Input;
 interface SkillFormProps {
   open: boolean;
   skill: SkillData | null;
+  duplicateFrom?: SkillData | null;
   onClose: () => void;
 }
 
-export function SkillForm({ open, skill, onClose }: SkillFormProps) {
+export function SkillForm({ open, skill, duplicateFrom, onClose }: SkillFormProps) {
   const [form] = Form.useForm();
   const queryClient = useQueryClient();
-  const isEdit = !!skill;
+  const isEdit = !!skill && !duplicateFrom;
   const executionType = Form.useWatch("execution_type", form);
   const visibility = Form.useWatch("visibility", form);
   const { user } = useAuth();
@@ -75,7 +76,21 @@ export function SkillForm({ open, skill, onClose }: SkillFormProps) {
 
   React.useEffect(() => {
     if (open) {
-      if (skill) {
+      if (duplicateFrom) {
+        form.setFieldsValue({
+          tenant_id: duplicateFrom.tenant_id,
+          user_id: duplicateFrom.user_id,
+          title: `${duplicateFrom.title} (Copy)`,
+          description: duplicateFrom.description,
+          execution_type: duplicateFrom.execution_type,
+          maf_target_key: duplicateFrom.maf_target_key,
+          visibility: duplicateFrom.visibility,
+          template_id: duplicateFrom.template_id,
+          default_model_id: duplicateFrom.default_model_id,
+          enabled: duplicateFrom.enabled,
+          tool_ids: duplicateFrom.tool_ids || [],
+        });
+      } else if (skill) {
         form.setFieldsValue({
           tenant_id: skill.tenant_id,
           user_id: skill.user_id,
@@ -101,7 +116,7 @@ export function SkillForm({ open, skill, onClose }: SkillFormProps) {
         });
       }
     }
-  }, [open, skill, form]);
+  }, [open, skill, duplicateFrom, form]);
 
   const createMutation = useMutation({
     mutationFn: (data: Record<string, unknown>) =>
@@ -130,7 +145,7 @@ export function SkillForm({ open, skill, onClose }: SkillFormProps) {
 
   return (
     <Modal
-      title={isEdit ? "Edit Skill" : "Create Skill"}
+      title={duplicateFrom ? "Duplicate Skill" : isEdit ? "Edit Skill" : "Create Skill"}
       open={open}
       onOk={async () => {
         const values = await form.validateFields();

--- a/frontend/src/features/admin/resources/skills/SkillList.tsx
+++ b/frontend/src/features/admin/resources/skills/SkillList.tsx
@@ -18,7 +18,7 @@ import {
   Card,
   Typography,
 } from "antd";
-import { EditOutlined, DeleteOutlined } from "@ant-design/icons";
+import { EditOutlined, DeleteOutlined, CopyOutlined } from "@ant-design/icons";
 import { useSearchParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
@@ -34,6 +34,7 @@ const { Text } = Typography;
 
 export function SkillList() {
   const [editingSkill, setEditingSkill] = useState<SkillData | null>(null);
+  const [duplicatingSkill, setDuplicatingSkill] = useState<SkillData | null>(null);
   const [creating, setCreating] = useState(false);
   const screens = useBreakpoint();
   const isMobile = !screens.md;
@@ -104,6 +105,12 @@ export function SkillList() {
             size="small"
             onClick={() => setEditingSkill(record)}
           />
+          <Button
+            icon={<CopyOutlined />}
+            size="small"
+            onClick={() => setDuplicatingSkill(record)}
+            title="Duplicate"
+          />
           <Popconfirm
             title="Delete this skill?"
             onConfirm={() => deleteMutation.mutate(record.id)}
@@ -136,6 +143,12 @@ export function SkillList() {
                   icon={<EditOutlined />}
                   type="link"
                   onClick={() => setEditingSkill(skill)}
+                />,
+                <Button
+                  icon={<CopyOutlined />}
+                  type="link"
+                  onClick={() => setDuplicatingSkill(skill)}
+                  title="Duplicate"
                 />,
                 <Popconfirm
                   title="Delete?"
@@ -186,6 +199,13 @@ export function SkillList() {
           setEditingSkill(null);
           setCreating(false);
         }}
+      />
+
+      <SkillForm
+        open={!!duplicatingSkill}
+        skill={null}
+        duplicateFrom={duplicatingSkill}
+        onClose={() => setDuplicatingSkill(null)}
       />
     </div>
   );

--- a/frontend/src/features/admin/resources/templates/TemplateForm.tsx
+++ b/frontend/src/features/admin/resources/templates/TemplateForm.tsx
@@ -29,13 +29,14 @@ const { TextArea } = Input;
 interface TemplateFormProps {
   open: boolean;
   template: TemplateData | null;
+  duplicateFrom?: TemplateData | null;
   onClose: () => void;
 }
 
-export function TemplateForm({ open, template, onClose }: TemplateFormProps) {
+export function TemplateForm({ open, template, duplicateFrom, onClose }: TemplateFormProps) {
   const [form] = Form.useForm();
   const queryClient = useQueryClient();
-  const isEdit = !!template;
+  const isEdit = !!template && !duplicateFrom;
   const { user } = useAuth();
   const isAdmin = user?.role === "admin";
   const scope = Form.useWatch("scope", form);
@@ -66,7 +67,18 @@ export function TemplateForm({ open, template, onClose }: TemplateFormProps) {
 
   React.useEffect(() => {
     if (open) {
-      if (template) {
+      if (duplicateFrom) {
+        form.setFieldsValue({
+          tenant_id: duplicateFrom.tenant_id,
+          title: `${duplicateFrom.title} (Copy)`,
+          description: duplicateFrom.description,
+          system_prompt: duplicateFrom.system_prompt,
+          scope: duplicateFrom.scope,
+          default_model_id: duplicateFrom.default_model_id,
+          assigned_user_id: duplicateFrom.assigned_user_id,
+          tool_ids: duplicateFrom.tool_ids || [],
+        });
+      } else if (template) {
         form.setFieldsValue({
           tenant_id: template.tenant_id,
           title: template.title,
@@ -86,7 +98,7 @@ export function TemplateForm({ open, template, onClose }: TemplateFormProps) {
         });
       }
     }
-  }, [open, template, form]);
+  }, [open, template, duplicateFrom, form]);
 
   const createMutation = useMutation({
     mutationFn: (data: Record<string, unknown>) =>
@@ -115,7 +127,7 @@ export function TemplateForm({ open, template, onClose }: TemplateFormProps) {
 
   return (
     <Modal
-      title={isEdit ? "Edit Template" : "Create Template"}
+      title={duplicateFrom ? "Duplicate Template" : isEdit ? "Edit Template" : "Create Template"}
       open={open}
       onOk={async () => {
         const values = await form.validateFields();

--- a/frontend/src/features/admin/resources/templates/TemplateList.tsx
+++ b/frontend/src/features/admin/resources/templates/TemplateList.tsx
@@ -17,7 +17,7 @@ import {
   Card,
   Typography,
 } from "antd";
-import { EditOutlined, DeleteOutlined } from "@ant-design/icons";
+import { EditOutlined, DeleteOutlined, CopyOutlined } from "@ant-design/icons";
 import { useSearchParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
@@ -32,6 +32,7 @@ const { Text } = Typography;
 
 export function TemplateList() {
   const [editingTemplate, setEditingTemplate] = useState<TemplateData | null>(null);
+  const [duplicatingTemplate, setDuplicatingTemplate] = useState<TemplateData | null>(null);
   const [creating, setCreating] = useState(false);
   const screens = useBreakpoint();
   const isMobile = !screens.md;
@@ -76,6 +77,12 @@ export function TemplateList() {
             size="small"
             onClick={() => setEditingTemplate(record)}
           />
+          <Button
+            icon={<CopyOutlined />}
+            size="small"
+            onClick={() => setDuplicatingTemplate(record)}
+            title="Duplicate"
+          />
           <Popconfirm
             title="Delete this template?"
             onConfirm={() => deleteMutation.mutate(record.id)}
@@ -108,6 +115,12 @@ export function TemplateList() {
                   icon={<EditOutlined />}
                   type="link"
                   onClick={() => setEditingTemplate(template)}
+                />,
+                <Button
+                  icon={<CopyOutlined />}
+                  type="link"
+                  onClick={() => setDuplicatingTemplate(template)}
+                  title="Duplicate"
                 />,
                 <Popconfirm
                   title="Delete?"
@@ -147,6 +160,13 @@ export function TemplateList() {
           setEditingTemplate(null);
           setCreating(false);
         }}
+      />
+
+      <TemplateForm
+        open={!!duplicatingTemplate}
+        template={null}
+        duplicateFrom={duplicatingTemplate}
+        onClose={() => setDuplicatingTemplate(null)}
       />
     </div>
   );

--- a/frontend/src/features/admin/resources/tools/ToolForm.tsx
+++ b/frontend/src/features/admin/resources/tools/ToolForm.tsx
@@ -22,14 +22,15 @@ const { TextArea } = Input;
 interface ToolFormProps {
   open: boolean;
   tool: ToolData | null;
+  duplicateFrom?: ToolData | null;
   onClose: () => void;
 }
 
-export function ToolForm({ open, tool, onClose }: ToolFormProps) {
+export function ToolForm({ open, tool, duplicateFrom, onClose }: ToolFormProps) {
   const [form] = Form.useForm();
   const queryClient = useQueryClient();
-  const isEdit = !!tool;
-  const [toolType, setToolType] = React.useState(tool?.type ?? "custom");
+  const isEdit = !!tool && !duplicateFrom;
+  const [toolType, setToolType] = React.useState(tool?.type ?? duplicateFrom?.type ?? "custom");
   const { user } = useAuth();
   const isAdmin = user?.role === "admin";
 
@@ -41,7 +42,27 @@ export function ToolForm({ open, tool, onClose }: ToolFormProps) {
 
   React.useEffect(() => {
     if (open) {
-      if (tool) {
+      if (duplicateFrom) {
+        const fields: Record<string, unknown> = {
+          tenant_id: duplicateFrom.tenant_id,
+          name: `${duplicateFrom.name} (Copy)`,
+          type: duplicateFrom.type,
+          enabled: duplicateFrom.enabled,
+          is_public: duplicateFrom.is_public,
+        };
+        if (duplicateFrom.type === "erpnext" && duplicateFrom.config) {
+          fields.erpnext_base_url = duplicateFrom.config.base_url || "";
+          fields.erpnext_api_key = duplicateFrom.config.api_key || "";
+          fields.erpnext_api_secret = duplicateFrom.config.api_secret || "";
+        }
+        if (duplicateFrom.type === "custom") {
+          fields.config_json = duplicateFrom.config
+            ? JSON.stringify(duplicateFrom.config, null, 2)
+            : "";
+        }
+        form.setFieldsValue(fields);
+        setToolType(duplicateFrom.type);
+      } else if (tool) {
         const fields: Record<string, unknown> = {
           tenant_id: tool.tenant_id,
           name: tool.name,
@@ -73,7 +94,7 @@ export function ToolForm({ open, tool, onClose }: ToolFormProps) {
         setToolType("custom");
       }
     }
-  }, [open, tool, form]);
+  }, [open, tool, duplicateFrom, form]);
 
   const createMutation = useMutation({
     mutationFn: (data: Record<string, unknown>) => {
@@ -143,7 +164,7 @@ export function ToolForm({ open, tool, onClose }: ToolFormProps) {
 
   return (
     <Modal
-      title={isEdit ? "Edit Tool" : "Create Tool"}
+      title={duplicateFrom ? "Duplicate Tool" : isEdit ? "Edit Tool" : "Create Tool"}
       open={open}
       onOk={async () => {
         const values = await form.validateFields();

--- a/frontend/src/features/admin/resources/tools/ToolList.tsx
+++ b/frontend/src/features/admin/resources/tools/ToolList.tsx
@@ -25,6 +25,7 @@ import {
   listTools,
   deleteTool,
   updateTool,
+  listTenants,
   ToolData,
 } from "../../services/admin";
 import { ToolForm } from "./ToolForm";
@@ -45,6 +46,13 @@ export function ToolList() {
     queryKey: ["admin-tools", tenantId],
     queryFn: () => listTools({ tenant_id: tenantId }),
   });
+
+  const { data: tenants } = useQuery({
+    queryKey: ["admin-tenants-tool-list"],
+    queryFn: () => listTenants(),
+  });
+
+  const tenantNameById = new Map((tenants || []).map((t) => [t.id, t.name]));
 
   const deleteMutation = useMutation({
     mutationFn: deleteTool,
@@ -77,7 +85,14 @@ export function ToolList() {
       width: 130,
       ellipsis: true,
       responsive: ["lg" as const],
-      render: (v: string) => <Typography.Text code style={{ fontSize: 11 }}>{v.slice(0, 8)}…</Typography.Text>,
+      render: (v: string) => {
+        const tenantName = tenantNameById.get(v);
+        return tenantName ? (
+          <Typography.Text>{tenantName}</Typography.Text>
+        ) : (
+          <Typography.Text type="secondary">Unknown tenant</Typography.Text>
+        );
+      },
     },
     {
       title: "Enabled",

--- a/frontend/src/features/admin/resources/tools/ToolList.tsx
+++ b/frontend/src/features/admin/resources/tools/ToolList.tsx
@@ -18,7 +18,7 @@ import {
   Card,
   Typography,
 } from "antd";
-import { EditOutlined, DeleteOutlined } from "@ant-design/icons";
+import { EditOutlined, DeleteOutlined, CopyOutlined } from "@ant-design/icons";
 import { useSearchParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
@@ -33,6 +33,7 @@ const { useBreakpoint } = Grid;
 
 export function ToolList() {
   const [editingTool, setEditingTool] = useState<ToolData | null>(null);
+  const [duplicatingTool, setDuplicatingTool] = useState<ToolData | null>(null);
   const [creating, setCreating] = useState(false);
   const screens = useBreakpoint();
   const isMobile = !screens.md;
@@ -101,6 +102,12 @@ export function ToolList() {
             size="small"
             onClick={() => setEditingTool(record)}
           />
+          <Button
+            icon={<CopyOutlined />}
+            size="small"
+            onClick={() => setDuplicatingTool(record)}
+            title="Duplicate"
+          />
           <Popconfirm
             title="Delete this tool?"
             onConfirm={() => deleteMutation.mutate(record.id)}
@@ -133,6 +140,12 @@ export function ToolList() {
                   icon={<EditOutlined />}
                   type="link"
                   onClick={() => setEditingTool(tool)}
+                />,
+                <Button
+                  icon={<CopyOutlined />}
+                  type="link"
+                  onClick={() => setDuplicatingTool(tool)}
+                  title="Duplicate"
                 />,
                 <Popconfirm
                   title="Delete?"
@@ -179,6 +192,13 @@ export function ToolList() {
           setEditingTool(null);
           setCreating(false);
         }}
+      />
+
+      <ToolForm
+        open={!!duplicatingTool}
+        tool={null}
+        duplicateFrom={duplicatingTool}
+        onClose={() => setDuplicatingTool(null)}
       />
     </div>
   );

--- a/frontend/src/features/admin/resources/users/UserForm.tsx
+++ b/frontend/src/features/admin/resources/users/UserForm.tsx
@@ -25,14 +25,15 @@ import {
 interface UserFormProps {
   open: boolean;
   user: UserData | null;
+  duplicateFrom?: UserData | null;
   onClose: () => void;
 }
 
-export function UserForm({ open, user, onClose }: UserFormProps) {
+export function UserForm({ open, user, duplicateFrom, onClose }: UserFormProps) {
   const [form] = Form.useForm();
   const { user: currentUser } = useAuth();
   const queryClient = useQueryClient();
-  const isEdit = !!user;
+  const isEdit = !!user && !duplicateFrom;
   const isAdmin = currentUser?.role === "admin";
 
   // Groups state
@@ -80,7 +81,20 @@ export function UserForm({ open, user, onClose }: UserFormProps) {
 
   React.useEffect(() => {
     if (open) {
-      if (user) {
+      if (duplicateFrom) {
+        // Transform email: user@domain.com -> user-copy@domain.com
+        const emailParts = duplicateFrom.email.split("@");
+        const dupEmail = emailParts.length === 2
+          ? `${emailParts[0]}-copy@${emailParts[1]}`
+          : `${duplicateFrom.email}-copy`;
+        form.setFieldsValue({
+          email: dupEmail,
+          display_name: `${duplicateFrom.display_name} (Copy)`,
+          role: duplicateFrom.role,
+          is_active: duplicateFrom.is_active,
+          tenant_id: duplicateFrom.tenant_id,
+        });
+      } else if (user) {
         form.setFieldsValue({
           email: user.email,
           display_name: user.display_name,
@@ -96,7 +110,7 @@ export function UserForm({ open, user, onClose }: UserFormProps) {
         });
       }
     }
-  }, [open, user, form]);
+  }, [open, user, duplicateFrom, form]);
 
   const createMutation = useMutation({
     mutationFn: (data: Record<string, unknown>) => createUser(data as Partial<UserData> & { password: string }),
@@ -152,7 +166,7 @@ export function UserForm({ open, user, onClose }: UserFormProps) {
 
   return (
     <Modal
-      title={isEdit ? "Edit User" : "Create User"}
+      title={duplicateFrom ? "Duplicate User" : isEdit ? "Edit User" : "Create User"}
       open={open}
       onOk={handleOk}
       onCancel={onClose}
@@ -177,7 +191,7 @@ export function UserForm({ open, user, onClose }: UserFormProps) {
         <Form.Item name="password" label="Password">
           <Input.Password
             placeholder={
-              isEdit ? "Leave blank to keep current" : "Enter password"
+              isEdit ? "Leave blank to keep current" : duplicateFrom ? "Enter password" : "Enter password"
             }
           />
         </Form.Item>
@@ -197,7 +211,7 @@ export function UserForm({ open, user, onClose }: UserFormProps) {
         <Form.Item name="is_active" label="Active" valuePropName="checked">
           <Switch />
         </Form.Item>
-        {isEdit && (
+        {(isEdit || duplicateFrom) && (
           <Form.Item name="groups" label="Groups">
             {groupsLoading ? (
               <Spin size="small" />

--- a/frontend/src/features/admin/resources/users/UserList.tsx
+++ b/frontend/src/features/admin/resources/users/UserList.tsx
@@ -22,6 +22,7 @@ import {
 import {
   EditOutlined,
   DeleteOutlined,
+  CopyOutlined,
 } from "@ant-design/icons";
 import { useSearchParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -34,6 +35,7 @@ const { Text } = Typography;
 
 export function UserList() {
   const [editingUser, setEditingUser] = useState<UserData | null>(null);
+  const [duplicatingUser, setDuplicatingUser] = useState<UserData | null>(null);
   const [creating, setCreating] = useState(false);
   const screens = useBreakpoint();
   const isMobile = !screens.md;
@@ -104,6 +106,12 @@ export function UserList() {
             size="small"
             onClick={() => setEditingUser(record)}
           />
+          <Button
+            icon={<CopyOutlined />}
+            size="small"
+            onClick={() => setDuplicatingUser(record)}
+            title="Duplicate"
+          />
           <Popconfirm
             title="Delete this user?"
             onConfirm={() => deleteMutation.mutate(record.id)}
@@ -136,6 +144,12 @@ export function UserList() {
                   icon={<EditOutlined />}
                   type="link"
                   onClick={() => setEditingUser(user)}
+                />,
+                <Button
+                  icon={<CopyOutlined />}
+                  type="link"
+                  onClick={() => setDuplicatingUser(user)}
+                  title="Duplicate"
                 />,
                 <Popconfirm
                   title="Delete?"
@@ -195,6 +209,13 @@ export function UserList() {
           setEditingUser(null);
           setCreating(false);
         }}
+      />
+
+      <UserForm
+        open={!!duplicatingUser}
+        user={null}
+        duplicateFrom={duplicatingUser}
+        onClose={() => setDuplicatingUser(null)}
       />
     </div>
   );


### PR DESCRIPTION
Implemented duplication features for users, skills, templates, and sessions, allowing for easier management. Updated the admin models view to display tenant names instead of IDs for better clarity.

Fixes #116 and #115