### PR TITLE
Increase file upload size and update version to 1.6.9

### DIFF
--- a/backend/src/agents/runner.py
+++ b/backend/src/agents/runner.py
@@ -212,7 +212,9 @@ SUMMARY_CAP_RATIO = 0.005
 # Prevents a hung tool (e.g., stalled HTTP request, blocking I/O) from
 # freezing the entire agent loop indefinitely.  The agent receives an
 # error result and can retry or report the failure.
-TOOL_EXECUTION_TIMEOUT = 60
+# SEC filings tools (get_filing_section, get_filing_text) may need up
+# to 90s for large documents with section extraction.
+TOOL_EXECUTION_TIMEOUT = 90
 
 # Maximum seconds the MAF streaming loop will wait for the next update
 # from the model before giving up.  Prevents the agent from hanging

--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -691,15 +691,30 @@ async def _stream_with_heartbeat(
     Emits ``{"event": "heartbeat", "data": "{}"}`` every *interval*
     seconds when no other event has been emitted, to keep proxy
     connections from closing due to idle timeout.
+
+    Uses ``asyncio.wait(..., timeout=interval)`` instead of
+    ``asyncio.wait_for`` so that the inner generator task is NOT
+    cancelled when the heartbeat fires.  Cancelling the inner task
+    would propagate ``CancelledError`` into any currently-running
+    tool (e.g. SEC filing extraction), silently aborting it.
     """
     while True:
         try:
-            event_dict = await asyncio.wait_for(
-                inner_gen.__anext__(), timeout=interval
+            # Wrap __anext__ in a task so we can wait on it without
+            # cancelling it when the heartbeat timeout fires.
+            anext_task = asyncio.ensure_future(inner_gen.__anext__())
+            done, _pending = await asyncio.wait(
+                [anext_task], timeout=interval
             )
-            yield event_dict
-        except asyncio.TimeoutError:
-            yield {"event": "heartbeat", "data": "{}"}
+            if done:
+                event_dict = await anext_task
+                yield event_dict
+            else:
+                # Heartbeat — inner task is still running, do NOT cancel it
+                yield {"event": "heartbeat", "data": "{}"}
+                # Wait for the inner task to complete, then yield its result
+                event_dict = await anext_task
+                yield event_dict
         except StopAsyncIteration:
             break
 

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -58,6 +58,9 @@ class Settings(BaseSettings):
     LOGIN_RATE_LIMIT: str = "5/minute"
     SEED_ALLOW_WEAK_PASSWORD: bool = False
 
+    # --- Logging ---
+    LOG_LEVEL: str = "INFO"
+
     model_config = {"env_file": ".env", "extra": "ignore"}
 
     def __init__(self, **kwargs):

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -23,7 +23,7 @@ class Settings(BaseSettings):
     MINIO_PUBLIC_ENDPOINT: str = ""
 
     # --- File Upload Limits ---
-    UPLOAD_MAX_SIZE_BYTES: int = 20_971_520  # 20 MiB
+    UPLOAD_MAX_SIZE_BYTES: int = 104_857_600  # 100 MiB
     UPLOAD_ALLOWED_TYPES: str = (
         "text/plain,text/csv,text/markdown,application/pdf,"
         "application/json,image/png,image/jpeg,image/gif,image/webp,"

--- a/backend/src/db/migrations/versions/852db3dd6183_change_extracted_text_to_longtext.py
+++ b/backend/src/db/migrations/versions/852db3dd6183_change_extracted_text_to_longtext.py
@@ -1,0 +1,41 @@
+"""change_extracted_text_to_longtext
+
+Revision ID: 852db3dd6183
+Revises: u1v2w3x4y5z6
+Create Date: 2026-05-18 14:08:12.068720
+
+Increases the extracted_text column from TEXT (~64 KB) to LONGTEXT (~4 GB)
+to accommodate PDF text extraction output for large documents.
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision: str = "852db3dd6183"
+down_revision: Union[str, None] = "u1v2w3x4y5z6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Increase extracted_text from TEXT (~64 KB) to LONGTEXT (~4 GB)."""
+    op.alter_column(
+        "file_uploads",
+        "extracted_text",
+        existing_type=mysql.TEXT(),
+        type_=mysql.LONGTEXT(),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "file_uploads",
+        "extracted_text",
+        existing_type=mysql.LONGTEXT(),
+        type_=mysql.TEXT(),
+        existing_nullable=True,
+    )

--- a/backend/src/db/orm/file_uploads.py
+++ b/backend/src/db/orm/file_uploads.py
@@ -6,6 +6,7 @@ import uuid
 from datetime import datetime, timezone
 
 from sqlalchemy import String, Boolean, Integer, Text, DateTime, ForeignKey, func
+from sqlalchemy.dialects.mysql import LONGTEXT
 from sqlalchemy.dialects.mysql import CHAR
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -40,7 +41,7 @@ class FileUpload(Base):
     storage_key: Mapped[str] = mapped_column(String(512), nullable=False)
     bucket: Mapped[str] = mapped_column(String(255), nullable=False)
     is_temporary: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
-    extracted_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    extracted_text: Mapped[str | None] = mapped_column(LONGTEXT, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -6,6 +6,8 @@
 # =============================================================================
 
 import asyncio
+import logging
+import os
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -48,6 +50,20 @@ async def _cleanup_orphaned_temp_uploads() -> None:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Startup: scan MAF registry, load agent identity, start cleanup task."""
+    # Configure root logger so INFO/DEBUG logs from all modules
+    # appear alongside uvicorn's own logging output.
+    log_level = os.environ.get("LOG_LEVEL", settings.LOG_LEVEL).upper()
+    level = getattr(logging, log_level, logging.INFO)
+    logger = logging.getLogger()
+    logger.setLevel(level)
+    if not any(isinstance(h, logging.StreamHandler) for h in logger.handlers):
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(
+            "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        ))
+        logger.addHandler(handler)
+
     from .agents.registry import startup_scan
     from .agents.runner import load_agent_identity
     from .db.base import AsyncSessionLocal
@@ -65,7 +81,7 @@ async def lifespan(app: FastAPI):
     task.cancel()
 
 
-app = FastAPI(title="PH Agent Hub", version="1.6.8", lifespan=lifespan)
+app = FastAPI(title="PH Agent Hub", version="1.6.9", lifespan=lifespan)
 
 # ---------------------------------------------------------------------------
 # Middleware

--- a/backend/src/tools/sec_filings.py
+++ b/backend/src/tools/sec_filings.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import time
 from datetime import datetime
 
 import httpx
@@ -105,10 +106,33 @@ async def _fetch_url_direct(
 ) -> tuple[str, str]:
     """Fallback: fetch and clean a filing via direct HTTP when edgartools
     cannot resolve the URL."""
-    async with httpx.AsyncClient(timeout=timeout) as client:
-        resp = await client.get(url, headers=headers, follow_redirects=True)
-        resp.raise_for_status()
-    html = resp.text
+    t_start = time.monotonic()
+    logger.debug(
+        "_fetch_url_direct START url=%s timeout=%.1f user_agent=%s",
+        url, timeout, headers.get("User-Agent", ""),
+    )
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.get(url, headers=headers, follow_redirects=True)
+            resp.raise_for_status()
+        html = resp.text
+    except httpx.HTTPStatusError as exc:
+        elapsed = time.monotonic() - t_start
+        logger.warning(
+            "_fetch_url_direct HTTP %s for %s (elapsed=%.3fs) "
+            "response_headers=%s body_preview=%s",
+            exc.response.status_code,
+            url,
+            elapsed,
+            dict(exc.response.headers),
+            (exc.response.text or "")[:500],
+        )
+        raise
+    elapsed = time.monotonic() - t_start
+    logger.debug(
+        "_fetch_url_direct OK url=%s status=%s elapsed=%.3fs",
+        url, getattr(resp, 'status_code', '?'), elapsed,
+    )
 
     # Resolve indirect pages
 
@@ -251,12 +275,18 @@ def build_sec_filings_tools(tool_config: dict | None = None) -> list:
         Uses the edgartools library — full filing history since 1994,
         proper rate limiting, no API key required.
 
+        **limit is applied per form type** so that frequent filers
+        (8-K) don't crowd out annual/quarterly reports (10-K, 10-Q).
+        For example, ``limit=5`` returns up to 5 of each requested
+        form type.
+
         Args:
             ticker: Stock ticker symbol (e.g. "AAPL", "MSFT").
             form_types: Optional list of form types to filter by.
                 Common types: "10-K", "10-Q", "8-K", "S-1",
                 "DEF 14A".  Default searches 10-K, 10-Q, 8-K, S-1.
-            limit: Max filings to return (default 10, max 50).
+            limit: Max filings **per form type** (default 10, max 50).
+                Total results may be up to limit × number of form types.
             filing_date_from: Earliest filing date in YYYY-MM-DD format
                 (e.g. "2024-01-01").  Filters to filings on or after
                 this date.
@@ -279,15 +309,17 @@ def build_sec_filings_tools(tool_config: dict | None = None) -> list:
 
             forms = form_types if form_types else ["10-K", "10-Q", "8-K", "S-1"]
 
-            # Gather filings for each requested form type
+            # Gather filings — apply limit PER FORM TYPE so frequent
+            # filers (8-K) don't crowd out annual/quarterly reports.
             all_filings: list = []
             for form in forms:
                 try:
                     batch = await asyncio.to_thread(
                         company.get_filings, form=form
                     )
-                    # edgartools Filings objects are iterable
-                    all_filings.extend(list(batch))
+                    batch_list = list(batch)
+                    # Take up to lim of this specific form type
+                    all_filings.extend(batch_list[:lim])
                 except Exception as exc:
                     logger.debug("No %s filings for %s: %s", form, sym, exc)
 
@@ -310,12 +342,11 @@ def build_sec_filings_tools(tool_config: dict | None = None) -> list:
                     if getattr(f, "filing_date", None) and f.filing_date >= cutoff
                 ]
 
-            # Sort by date descending
+            # Sort by date descending (per-form-type limits already applied)
             all_filings.sort(
                 key=lambda f: getattr(f, "filing_date", datetime.min),
                 reverse=True,
             )
-            all_filings = all_filings[:lim]
 
             # Serialise to JSON-safe dicts
             results: list[dict] = []
@@ -432,8 +463,9 @@ def build_sec_filings_tools(tool_config: dict | None = None) -> list:
                 logger.warning("get_filing_text timed out for %s", url)
                 # Fall through to HTTP fallback
             except Exception as exc:
-                logger.debug(
-                    "edgartools lookup failed for %s: %s — falling back to HTTP",
+                logger.warning(
+                    "get_filing_text: edgartools lookup FAILED for %s: %s — "
+                    "falling back to HTTP",
                     url, exc,
                 )
 
@@ -453,6 +485,13 @@ def build_sec_filings_tools(tool_config: dict | None = None) -> list:
                 "source": "SEC EDGAR",
             }
         except httpx.HTTPStatusError as exc:
+            logger.warning(
+                "get_filing_text HTTP %s for %s headers=%s body_preview=%s",
+                exc.response.status_code,
+                url,
+                dict(exc.response.headers),
+                (exc.response.text or "")[:500],
+            )
             return {
                 "url": url,
                 "error": f"SEC EDGAR returned HTTP {exc.response.status_code}",
@@ -487,6 +526,7 @@ def build_sec_filings_tools(tool_config: dict | None = None) -> list:
             - ``source``: "SEC EDGAR"
         """
         logger.info("get_filing_section: %s [section=%s]", url, section)
+        t_start = time.monotonic()
 
         acc, cik = _parse_acc_num_and_cik(url)
 
@@ -550,7 +590,23 @@ def build_sec_filings_tools(tool_config: dict | None = None) -> list:
                     if direct:
                         matched = section.strip()
                         section_text = direct
-                except (Exception, asyncio.TimeoutError):
+                        logger.debug(
+                            "get_filing_section: direct lookup OK for %r "
+                            "(len=%d)",
+                            section, len(section_text),
+                        )
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "get_filing_section: direct lookup TIMED OUT "
+                        "after %ds for section %r",
+                        EDGAR_TIMEOUT, section,
+                    )
+                    direct = None
+                except Exception as exc:
+                    logger.warning(
+                        "get_filing_section: direct lookup FAILED "
+                        "for section %r: %s", section, exc,
+                    )
                     direct = None
 
                 # If direct lookup failed, try case-insensitive match
@@ -577,6 +633,17 @@ def build_sec_filings_tools(tool_config: dict | None = None) -> list:
                             timeout=EDGAR_TIMEOUT,
                         )
                         section_text = extracted or ""
