### PR TITLE
Fix message resending on navigation and preserve messages on stop

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -44,7 +44,7 @@ async def lifespan(app: FastAPI):
     yield
 
 
-app = FastAPI(title="PH Agent Hub", version="1.3.6", lifespan=lifespan)
+app = FastAPI(title="PH Agent Hub", version="1.3.7", lifespan=lifespan)
 
 # ---------------------------------------------------------------------------
 # Middleware

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ph-agent-hub-frontend",
   "private": true,
-  "version": "1.3.6",
+  "version": "1.3.7",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000 --host",

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -361,6 +361,16 @@ export function ChatWindow({
   }, [inputValue, streaming, sessionId, startStream, queryClient, pendingFiles, editingMsgId]);
 
   const handleStop = async () => {
+    // Clear the streaming ghost bubble immediately for instant UX.
+    // The backend will persist the partial response (stopStream sends
+    // the cancel signal first), and when the stream ends naturally the
+    // onClose handler refetches messages → the partial response becomes
+    // a permanent message bubble.
+    setStreamingContent("");
+    setStreamingReasoningContent("");
+    setStreamingMessageId(null);
+    setStreamingTokens(null);
+    setToolEvents([]);
     await stopStream(sessionId);
   };
 

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -126,6 +126,30 @@ export function ChatWindow({
   );
   const modelSupportsThinking = selectedModel?.thinking_enabled === true;
 
+  // Reset all streaming state when the session changes (mount with new
+  // sessionId or fresh mount). This prevents stale streamingContent,
+  // pendingUserMessage, etc. from bleeding into the new session.
+  //
+  // NOTE: We intentionally do NOT call stopStream(sessionId) in a cleanup
+  // effect here.  React StrictMode double-mounts components in dev, so a
+  // cleanup-based stopStream would fire DELETE /chat/session/:id/stream on
+  // every mount, setting a Redis cancel flag (60 s TTL) that cancels the
+  // next message the user sends (Issue #124).  Stream abort on unmount is
+  // handled inside useStream.ts, and stale session–switch state is cleared
+  // by the state‑reset effect below.
+  useEffect(() => {
+    setStreamingContent("");
+    setStreamingReasoningContent("");
+    setStreamingMessageId(null);
+    setStreamError(null);
+    setToolEvents([]);
+    setFollowUpQuestions([]);
+    setStreamingTokens(null);
+    setPendingUserMessage(null);
+    setEditingMsgId(null);
+    setRegeneratingMsgId(null);
+  }, [sessionId]);
+
   // Smart auto-scroll: only scroll to bottom when user hasn't scrolled up.
   // Allows the user to interrupt auto-scroll by scrolling up, and resumes
   // auto-scroll when they scroll back to the bottom.

--- a/frontend/src/features/chat/hooks/useStream.ts
+++ b/frontend/src/features/chat/hooks/useStream.ts
@@ -7,7 +7,7 @@
 // POST to /chat/session/:id/message with Accept: text/event-stream.
 // =============================================================================
 
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import {
   fetchEventSource,
   EventStreamContentType,
@@ -149,6 +149,15 @@ export function useStream() {
   );
   const abortRef = useRef<AbortController | null>(null);
 
+  // Abort any in-flight SSE stream when the hook unmounts. Without this,
+  // @microsoft/fetch-event-source reconnects on document visibility change
+  // after navigation, re-POSTing the message (Issue #124).
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
   const startStream = useCallback(
     async (
       sessionId: string,
@@ -189,6 +198,7 @@ export function useStream() {
               content,
               file_ids: fileIds || [],
             }),
+            openWhenHidden: true,
             signal: controller.signal,
             async onopen(response) {
               if (
@@ -330,6 +340,7 @@ export function useStream() {
               Accept: "text/event-stream",
               ...(token ? { Authorization: `Bearer ${token}` } : {}),
             },
+            openWhenHidden: true,
             signal: controller.signal,
             async onopen(response) {
               if (
@@ -450,6 +461,7 @@ export function useStream() {
               ...(token ? { Authorization: `Bearer ${token}` } : {}),
             },
             body: JSON.stringify({ content }),
+            openWhenHidden: true,
             signal: controller.signal,
             async onopen(response) {
               if (

--- a/frontend/src/features/chat/hooks/useStream.ts
+++ b/frontend/src/features/chat/hooks/useStream.ts
@@ -261,10 +261,13 @@ export function useStream() {
               handlers.onClose?.();
             },
             onerror(err) {
-              // Don't throw on abort
+              // Don't throw on abort — but still run onClose so the
+              // ChatWindow can refetch messages (the backend may have
+              // persisted a partial response).
               if (controller.signal.aborted) {
                 setStreaming(false);
                 setStreamingSessionId(null);
+                handlers.onClose?.();
                 return; // stops the retry
               }
               // Don't throw — let onclose fire to clean up state and refresh messages
@@ -288,8 +291,9 @@ export function useStream() {
 
   const stopStream = useCallback(
     async (sessionId: string) => {
-      abortRef.current?.abort();
-      // Also call backend cancel
+      // 1. Tell the backend to cancel via Redis flag — the agent runner
+      //    checks this on every token yield, breaks, persists the partial
+      //    response, and ends the stream normally.
       try {
         const token = getToken();
         await fetch(`${BASE_URL}/chat/session/${sessionId}/stream`, {
@@ -299,8 +303,23 @@ export function useStream() {
       } catch {
         // Best effort
       }
-      setStreaming(false);
-      setStreamingSessionId(null);
+      // 2. Schedule a safety-net abort in case the backend doesn't finish
+      //    within 2 s (e.g. stuck in a long tool call).  When the backend
+      //    shuts down cleanly the onclose handler fires and does the final
+      //    setStreaming(false) + setStreamingSessionId(null).
+      const controller = abortRef.current;
+      if (controller) {
+        setTimeout(() => {
+          if (!controller.signal.aborted) {
+            controller.abort();
+            setStreaming(false);
+            setStreamingSessionId(null);
+          }
+        }, 2000);
+      } else {
+        setStreaming(false);
+        setStreamingSessionId(null);
+      }
     },
     [],
   );
@@ -405,6 +424,7 @@ export function useStream() {
               if (controller.signal.aborted) {
                 setStreaming(false);
                 setStreamingSessionId(null);
+                handlers.onClose?.();
                 return;
               }
               setStreaming(false);
@@ -523,6 +543,7 @@ export function useStream() {
               if (controller.signal.aborted) {
                 setStreaming(false);
                 setStreamingSessionId(null);
+                handlers.onClose?.();
                 return;
               }
               setStreaming(false);


### PR DESCRIPTION
Navigating away from the chat window no longer triggers the resending of in-progress messages. Additionally, when a running response is stopped, the messages will now be preserved instead of deleted, allowing users to retain context for new inputs.

Fixes #124, Fixes #125