### PR TITLE
Fix currency conversion issue by updating API endpoint

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -81,7 +81,7 @@ async def lifespan(app: FastAPI):
     task.cancel()
 
 
-app = FastAPI(title="PH Agent Hub", version="1.7.2", lifespan=lifespan)
+app = FastAPI(title="PH Agent Hub", version="1.7.3", lifespan=lifespan)
 
 # ---------------------------------------------------------------------------
 # Middleware

--- a/backend/src/tools/currency_exchange.py
+++ b/backend/src/tools/currency_exchange.py
@@ -1,8 +1,8 @@
 # =============================================================================
-# PH Agent Hub — Currency Exchange Tool Factory (frankfurter.app)
+# PH Agent Hub — Currency Exchange Tool Factory (frankfurter.dev)
 # =============================================================================
 # Builds MAF @tool-decorated async functions for currency conversion and
-# exchange rates using the free frankfurter.app API (ECB data).
+# exchange rates using the free frankfurter.dev API (ECB data).
 # No API key required.  Uses httpx for async HTTP requests.
 # =============================================================================
 
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-FRANKFURTER_BASE: str = "https://api.frankfurter.app"
+FRANKFURTER_BASE: str = "https://api.frankfurter.dev"
 DEFAULT_TIMEOUT: float = 15.0
 DEFAULT_BASE_CURRENCY: str = "EUR"
 
@@ -55,7 +55,7 @@ def build_currency_exchange_tools(tool_config: dict | None = None) -> list:
         """Convert an amount from one currency to another.
 
         Uses the European Central Bank's daily reference rates via
-        frankfurter.app — free, no API key required.
+        frankfurter.dev — free, no API key required.
 
         Args:
             amount: The amount to convert (e.g. 100).
@@ -74,13 +74,13 @@ def build_currency_exchange_tools(tool_config: dict | None = None) -> list:
         fc = from_currency.upper()
         tc = to_currency.upper()
         url = (
-            f"{FRANKFURTER_BASE}/latest"
+            f"{FRANKFURTER_BASE}/v1/latest"
             f"?amount={amount}&from={fc}&to={tc}"
         )
         logger.info("convert_currency: %.2f %s → %s", amount, fc, tc)
 
         try:
-            async with httpx.AsyncClient(timeout=timeout) as client:
+            async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
                 response = await client.get(
                     url,
                     headers={"User-Agent": "ph-agent-hub/1.0"},
@@ -140,7 +140,7 @@ def build_currency_exchange_tools(tool_config: dict | None = None) -> list:
         """Get the latest exchange rates for a base currency.
 
         Uses the European Central Bank's daily reference rates via
-        frankfurter.app — free, no API key required.
+        frankfurter.dev — free, no API key required.
 
         Args:
             base: Base currency code (e.g. "USD").
@@ -154,11 +154,11 @@ def build_currency_exchange_tools(tool_config: dict | None = None) -> list:
             - ``rate_count``: number of currencies available
         """
         b = (base or base_currency).upper()
-        url = f"{FRANKFURTER_BASE}/latest?from={b}"
+        url = f"{FRANKFURTER_BASE}/v1/latest?from={b}"
         logger.info("get_exchange_rates: base=%s", b)
 
         try:
-            async with httpx.AsyncClient(timeout=timeout) as client:
+            async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
                 response = await client.get(
                     url,
                     headers={"User-Agent": "ph-agent-hub/1.0"},

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -162,7 +162,7 @@ Tools extend agent capabilities — they can call external APIs, query ERPNext i
 | **calculator** | Utility | Safe AST expression evaluator | None |
 | **calendar** | Productivity | Google Calendar — list/create events, find free slots | `provider`, `credentials`, `calendar_id`, `timezone` |
 | **code_interpreter** | Utility | Docker-sandboxed Python execution (pandas, numpy, matplotlib, plotly) | `timeout`, `allow_network` |
-| **currency_exchange** | Financial | Exchange rates via frankfurter.app (ECB data) | `base_currency`, `timeout` |
+| **currency_exchange** | Financial | Exchange rates via frankfurter.dev (ECB data) | `base_currency`, `timeout` |
 | **custom** | Extensibility | Admin-authored sandboxed Python tools | `code` (Python), `config` (JSON) |
 | **datetime** | Utility | Timezone-aware date/time queries | `timezone` |
 | **document_generation** | Utility | Markdown→PDF (weasyprint), list→Excel (openpyxl), list→CSV | `company_logo_url` |

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ph-agent-hub-frontend",
   "private": true,
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000 --host",


### PR DESCRIPTION
The currency conversion functionality now uses the updated API endpoint at frankfurter.dev, resolving the HTTP 301 errors encountered with the previous endpoint. This change ensures successful currency conversions and updates the application version accordingly.

Fixes #227