### PR TITLE
Interruption for complicated prompt

### DIFF
--- a/backend/src/models/deepseek.py
+++ b/backend/src/models/deepseek.py
@@ -59,6 +59,10 @@ class DeepSeekThinkingClient(OpenAIChatCompletionClient):
         # Inject reasoning_effort when thinking is enabled and a value is set
         if thinking_type == "enabled" and self._reasoning_effort:
             result["reasoning_effort"] = self._reasoning_effort
+        elif "reasoning_effort" in result:
+            # Base class may have propagated reasoning_effort from options;
+            # DeepSeek requires it not be set when thinking is disabled.
+            del result["reasoning_effort"]
 
         result["extra_body"] = {
             "thinking": {"type": thinking_type}


### PR DESCRIPTION
The changes ensure that the `reasoning_effort` is removed when thinking is disabled, addressing the issue of interruptions in complex prompts. Fixes #172