### PR TITLE
Bump version to 1.6.1 and update migration script

### DIFF
--- a/backend/src/db/migrations/versions/x1y2z3a4b5c6_add_reasoning_effort_to_models.py
+++ b/backend/src/db/migrations/versions/x1y2z3a4b5c6_add_reasoning_effort_to_models.py
@@ -4,7 +4,7 @@ Add reasoning_effort column to the models table for DeepSeek thinking
 mode effort control (values: high, max).
 
 Revision ID: x1y2z3a4b5c6
-Revises: 0a1b2c3d4e5f, 4290105c63b9, c8f7e3a1b2d4, d6e7f8a9b0c1, g1h2i3j4k5l6
+Revises: t5u6v7w8x9y0
 Create Date: 2026-05-14
 
 """
@@ -15,13 +15,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = "x1y2z3a4b5c6"
-down_revision: Union[str, Sequence[str], None] = (
-    "0a1b2c3d4e5f",
-    "4290105c63b9",
-    "c8f7e3a1b2d4",
-    "d6e7f8a9b0c1",
-    "g1h2i3j4k5l6",
-)
+down_revision: Union[str, Sequence[str], None] = "t5u6v7w8x9y0"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -65,7 +65,7 @@ async def lifespan(app: FastAPI):
     task.cancel()
 
 
-app = FastAPI(title="PH Agent Hub", version="1.6.0", lifespan=lifespan)
+app = FastAPI(title="PH Agent Hub", version="1.6.1", lifespan=lifespan)
 
 # ---------------------------------------------------------------------------
 # Middleware

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ph-agent-hub-frontend",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000 --host",


### PR DESCRIPTION
Update the application version to 1.6.1 and revise the down_revision in the migration script to reflect the latest changes.