### PR TITLE
Enable file uploads in temporary chat sessions

### DIFF
--- a/backend/src/agents/runner.py
+++ b/backend/src/agents/runner.py
@@ -765,7 +765,7 @@ async def run_agent(
         )
 
         # ---- 9. Link file uploads to the user message ------------------------
-        if file_ids:
+        if file_ids and not is_temporary:
             from ..services import upload_service as _upload_svc
 
             await _upload_svc.link_uploads_to_message(
@@ -1068,7 +1068,11 @@ async def _resolve_tool_callables(
     # the session without polluting the user message with injected text.
     try:
         from ..tools.file_list import build_file_list_tool
-        file_list_tools = build_file_list_tool(db, session_id, tenant_id)
+        file_list_tools = build_file_list_tool(
+            db, session_id, tenant_id,
+            is_temporary=is_temporary,
+            uploaded_file_ids=session_data.get("uploaded_file_ids"),
+        )
         callables.extend(file_list_tools)
     except Exception:
         logger.warning(
@@ -1596,7 +1600,7 @@ async def run_agent_stream(
     )
 
     # Link file uploads to the user message
-    if file_ids:
+    if file_ids and not is_temporary:
         from ..services import upload_service as _upload_svc
 
         await _upload_svc.link_uploads_to_message(
@@ -1696,6 +1700,22 @@ async def run_agent_stream(
 
     except Exception as exc:
         logger.exception("Agent stream failed for session %s", session_id)
+        # Persist whatever we accumulated before the error
+        if accumulated_text or accumulated_reasoning or accumulated_tool_events:
+            try:
+                await _persist_assistant_message(
+                    db=db,
+                    session_id=session_id,
+                    is_temporary=is_temporary,
+                    assistant_response=accumulated_text,
+                    model_id=getattr(cfg, "model", Model(id="unknown", name="unknown", provider="unknown")).id if cfg else "unknown",
+                    tool_events=accumulated_tool_events,
+                    tokens_in=0,
+                    tokens_out=0,
+                    reasoning=accumulated_reasoning,
+                )
+            except Exception:
+                logger.exception("Failed to persist partial message after stream error")
         yield {
             "event": "error",
             "data": json.dumps({

--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -489,13 +489,17 @@ async def delete_session(
     db: AsyncSession = Depends(get_db),
     current_user: UserORM = Depends(get_current_user),
 ):
-    """Delete a session (DB or Redis)."""
+    """Delete a session (DB or Redis). Cleans up file uploads for temp sessions."""
     data = await _load_session(db, session_id)
     await _require_session_owner(data, current_user)
 
     is_temp = data.get("is_temporary", False)
 
     if is_temp:
+        # Clean up associated file uploads (MinIO + DB) before deleting Redis keys
+        uploaded_ids: list[str] = data.get("uploaded_file_ids", [])
+        for file_id in uploaded_ids:
+            await upload_service._delete_temp_upload_by_id(db, file_id)
         await delete_temp_session(session_id)
     else:
         await session_service.delete_session(db, session_id)
@@ -1452,6 +1456,8 @@ async def list_uploads(
         db=db,
         session_id=session_id,
         user_id=current_user.id,
+        is_temporary=data.get("is_temporary", False),
+        file_ids=data.get("uploaded_file_ids"),
     )
     return [
         FileUploadResponse(

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -5,6 +5,7 @@
 # and API router stubs wired in.
 # =============================================================================
 
+import asyncio
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -29,9 +30,24 @@ from .core.limiter import limiter, RateLimitExceeded
 # ---------------------------------------------------------------------------
 
 
+async def _cleanup_orphaned_temp_uploads() -> None:
+    """Periodic background task: delete file uploads for expired temp sessions."""
+    from .db.base import AsyncSessionLocal
+    from .services.upload_service import delete_orphaned_temp_uploads
+
+    interval = settings.TEMPORARY_SESSION_TTL_SECONDS  # same cadence as TTL
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            async with AsyncSessionLocal() as db:
+                await delete_orphaned_temp_uploads(db)
+        except Exception:
+            pass  # Best-effort: never let a cleanup failure crash the task
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Startup: scan MAF registry, load agent identity. Shutdown: no-op."""
+    """Startup: scan MAF registry, load agent identity, start cleanup task."""
     from .agents.registry import startup_scan
     from .agents.runner import load_agent_identity
     from .db.base import AsyncSessionLocal
@@ -41,7 +57,12 @@ async def lifespan(app: FastAPI):
     async with AsyncSessionLocal() as db:
         await startup_scan(db)
 
+    # Start background cleanup for orphaned temp uploads
+    task = asyncio.create_task(_cleanup_orphaned_temp_uploads())
+
     yield
+
+    task.cancel()
 
 
 app = FastAPI(title="PH Agent Hub", version="1.5.1", lifespan=lifespan)

--- a/backend/src/services/upload_service.py
+++ b/backend/src/services/upload_service.py
@@ -14,7 +14,7 @@ from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..core.config import settings
-from ..core.exceptions import ForbiddenError, NotFoundError, ValidationError
+from ..core.exceptions import NotFoundError, ValidationError
 from ..db.orm.file_uploads import FileUpload
 from ..db.orm.users import User
 from ..storage import s3
@@ -146,9 +146,8 @@ async def create_upload(
             f"{settings.UPLOAD_MAX_SIZE_BYTES} bytes"
         )
 
-    # 3. Reject temporary sessions
-    if session_data.get("is_temporary", False):
-        raise ForbiddenError("Uploads are disabled for temporary sessions")
+    # 3. Determine if this is a temporary session
+    is_temp = session_data.get("is_temporary", False)
 
     # 4. Build storage path
     file_id = str(uuid.uuid4())
@@ -180,18 +179,30 @@ async def create_upload(
         id=file_id,
         tenant_id=current_user.tenant_id,
         user_id=current_user.id,
-        session_id=session_data["id"],
+        session_id=None if is_temp else session_data["id"],
         original_filename=original_filename,
         content_type=resolved_type,
         size_bytes=len(file_bytes),
         storage_key=key,
         bucket=bucket,
-        is_temporary=False,
+        is_temporary=is_temp,
         extracted_text=extracted_text,
     )
     db.add(upload)
     await db.commit()
     await db.refresh(upload)
+
+    # 7. Track file ID in Redis for temp sessions (cleanup on delete / TTL expiry)
+    if is_temp:
+        from ..core.redis import get_temp_session, store_temp_session
+
+        redis_data = await get_temp_session(session_data["id"])
+        if redis_data is not None:
+            uploaded_ids: list[str] = redis_data.get("uploaded_file_ids", [])
+            uploaded_ids.append(file_id)
+            redis_data["uploaded_file_ids"] = uploaded_ids
+            await store_temp_session(session_data["id"], redis_data)
+
     return upload
 
 
@@ -199,16 +210,37 @@ async def list_uploads(
     db: AsyncSession,
     session_id: str,
     user_id: str,
+    is_temporary: bool = False,
+    file_ids: list[str] | None = None,
 ) -> list[FileUpload]:
-    """List all file uploads for a session owned by a user."""
-    result = await db.execute(
-        select(FileUpload)
-        .where(
-            FileUpload.session_id == session_id,
-            FileUpload.user_id == user_id,
+    """List all file uploads for a session owned by a user.
+
+    For temp sessions, *file_ids* should be the ``uploaded_file_ids``
+    from the Redis session blob.  When omitted for temp sessions the
+    result will be empty (prevents cross-session leakage).
+    """
+    if is_temporary and file_ids:
+        result = await db.execute(
+            select(FileUpload)
+            .where(
+                FileUpload.id.in_(file_ids),
+                FileUpload.user_id == user_id,
+            )
+            .order_by(FileUpload.created_at.desc())
         )
-        .order_by(FileUpload.created_at.desc())
-    )
+    elif is_temporary:
+        result = await db.execute(
+            select(FileUpload).where(FileUpload.id.in_([]))
+        )
+    else:
+        result = await db.execute(
+            select(FileUpload)
+            .where(
+                FileUpload.session_id == session_id,
+                FileUpload.user_id == user_id,
+            )
+            .order_by(FileUpload.created_at.desc())
+        )
     return list(result.scalars().all())
 
 
@@ -349,6 +381,61 @@ async def list_uploads_for_message(
         .order_by(FileUpload.created_at.asc())
     )
     return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# Temporary session cleanup
+# ---------------------------------------------------------------------------
+
+
+async def delete_orphaned_temp_uploads(db: AsyncSession) -> None:
+    """Delete file uploads belonging to temp sessions whose Redis TTL has expired.
+
+    Queries ``FileUpload`` rows where ``is_temporary = True`` and
+    ``created_at`` is older than ``TEMPORARY_SESSION_TTL_SECONDS`` plus a
+    1-hour grace period, then removes the MinIO object and DB row.
+    Commits at the end.
+    """
+    from datetime import datetime, timezone, timedelta
+
+    cutoff = datetime.now(timezone.utc) - timedelta(
+        seconds=settings.TEMPORARY_SESSION_TTL_SECONDS + 3600  # +1h grace
+    )
+
+    result = await db.execute(
+        select(FileUpload).where(
+            FileUpload.is_temporary == True,  # noqa: E712
+            FileUpload.created_at < cutoff,
+        )
+    )
+    uploads = list(result.scalars().all())
+
+    for upload in uploads:
+        try:
+            await s3.delete_object(bucket=upload.bucket, key=upload.storage_key)
+        except Exception:
+            pass  # Best-effort: MinIO object may already be gone
+
+    if uploads:
+        ids = [u.id for u in uploads]
+        await db.execute(delete(FileUpload).where(FileUpload.id.in_(ids)))
+        await db.commit()
+
+
+async def _delete_temp_upload_by_id(db: AsyncSession, file_id: str) -> None:
+    """Delete a single temp upload by file_id.  Not exposed as an endpoint."""
+    result = await db.execute(
+        select(FileUpload).where(FileUpload.id == file_id)
+    )
+    upload = result.scalar_one_or_none()
+    if upload is None:
+        return
+    try:
+        await s3.delete_object(bucket=upload.bucket, key=upload.storage_key)
+    except Exception:
+        pass
+    await db.execute(delete(FileUpload).where(FileUpload.id == file_id))
+    await db.flush()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/src/tools/file_list.py
+++ b/backend/src/tools/file_list.py
@@ -22,6 +22,8 @@ def build_file_list_tool(
     db: AsyncSession,
     session_id: str,
     tenant_id: str,
+    is_temporary: bool = False,
+    uploaded_file_ids: list[str] | None = None,
 ) -> list:
     """Return built-in MAF @tools for file discovery and content reading.
 
@@ -29,6 +31,8 @@ def build_file_list_tool(
         db: Active async DB session.
         session_id: Current session ID.
         tenant_id: Current tenant ID.
+        is_temporary: Whether the session is temporary (changes DB query).
+        uploaded_file_ids: Specific file IDs for temp sessions (from Redis).
     """
     from ..db.orm.file_uploads import FileUpload
 
@@ -42,12 +46,27 @@ def build_file_list_tool(
         Call this when a user mentions a file and you need its exact name
         (e.g. for the ERPNext ``upload_file`` tool).
         """
-        result = await db.execute(
-            select(FileUpload).where(
-                FileUpload.session_id == session_id,
-                FileUpload.tenant_id == tenant_id,
+        if is_temporary and uploaded_file_ids:
+            result = await db.execute(
+                select(FileUpload).where(
+                    FileUpload.id.in_(uploaded_file_ids),
+                    FileUpload.tenant_id == tenant_id,
+                )
             )
-        )
+        elif is_temporary:
+            # No file IDs tracked — return empty
+            result = await db.execute(
+                select(FileUpload).where(
+                    FileUpload.id.in_([]),
+                )
+            )
+        else:
+            result = await db.execute(
+                select(FileUpload).where(
+                    FileUpload.session_id == session_id,
+                    FileUpload.tenant_id == tenant_id,
+                )
+            )
         uploads = result.scalars().all()
 
         files: list[dict[str, Any]] = []

--- a/docs/chat-area-architecture.md
+++ b/docs/chat-area-architecture.md
@@ -130,7 +130,8 @@ The chat area is a thin client. It renders state returned by the backend but doe
 - Temporary sessions are held in Redis with a TTL; they are not written to MariaDB
 - Temporary sessions are automatically deleted on logout or TTL expiry
 - Memory writes are disabled for temporary sessions
-- File uploads and RAG embedding are disabled for temporary sessions
+- File uploads are supported for both permanent and temporary sessions (auto-cleaned on session expiry)
+- RAG embedding is disabled for temporary sessions
 - The UI prominently marks temporary sessions so the user always knows the session will not be saved
 
 ### **4.9 Message Management**

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -32,7 +32,7 @@ Click **New Session** in the left sidebar, or start typing a message — a sessi
 
 Sessions can be:
 - **Permanent**: Saved to the database. Appears in your session list. Supports all features.
-- **Temporary**: Lives only in Redis. Disappears after inactivity. Does not support file uploads, branching, or editing.
+- **Temporary**: Lives only in Redis. Disappears after inactivity. Does not support branching or editing.
 
 ### 2.2 Pin a Session
 
@@ -174,7 +174,6 @@ You can attach files to your chat sessions for the AI to reference.
 
 ### 7.2 File Limitations
 
-- File uploads are only available for **permanent sessions** (not temporary ones)
 - Uploaded files are stored securely and scoped to your session
 
 ### 7.3 Delete an Upload
@@ -286,7 +285,7 @@ Only models enabled by your administrator for your tenant appear in the selector
 
 - Check the file type is supported (see §7.1)
 - Check the file is under 20 MB
-- Make sure you're in a permanent session, not a temporary one
+- Check your session is active (temporary sessions expire after inactivity)
 
 ### I see an error message
 

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -1008,7 +1008,7 @@ export function ChatWindow({
               await handleFileUpload(file);
               return false;
             }}
-            disabled={streaming || isTemporary || !!editingMsgId}
+            disabled={streaming || !!editingMsgId}
             accept={
               ".pdf,.csv,.txt,.md,.json,.png,.jpg,.jpeg,.gif,.webp,.xlsx,.docx,.pptx," +
               "application/pdf,text/csv,text/plain,text/markdown," +
@@ -1020,7 +1020,7 @@ export function ChatWindow({
           >
             <Button
               icon={<PaperClipOutlined />}
-              disabled={streaming || isTemporary || !!editingMsgId}
+              disabled={streaming || !!editingMsgId}
               loading={uploading}
               title="Attach files"
             />

--- a/frontend/src/features/chat/components/FileUpload.tsx
+++ b/frontend/src/features/chat/components/FileUpload.tsx
@@ -1,7 +1,7 @@
 // =============================================================================
 // PH Agent Hub — FileUpload
 // =============================================================================
-// Ant Design Upload; POST /chat/session/:id/upload; disabled for temporary sessions.
+// Ant Design Upload; POST /chat/session/:id/upload.
 // =============================================================================
 
 import React from "react";

--- a/infrastructure/nginx.conf
+++ b/infrastructure/nginx.conf
@@ -44,7 +44,7 @@ http {
             # SSE: disable buffering
             proxy_buffering off;
             proxy_cache off;
-            proxy_read_timeout 300s;
+            proxy_read_timeout 600s;
             chunked_transfer_encoding on;
         }
 


### PR DESCRIPTION
Allow file uploads in temporary chat sessions, addressing the previous limitation. Update related documentation and ensure proper cleanup of uploads for expired sessions.

Fixes #167