### PR TITLE
Fix PDF report download issue

### DIFF
--- a/infrastructure/docker-compose.prod.yml
+++ b/infrastructure/docker-compose.prod.yml
@@ -54,6 +54,7 @@ services:
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+      MINIO_SERVER_URL: https://${FILES_DOMAIN}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 10s
@@ -63,6 +64,20 @@ services:
       - minio_data:/data
     networks:
       - phagent-network
+      - traefik-public
+    labels:
+      traefik.enable: "true"
+      traefik.docker.network: traefik-public
+      traefik.http.routers.phagent-files-http.entrypoints: http
+      traefik.http.routers.phagent-files-http.middlewares: https-redirect
+      traefik.http.routers.phagent-files-http.rule: Host(`${FILES_DOMAIN}`)
+      traefik.http.routers.phagent-files-http.service: phagent-files
+      traefik.http.routers.phagent-files-https.entrypoints: https
+      traefik.http.routers.phagent-files-https.rule: Host(`${FILES_DOMAIN}`)
+      traefik.http.routers.phagent-files-https.service: phagent-files
+      traefik.http.routers.phagent-files-https.tls: "true"
+      traefik.http.routers.phagent-files-https.tls.certresolver: le
+      traefik.http.services.phagent-files.loadbalancer.server.port: "9000"
 
   # ── Backend ──────────────────────────────────────────────────────────────
   backend:

--- a/infrastructure/env.example
+++ b/infrastructure/env.example
@@ -23,7 +23,7 @@ MINIO_SECRET_KEY=minioadmin
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=minioadmin
 MINIO_BUCKET_PREFIX=phhub-tenant
-MINIO_PUBLIC_ENDPOINT=http://localhost:9000
+MINIO_PUBLIC_ENDPOINT=https://files.phagent.example.com
 
 # --- File Upload Limits ---
 UPLOAD_MAX_SIZE_BYTES=104857600
@@ -51,6 +51,7 @@ VITE_API_URL=/api
 API_DOMAIN=api.phagent.example.com
 APP_DOMAIN=app.phagent.example.com
 PMA_DOMAIN=pma.phagent.example.com
+FILES_DOMAIN=files.phagent.example.com
 
 # --- Docker Images (optional, for docker-compose.prod.yml) ---
 # Override these to use a custom registry or tag.


### PR DESCRIPTION
Updated the MinIO configuration to enable secure access for generated reports. This change ensures that the reports can be downloaded successfully from the production server.

Fixes #216