+                        if section_text:
+                            logger.debug(
+                                "get_filing_section: fallback lookup OK "
+                                "for %r (len=%d)",
+                                matched, len(section_text),
+                            )
+                        else:
+                            logger.warning(
+                                "get_filing_section: fallback lookup "
+                                "returned empty for %r", matched,
+                            )
             else:
                 # Fallback: regex-based splitter for unrecognised filing types
                 full_text = await asyncio.wait_for(
@@ -595,6 +662,12 @@ def build_sec_filings_tools(tool_config: dict | None = None) -> list:
                     section_text = sections.get(matched, "")
 
             if not section_text:
+                elapsed = time.monotonic() - t_start
+                logger.warning(
+                    "get_filing_section: section %r NOT FOUND "
+                    "(elapsed=%.1fs, available=%s)",
+                    section, elapsed, available,
+                )
                 return {
                     "url": url,
                     "section": section,
@@ -606,6 +679,11 @@ def build_sec_filings_tools(tool_config: dict | None = None) -> list:
                     "source": "SEC EDGAR",
                 }
 
+            elapsed = time.monotonic() - t_start
+            logger.info(
+                "get_filing_section: SUCCESS section=%r len=%d elapsed=%.1fs",
+                matched, len(section_text), elapsed,
+            )
             return {
                 "url": url,
                 "section": matched,
@@ -616,10 +694,27 @@ def build_sec_filings_tools(tool_config: dict | None = None) -> list:
             }
 
         except asyncio.TimeoutError:
-            logger.warning("get_filing_section timed out for %s [section=%s]", url, section)
+            elapsed = time.monotonic() - t_start
+            logger.warning(
+                "get_filing_section: inner operation TIMED OUT "
+                "after %.1fs for %s [section=%s]",
+                elapsed, url, section,
+            )
             return {"url": url, "error": f"Operation timed out after {EDGAR_TIMEOUT}s"}
+        except asyncio.CancelledError:
+            elapsed = time.monotonic() - t_start
+            logger.warning(
+                "get_filing_section: CANCELLED after %.1fs for %s "
+                "[section=%s] — likely framework tool timeout (60s)",
+                elapsed, url, section,
+            )
+            raise
         except Exception as exc:
-            logger.exception("get_filing_section failed for %s", url)
+            elapsed = time.monotonic() - t_start
+            logger.exception(
+                "get_filing_section failed after %.1fs for %s",
+                elapsed, url,
+            )
             return {"url": url, "error": str(exc)}
 
     return [list_sec_filings, get_filing_text, get_filing_section]

--- a/docs/file-upload-architecture.md
+++ b/docs/file-upload-architecture.md
@@ -167,7 +167,7 @@ Enforced at the API layer before the object is written to MinIO:
 
 | Setting | Default | Config key |
 |---|---|---|
-| Max file size | 20 MB | `UPLOAD_MAX_SIZE_BYTES` |
+| Max file size | 100 MB | `UPLOAD_MAX_SIZE_BYTES` |
 | Allowed MIME types | see below | `UPLOAD_ALLOWED_TYPES` |
 
 **Default allowed MIME types:**
@@ -262,7 +262,7 @@ MINIO_ACCESS_KEY=minioadmin
 MINIO_SECRET_KEY=minioadmin
 MINIO_BUCKET_PREFIX=phhub-tenant
 
-UPLOAD_MAX_SIZE_BYTES=20971520
+UPLOAD_MAX_SIZE_BYTES=104857600
 UPLOAD_ALLOWED_TYPES=text/plain,text/csv,text/markdown,application/pdf,application/json,image/png,image/jpeg,image/gif,image/webp
 ```
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -170,7 +170,7 @@ You can attach files to your chat sessions for the AI to reference.
 3. The file is uploaded and attached to the current session
 
 **Supported file types**: Plain text, CSV, Markdown, PDF, JSON, PNG, JPEG, GIF, WebP.
-**Maximum file size**: 20 MB.
+**Maximum file size**: 100 MB.
 
 ### 7.2 File Limitations
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -9,6 +9,8 @@ server {
     listen 3000;
     server_name localhost;
 
+    client_max_body_size 100m;
+
     # ── Static files ───────────────────────────────────────────────────────
     root /usr/share/nginx/html;
     index index.html;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ph-agent-hub-frontend",
   "private": true,
-  "version": "1.6.8",
+  "version": "1.6.9",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000 --host",

--- a/infrastructure/env.example
+++ b/infrastructure/env.example
@@ -26,7 +26,7 @@ MINIO_BUCKET_PREFIX=phhub-tenant
 MINIO_PUBLIC_ENDPOINT=http://localhost:9000
 
 # --- File Upload Limits ---
-UPLOAD_MAX_SIZE_BYTES=20971520
+UPLOAD_MAX_SIZE_BYTES=104857600
 UPLOAD_ALLOWED_TYPES=text/plain,text/csv,text/markdown,application/pdf,application/json,image/png,image/jpeg,image/gif,image/webp,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/msword,application/vnd.ms-excel,application/vnd.ms-powerpoint
 
 # --- Authentication (JWT) ---

--- a/infrastructure/nginx.conf
+++ b/infrastructure/nginx.conf
@@ -9,6 +9,8 @@ events {
 }
 
 http {
+    client_max_body_size 100m;
+
     # ── Upstreams ──────────────────────────────────────────────────────────
     upstream backend {
         server backend:8000;


### PR DESCRIPTION
The pull request increases the maximum file upload size to 100 MB and changes the `extracted_text` column type to LONGTEXT to support larger documents. Additionally, it updates the version to 1.6.9 and adjusts the `TOOL_EXECUTION_TIMEOUT` for SEC filings tools to 90 seconds.

Fixes #211 and #210