### PR TITLE
Add tool categories for grouping ~31 tools in admin and chat UIs

### DIFF
--- a/backend/src/api/admin.py
+++ b/backend/src/api/admin.py
@@ -264,7 +264,6 @@ class ToolCreate(BaseModel):
     code: str | None = None
     enabled: bool = True
     is_public: bool = False
-    category: str | None = None
 
 
 class ToolUpdate(BaseModel):
@@ -275,7 +274,6 @@ class ToolUpdate(BaseModel):
     code: str | None = None
     enabled: bool | None = None
     is_public: bool | None = None
-    category: str | None = None
 
 
 class ToolResponse(BaseModel):
@@ -836,7 +834,6 @@ async def create_tool(
         code=body.code,
         enabled=body.enabled,
         is_public=body.is_public,
-        category=body.category or "general",
     )
     await write_audit_log(
         db,
@@ -888,8 +885,6 @@ async def update_tool(
         update_kwargs["enabled"] = body.enabled
     if body.is_public is not None:
         update_kwargs["is_public"] = body.is_public
-    if body.category is not None:
-        update_kwargs["category"] = body.category
     if body.tenant_id is not None:
         if current_user.role == "manager" and body.tenant_id != current_user.tenant_id:
             raise ForbiddenError("Managers can only assign tools to their own tenant")

--- a/backend/src/api/admin.py
+++ b/backend/src/api/admin.py
@@ -264,6 +264,7 @@ class ToolCreate(BaseModel):
     code: str | None = None
     enabled: bool = True
     is_public: bool = False
+    category: str | None = None
 
 
 class ToolUpdate(BaseModel):
@@ -274,6 +275,7 @@ class ToolUpdate(BaseModel):
     code: str | None = None
     enabled: bool | None = None
     is_public: bool | None = None
+    category: str | None = None
 
 
 class ToolResponse(BaseModel):
@@ -281,6 +283,7 @@ class ToolResponse(BaseModel):
     tenant_id: str
     name: str
     type: str
+    category: str
     config: dict | None
     code: str | None
     enabled: bool
@@ -833,6 +836,7 @@ async def create_tool(
         code=body.code,
         enabled=body.enabled,
         is_public=body.is_public,
+        category=body.category or "general",
     )
     await write_audit_log(
         db,
@@ -884,6 +888,8 @@ async def update_tool(
         update_kwargs["enabled"] = body.enabled
     if body.is_public is not None:
         update_kwargs["is_public"] = body.is_public
+    if body.category is not None:
+        update_kwargs["category"] = body.category
     if body.tenant_id is not None:
         if current_user.role == "manager" and body.tenant_id != current_user.tenant_id:
             raise ForbiddenError("Managers can only assign tools to their own tenant")

--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -140,6 +140,7 @@ class ToolResponse(BaseModel):
     tenant_id: str
     name: str
     type: str
+    category: str
     config: dict | None
     enabled: bool
     created_at: datetime

--- a/backend/src/db/migrations/versions/p1q2r3s4t5u6_add_category_to_tools.py
+++ b/backend/src/db/migrations/versions/p1q2r3s4t5u6_add_category_to_tools.py
@@ -1,0 +1,36 @@
+"""add_category_to_tools
+
+Add category VARCHAR(50) NOT NULL DEFAULT 'general' to the tools table.
+
+Revision ID: p1q2r3s4t5u6
+Revises: 0a1b2c3d4e5f
+Create Date: 2026-05-13
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "p1q2r3s4t5u6"
+down_revision: Union[str, None] = "0a1b2c3d4e5f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tools",
+        sa.Column(
+            "category",
+            sa.String(50),
+            nullable=False,
+            server_default="general",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("tools", "category")

--- a/backend/src/db/migrations/versions/q2r3s4t5u6v7_backfill_tool_categories.py
+++ b/backend/src/db/migrations/versions/q2r3s4t5u6v7_backfill_tool_categories.py
@@ -1,0 +1,47 @@
+"""backfill_tool_categories
+
+Set category for existing 13 tools based on their type.
+
+Revision ID: q2r3s4t5u6v7
+Revises: p1q2r3s4t5u6
+Create Date: 2026-05-13
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "q2r3s4t5u6v7"
+down_revision: Union[str, None] = "p1q2r3s4t5u6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Map tool type -> category
+TYPE_TO_CATEGORY = {
+    "currency_exchange": "financial",
+    "web_search": "web",
+    "fetch_url": "web",
+    "rss_feed": "web",
+    "wikipedia": "web",
+    "erpnext": "enterprise",
+    "membrane": "enterprise",
+    "calculator": "utility",
+    "datetime": "utility",
+    "weather": "utility",
+    "custom": "custom",
+    "file_list": "system",
+    "memory": "system",
+}
+
+
+def upgrade() -> None:
+    for tool_type, category in TYPE_TO_CATEGORY.items():
+        op.execute(
+            f"UPDATE tools SET category = '{category}' WHERE type = '{tool_type}'"
+        )
+
+
+def downgrade() -> None:
+    op.execute("UPDATE tools SET category = 'general'")

--- a/backend/src/db/orm/tools.py
+++ b/backend/src/db/orm/tools.py
@@ -28,6 +28,9 @@ class Tool(Base):
     )
     config: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     code: Mapped[str | None] = mapped_column(Text, nullable=True)
+    category: Mapped[str] = mapped_column(
+        String(50), nullable=False, default="general", server_default="general"
+    )
     enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     is_public: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/src/services/tool_service.py
+++ b/backend/src/services/tool_service.py
@@ -15,9 +15,26 @@ VALID_TOOL_TYPES = {
     "currency_exchange",
 }
 
-VALID_TOOL_CATEGORIES = {
-    "financial", "web", "enterprise", "utility", "custom", "system", "general",
+TOOL_TYPE_TO_CATEGORY = {
+    "currency_exchange": "financial",
+    "web_search": "web",
+    "fetch_url": "web",
+    "rss_feed": "web",
+    "wikipedia": "web",
+    "erpnext": "enterprise",
+    "membrane": "enterprise",
+    "calculator": "utility",
+    "datetime": "utility",
+    "weather": "utility",
+    "custom": "custom",
+    "file_list": "system",
+    "memory": "system",
 }
+
+
+def derive_tool_category(tool_type: str) -> str:
+    """Map tool type to category. Unknown types fall back to general."""
+    return TOOL_TYPE_TO_CATEGORY.get(tool_type, "general")
 
 
 async def list_tools(
@@ -69,18 +86,12 @@ async def create_tool(
     code: str | None = None,
     enabled: bool = True,
     is_public: bool = False,
-    category: str = "general",
 ) -> Tool:
-    """Create a new tool. Raises ValidationError if type or category is invalid."""
+    """Create a new tool. Raises ValidationError if type is invalid."""
     if type not in VALID_TOOL_TYPES:
         raise ValidationError(
             f"Invalid tool type '{type}'. "
             f"Must be one of: {', '.join(sorted(VALID_TOOL_TYPES))}"
-        )
-    if category not in VALID_TOOL_CATEGORIES:
-        raise ValidationError(
-            f"Invalid tool category '{category}'. "
-            f"Must be one of: {', '.join(sorted(VALID_TOOL_CATEGORIES))}"
         )
 
     tool = Tool(
@@ -91,7 +102,7 @@ async def create_tool(
         code=code,
         enabled=enabled,
         is_public=is_public,
-        category=category,
+        category=derive_tool_category(type),
     )
     db.add(tool)
     await db.commit()
@@ -111,11 +122,11 @@ async def update_tool(db: AsyncSession, tool_id: str, **fields) -> Tool:
             f"Invalid tool type '{fields['type']}'. "
             f"Must be one of: {', '.join(sorted(VALID_TOOL_TYPES))}"
         )
-    if "category" in fields and fields["category"] not in VALID_TOOL_CATEGORIES:
-        raise ValidationError(
-            f"Invalid tool category '{fields['category']}'. "
-            f"Must be one of: {', '.join(sorted(VALID_TOOL_CATEGORIES))}"
-        )
+    # Category is system-derived from type and not user-editable.
+    fields.pop("category", None)
+
+    if "type" in fields:
+        fields["category"] = derive_tool_category(fields["type"])
 
     for key, value in fields.items():
         if hasattr(tool, key):

--- a/backend/src/services/tool_service.py
+++ b/backend/src/services/tool_service.py
@@ -15,6 +15,10 @@ VALID_TOOL_TYPES = {
     "currency_exchange",
 }
 
+VALID_TOOL_CATEGORIES = {
+    "financial", "web", "enterprise", "utility", "custom", "system", "general",
+}
+
 
 async def list_tools(
     db: AsyncSession,
@@ -65,12 +69,18 @@ async def create_tool(
     code: str | None = None,
     enabled: bool = True,
     is_public: bool = False,
+    category: str = "general",
 ) -> Tool:
-    """Create a new tool. Raises ValidationError if type is invalid."""
+    """Create a new tool. Raises ValidationError if type or category is invalid."""
     if type not in VALID_TOOL_TYPES:
         raise ValidationError(
             f"Invalid tool type '{type}'. "
             f"Must be one of: {', '.join(sorted(VALID_TOOL_TYPES))}"
+        )
+    if category not in VALID_TOOL_CATEGORIES:
+        raise ValidationError(
+            f"Invalid tool category '{category}'. "
+            f"Must be one of: {', '.join(sorted(VALID_TOOL_CATEGORIES))}"
         )
 
     tool = Tool(
@@ -81,6 +91,7 @@ async def create_tool(
         code=code,
         enabled=enabled,
         is_public=is_public,
+        category=category,
     )
     db.add(tool)
     await db.commit()
@@ -99,6 +110,11 @@ async def update_tool(db: AsyncSession, tool_id: str, **fields) -> Tool:
         raise ValidationError(
             f"Invalid tool type '{fields['type']}'. "
             f"Must be one of: {', '.join(sorted(VALID_TOOL_TYPES))}"
+        )
+    if "category" in fields and fields["category"] not in VALID_TOOL_CATEGORIES:
+        raise ValidationError(
+            f"Invalid tool category '{fields['category']}'. "
+            f"Must be one of: {', '.join(sorted(VALID_TOOL_CATEGORIES))}"
         )
 
     for key, value in fields.items():

--- a/frontend/src/features/admin/resources/tools/ToolForm.tsx
+++ b/frontend/src/features/admin/resources/tools/ToolForm.tsx
@@ -78,6 +78,7 @@ export function ToolForm({ open, tool, duplicateFrom, onClose }: ToolFormProps) 
             : "";
           fields.code = duplicateFrom.code || "";
         }
+        fields.category = duplicateFrom.category || undefined;
         form.setFieldsValue(fields);
         setToolType(duplicateFrom.type);
       } else if (tool) {
@@ -85,6 +86,7 @@ export function ToolForm({ open, tool, duplicateFrom, onClose }: ToolFormProps) 
           tenant_id: tool.tenant_id,
           name: tool.name,
           type: tool.type,
+          category: tool.category || undefined,
           enabled: tool.enabled,
           is_public: tool.is_public,
         };
@@ -107,6 +109,7 @@ export function ToolForm({ open, tool, duplicateFrom, onClose }: ToolFormProps) 
         form.resetFields();
         form.setFieldsValue({
           type: "custom",
+          category: undefined,
           enabled: true,
           is_public: false,
           code: DEFAULT_CODE_TEMPLATE,
@@ -241,6 +244,25 @@ export function ToolForm({ open, tool, duplicateFrom, onClose }: ToolFormProps) 
               { label: "Wikipedia", value: "wikipedia" },
             ]}
             onChange={(value) => setToolType(value)}
+          />
+        </Form.Item>
+        <Form.Item
+          name="category"
+          label="Category"
+          extra="Group tools by category in admin and chat UIs"
+        >
+          <Select
+            allowClear
+            placeholder="Select category (default: general)"
+            options={[
+              { label: "Financial", value: "financial" },
+              { label: "Web", value: "web" },
+              { label: "Enterprise", value: "enterprise" },
+              { label: "Utility", value: "utility" },
+              { label: "Custom", value: "custom" },
+              { label: "System", value: "system" },
+              { label: "General", value: "general" },
+            ]}
           />
         </Form.Item>
 

--- a/frontend/src/features/admin/resources/tools/ToolForm.tsx
+++ b/frontend/src/features/admin/resources/tools/ToolForm.tsx
@@ -78,7 +78,6 @@ export function ToolForm({ open, tool, duplicateFrom, onClose }: ToolFormProps) 
             : "";
           fields.code = duplicateFrom.code || "";
         }
-        fields.category = duplicateFrom.category || undefined;
         form.setFieldsValue(fields);
         setToolType(duplicateFrom.type);
       } else if (tool) {
@@ -86,7 +85,6 @@ export function ToolForm({ open, tool, duplicateFrom, onClose }: ToolFormProps) 
           tenant_id: tool.tenant_id,
           name: tool.name,
           type: tool.type,
-          category: tool.category || undefined,
           enabled: tool.enabled,
           is_public: tool.is_public,
         };
@@ -109,7 +107,6 @@ export function ToolForm({ open, tool, duplicateFrom, onClose }: ToolFormProps) 
         form.resetFields();
         form.setFieldsValue({
           type: "custom",
-          category: undefined,
           enabled: true,
           is_public: false,
           code: DEFAULT_CODE_TEMPLATE,
@@ -244,25 +241,6 @@ export function ToolForm({ open, tool, duplicateFrom, onClose }: ToolFormProps) 
               { label: "Wikipedia", value: "wikipedia" },
             ]}
             onChange={(value) => setToolType(value)}
-          />
-        </Form.Item>
-        <Form.Item
-          name="category"
-          label="Category"
-          extra="Group tools by category in admin and chat UIs"
-        >
-          <Select
-            allowClear
-            placeholder="Select category (default: general)"
-            options={[
-              { label: "Financial", value: "financial" },
-              { label: "Web", value: "web" },
-              { label: "Enterprise", value: "enterprise" },
-              { label: "Utility", value: "utility" },
-              { label: "Custom", value: "custom" },
-              { label: "System", value: "system" },
-              { label: "General", value: "general" },
-            ]}
           />
         </Form.Item>
 

--- a/frontend/src/features/admin/resources/tools/ToolList.tsx
+++ b/frontend/src/features/admin/resources/tools/ToolList.tsx
@@ -4,7 +4,7 @@
 // Ant Design Table/List; type column (erpnext/membrane/custom).
 // =============================================================================
 
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import {
   Table,
   Button,
@@ -17,6 +17,7 @@ import {
   List,
   Card,
   Typography,
+  Select,
 } from "antd";
 import { EditOutlined, DeleteOutlined, CopyOutlined } from "@ant-design/icons";
 import { useSearchParams } from "react-router-dom";
@@ -36,6 +37,7 @@ export function ToolList() {
   const [editingTool, setEditingTool] = useState<ToolData | null>(null);
   const [duplicatingTool, setDuplicatingTool] = useState<ToolData | null>(null);
   const [creating, setCreating] = useState(false);
+  const [categoryFilter, setCategoryFilter] = useState<string | undefined>(undefined);
   const screens = useBreakpoint();
   const isMobile = !screens.md;
   const queryClient = useQueryClient();
@@ -53,6 +55,32 @@ export function ToolList() {
   });
 
   const tenantNameById = new Map((tenants || []).map((t) => [t.id, t.name]));
+
+  const CATEGORY_LABELS: Record<string, string> = {
+    financial: "Financial",
+    web: "Web",
+    enterprise: "Enterprise",
+    utility: "Utility",
+    custom: "Custom",
+    system: "System",
+    general: "General",
+  };
+
+  const CATEGORY_COLORS: Record<string, string> = {
+    financial: "green",
+    web: "blue",
+    enterprise: "orange",
+    utility: "cyan",
+    custom: "purple",
+    system: "default",
+    general: "default",
+  };
+
+  const filteredTools = useMemo(() => {
+    if (!tools) return [];
+    if (!categoryFilter) return tools;
+    return tools.filter((t) => t.category === categoryFilter);
+  }, [tools, categoryFilter]);
 
   const deleteMutation = useMutation({
     mutationFn: deleteTool,
@@ -72,6 +100,16 @@ export function ToolList() {
 
   const columns = [
     { title: "Name", dataIndex: "name", key: "name" },
+    {
+      title: "Category",
+      dataIndex: "category",
+      key: "category",
+      render: (v: string) => (
+        <Tag color={CATEGORY_COLORS[v] || "default"}>
+          {CATEGORY_LABELS[v] || v}
+        </Tag>
+      ),
+    },
     {
       title: "Type",
       dataIndex: "type",
@@ -149,10 +187,24 @@ export function ToolList() {
         </Button>
       </Space>
 
+      <Space style={{ marginBottom: 16, marginLeft: 8 }}>
+        <Select
+          allowClear
+          placeholder="Filter by category"
+          style={{ width: 180 }}
+          value={categoryFilter}
+          onChange={(val) => setCategoryFilter(val)}
+          options={Object.entries(CATEGORY_LABELS).map(([value, label]) => ({
+            label,
+            value,
+          }))}
+        />
+      </Space>
+
       {isMobile ? (
         <List
           loading={isLoading}
-          dataSource={tools || []}
+          dataSource={filteredTools}
           renderItem={(tool) => (
             <Card
               size="small"
@@ -182,6 +234,9 @@ export function ToolList() {
                 description={
                   <Space direction="vertical" size={2}>
                     <Space size={4}>
+                      <Tag color={CATEGORY_COLORS[tool.category] || "default"}>
+                        {CATEGORY_LABELS[tool.category] || tool.category}
+                      </Tag>
                       <Tag color="purple">{tool.type}</Tag>
                       {tool.type === "custom" && tool.code && (
                         <Tag color="green" style={{ fontSize: 11 }}>code</Tag>
@@ -206,7 +261,7 @@ export function ToolList() {
       ) : (
         <Table
           columns={columns}
-          dataSource={tools || []}
+          dataSource={filteredTools}
           rowKey="id"
           loading={isLoading}
         />

--- a/frontend/src/features/admin/services/admin.ts
+++ b/frontend/src/features/admin/services/admin.ts
@@ -63,6 +63,7 @@ export interface ToolData {
   tenant_id: string;
   name: string;
   type: string;
+  category: string;
   config: Record<string, unknown> | null;
   code: string | null;
   enabled: boolean;

--- a/frontend/src/features/chat/components/SessionToolActivation.tsx
+++ b/frontend/src/features/chat/components/SessionToolActivation.tsx
@@ -2,8 +2,10 @@
 // PH Agent Hub — SessionToolActivation
 // =============================================================================
 // Ant Design Drawer+Switch list; GET/POST/DELETE /chat/session/:id/tools.
+// Tools are grouped by category with headers.
 // =============================================================================
 
+import { useMemo } from "react";
 import {
   Drawer,
   List,
@@ -13,6 +15,7 @@ import {
   Space,
   message,
   Tooltip,
+  Divider,
 } from "antd";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "../../../services/api";
@@ -26,6 +29,29 @@ import {
 } from "../services/chat";
 
 const { Text } = Typography;
+
+const CATEGORY_ORDER: Record<string, number> = {
+  financial: 1,
+  web: 2,
+  enterprise: 3,
+  utility: 4,
+  custom: 5,
+  system: 6,
+  general: 7,
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  financial: "Financial",
+  web: "Web",
+  enterprise: "Enterprise",
+  utility: "Utility",
+  custom: "Custom",
+  system: "System",
+  general: "General",
+};
+
+// System tools are never shown in the UI picker
+const HIDDEN_CATEGORIES = new Set(["system"]);
 
 interface SessionToolActivationProps {
   sessionId: string;
@@ -63,6 +89,23 @@ export function SessionToolActivation({
 
   const alwaysOnSet = new Set(alwaysOnIds || []);
   const activeIds = new Set((activeTools || []).map((t) => t.id));
+
+  // Group tools by category, excluding hidden categories
+  const groupedTools = useMemo(() => {
+    const tools = availableTools || [];
+    const groups: Record<string, typeof tools> = {};
+    for (const tool of tools) {
+      const cat = tool.category || "general";
+      if (HIDDEN_CATEGORIES.has(cat)) continue;
+      if (!groups[cat]) groups[cat] = [];
+      groups[cat].push(tool);
+    }
+    // Sort categories by defined order
+    const sorted = Object.entries(groups).sort(([a], [b]) => {
+      return (CATEGORY_ORDER[a] || 99) - (CATEGORY_ORDER[b] || 99);
+    });
+    return sorted;
+  }, [availableTools]);
 
   const addMutation = useMutation({
     mutationFn: (toolId: string) => addSessionTool(sessionId, toolId),
@@ -104,57 +147,70 @@ export function SessionToolActivation({
       onClose={onClose}
       width={420}
     >
-      <List
-        loading={loadingAvailable || loadingActive}
-        dataSource={availableTools || []}
-        locale={{
-          emptyText: (
-            <Empty description="No tools available for your tenant" />
-          ),
-        }}
-        renderItem={(tool) => (
-          <List.Item
-            actions={[
-              <Tooltip title="Auto-activate in new sessions" key="always">
-                <Switch
-                  size="small"
-                  checked={alwaysOnSet.has(tool.id)}
-                  onChange={(checked) =>
-                    alwaysOnMutation.mutate({
-                      toolId: tool.id,
-                      alwaysOn: checked,
-                    })
-                  }
-                  loading={alwaysOnMutation.isPending}
-                />
-              </Tooltip>,
-              <Switch
-                key="active"
-                checked={activeIds.has(tool.id)}
-                onChange={(checked) => handleToggle(tool.id, checked)}
-                loading={
-                  addMutation.isPending || removeMutation.isPending
-                }
-              />,
-            ]}
-          >
-            <List.Item.Meta
-              title={tool.name}
-              description={
-                <Space direction="vertical" size={0}>
-                  <Text type="secondary">
-                    Type: {tool.type}
-                    {alwaysOnSet.has(tool.id) ? " · Always on" : ""}
-                  </Text>
-                  {tool.enabled ? null : (
-                    <Text type="danger">Disabled</Text>
-                  )}
-                </Space>
-              }
+      {groupedTools.length === 0 && !loadingAvailable ? (
+        <Empty description="No tools available for your tenant" />
+      ) : (
+        groupedTools.map(([category, tools]) => (
+          <div key={category}>
+            <Divider orientation="left" plain style={{ margin: "12px 0 8px" }}>
+              <Text strong style={{ fontSize: 13 }}>
+                {CATEGORY_LABELS[category] || category}
+              </Text>
+              <Text type="secondary" style={{ marginLeft: 8, fontSize: 12 }}>
+                ({tools.length})
+              </Text>
+            </Divider>
+            <List
+              loading={loadingAvailable || loadingActive}
+              dataSource={tools}
+              split={false}
+              renderItem={(tool) => (
+                <List.Item
+                  style={{ padding: "6px 0" }}
+                  actions={[
+                    <Tooltip title="Auto-activate in new sessions" key="always">
+                      <Switch
+                        size="small"
+                        checked={alwaysOnSet.has(tool.id)}
+                        onChange={(checked) =>
+                          alwaysOnMutation.mutate({
+                            toolId: tool.id,
+                            alwaysOn: checked,
+                          })
+                        }
+                        loading={alwaysOnMutation.isPending}
+                      />
+                    </Tooltip>,
+                    <Switch
+                      key="active"
+                      checked={activeIds.has(tool.id)}
+                      onChange={(checked) => handleToggle(tool.id, checked)}
+                      loading={
+                        addMutation.isPending || removeMutation.isPending
+                      }
+                    />,
+                  ]}
+                >
+                  <List.Item.Meta
+                    title={tool.name}
+                    description={
+                      <Space direction="vertical" size={0}>
+                        <Text type="secondary">
+                          Type: {tool.type}
+                          {alwaysOnSet.has(tool.id) ? " · Always on" : ""}
+                        </Text>
+                        {tool.enabled ? null : (
+                          <Text type="danger">Disabled</Text>
+                        )}
+                      </Space>
+                    }
+                  />
+                </List.Item>
+              )}
             />
-          </List.Item>
-        )}
-      />
+          </div>
+        ))
+      )}
     </Drawer>
   );
 }

--- a/frontend/src/features/chat/services/chat.ts
+++ b/frontend/src/features/chat/services/chat.ts
@@ -54,6 +54,7 @@ export interface ToolData {
   tenant_id: string;
   name: string;
   type: string;
+  category: string;
   config: Record<string, unknown> | null;
   enabled: boolean;
   created_at: string;


### PR DESCRIPTION
A new `category` column has been added to the `tools` table to facilitate the grouping of approximately 31 tools in the admin and chat UIs. This change includes the addition of categories for existing tools and the implementation of a backfill migration to set these categories based on their types. The admin UI has been updated to include a category filter and display, while the chat UI groups tools by category. The category field is derived from the tool type during creation and updates, ensuring a consistent and user-friendly experience.

Fixes #157