### PR TITLE
Implement cross-session memory for semantic retrieval of past conversations

### DIFF
--- a/backend/src/agents/runner.py
+++ b/backend/src/agents/runner.py
@@ -83,6 +83,7 @@ async def _resolve_session_config(
     tenant_id: str,
     user: User | None = None,
     file_ids: list[str] | None = None,
+    user_message: str | None = None,
 ) -> SessionConfig:
     """Resolve model, system prompt, skill, tools, execution type, and agent name.
 
@@ -92,8 +93,10 @@ async def _resolve_session_config(
     # 1. Resolve model
     model = await _resolve_model(db, session_data, user)
 
-    # 2. Build system prompt
-    system_prompt = await _build_system_prompt(db, session_data, user=user)
+    # 2. Build system prompt (includes cross-session memory retrieval if enabled)
+    system_prompt = await _build_system_prompt(
+        db, session_data, user=user, user_message=user_message,
+    )
 
     # 3. Resolve skill
     skill = await _resolve_skill(db, session_data)
@@ -791,7 +794,7 @@ async def run_agent(
     is_temporary = session_data.get("is_temporary", False)
 
     # ---- 1-6. Resolve session config ------------------------------------
-    cfg = await _resolve_session_config(db, session_data, tenant_id, current_user, file_ids=file_ids)
+    cfg = await _resolve_session_config(db, session_data, tenant_id, current_user, file_ids=file_ids, user_message=user_message)
 
     # ---- Build contextualized message (history + auto-summarization) ----
     contextualized_message, _ = await _maybe_summarize_and_build_context(
@@ -847,6 +850,21 @@ async def run_agent(
             tokens_in=tokens_in,
             tokens_out=tokens_out,
         )
+
+        # ---- Background: embed user message for cross-session retrieval -----
+        if not is_temporary:
+            try:
+                from ..services.embedding_service import embed_message as _embed_msg
+
+                asyncio.ensure_future(_embed_msg(
+                    db=await _fresh_db_session(),
+                    message_id=_user_msg_id,
+                    user_id=current_user.id,
+                    tenant_id=current_user.tenant_id,
+                    text=user_message,
+                ))
+            except Exception:
+                logger.warning("Failed to schedule embedding for message %s", _user_msg_id, exc_info=True)
 
         # ---- 9. Link file uploads to the user message ------------------------
         if file_ids and not is_temporary:
@@ -959,14 +977,21 @@ async def _resolve_model(
 
 
 async def _build_system_prompt(
-    db: AsyncSession, session_data: dict, user: User | None = None
+    db: AsyncSession,
+    session_data: dict,
+    user: User | None = None,
+    user_message: str | None = None,
 ) -> str:
-    """Build the system prompt from template + agent memory.
+    """Build the system prompt from template + agent memory + cross-session retrieval.
 
     Resolution chain:
     1. session.selected_template_id (manual override in chat)
     2. skill.template_id (from the selected skill's config)
     3. "You are a helpful assistant." (hardcoded fallback)
+
+    If ``user_message`` is provided and cross-session retrieval is enabled,
+    past conversations semantically similar to the user message are injected
+    as an additional context block (Issue #229).
     """
     template_id = session_data.get("selected_template_id")
 
@@ -1030,6 +1055,97 @@ async def _build_system_prompt(
         except Exception:
             logger.warning(
                 "Failed to load agent memory for user=%s", user.id, exc_info=True
+            )
+
+    # ---- Cross-session memory retrieval (Issue #229) -----------------------
+    # Inject relevant past conversation snippets via semantic search.
+    if user and user_message:
+        try:
+            from ..services.embedding_service import (
+                embed_query as _embed_query,
+                retrieve_similar as _retrieve_similar,
+            )
+
+            # Resolve whether retrieval is enabled:
+            #   session override (tri-state) → skill default → off
+            retrieval_enabled = session_data.get("cross_session_retrieval_enabled")
+            if retrieval_enabled is None:
+                # Fall back to skill config
+                skill_id = session_data.get("selected_skill_id")
+                if skill_id:
+                    result = await db.execute(
+                        select(Skill).where(Skill.id == skill_id)
+                    )
+                    skill_row = result.scalar_one_or_none()
+                    if skill_row:
+                        retrieval_enabled = skill_row.cross_session_retrieval_enabled
+                        max_snippets = skill_row.cross_session_max_snippets
+                        min_score = skill_row.cross_session_min_score
+                    else:
+                        retrieval_enabled = False
+                        max_snippets = 3
+                        min_score = 0.70
+                else:
+                    retrieval_enabled = False
+                    max_snippets = 3
+                    min_score = 0.30
+            else:
+                # Use session-level defaults when skill doesn't apply
+                max_snippets = 3
+                min_score = 0.30
+
+            if retrieval_enabled:
+                query_emb = await _embed_query(user_message)
+                if query_emb:
+                    similar = await _retrieve_similar(
+                        db=db,
+                        user_id=user.id,
+                        tenant_id=user.tenant_id,
+                        query_embedding=query_emb,
+                        session_id=session_data.get("id"),
+                        top_k=max_snippets,
+                        min_score=min_score,
+                    )
+
+                    if similar:
+                        snippet_lines: list[str] = [
+                            "## Relevant Past Conversations",
+                            "",
+                            "The following excerpts from your past conversations "
+                            "may be relevant to the current message. "
+                            "Use this context if helpful, but do NOT mention "
+                            "these entries unless they are directly relevant:",
+                            "",
+                        ]
+                        for s in similar:
+                            session_label = s.get("session_title") or "Unknown session"
+                            snippet_lines.append(
+                                f"- [Session: {session_label} | "
+                                f"Relevance: {s['score']:.2f}]"
+                            )
+                            # Truncate user message
+                            user_txt = s.get("user_text", "")
+                            if len(user_txt) > 300:
+                                user_txt = user_txt[:300] + "..."
+                            snippet_lines.append(f"  User: {user_txt}")
+
+                            asst_txt = s.get("assistant_text")
+                            if asst_txt:
+                                if len(asst_txt) > 500:
+                                    asst_txt = asst_txt[:500] + "..."
+                                snippet_lines.append(f"  Assistant: {asst_txt}")
+
+                            snippet_lines.append("")
+
+                        parts.append("\n".join(snippet_lines))
+                        logger.debug(
+                            "Injected %d cross-session snippets for user=%s",
+                            len(similar), user.id,
+                        )
+        except Exception:
+            logger.warning(
+                "Failed to retrieve cross-session memory for user=%s",
+                user.id, exc_info=True,
             )
 
     if parts:
@@ -1567,6 +1683,22 @@ async def _run_workflow(
 
 
 # ---------------------------------------------------------------------------
+# Fresh DB session helper (for background fire-and-forget tasks)
+# ---------------------------------------------------------------------------
+
+
+async def _fresh_db_session() -> AsyncSession:
+    """Create a new async DB session independent of the current request.
+
+    Used by ``asyncio.ensure_future`` background tasks (e.g. embedding)
+    that outlive the request-response cycle and therefore can't reuse
+    the request-scoped ``db`` session.
+    """
+    from ..db.base import AsyncSessionLocal
+    return AsyncSessionLocal()
+
+
+# ---------------------------------------------------------------------------
 # Message persistence
 # ---------------------------------------------------------------------------
 
@@ -1808,9 +1940,25 @@ async def run_agent_stream(
             message_id=user_msg_id,
             user_id=current_user.id,
         )
+
+    # ---- Background: embed user message for cross-session retrieval -----
+    if not is_temporary:
+        try:
+            from ..services.embedding_service import embed_message as _embed_msg
+
+            asyncio.ensure_future(_embed_msg(
+                db=await _fresh_db_session(),
+                message_id=user_msg_id,
+                user_id=current_user.id,
+                tenant_id=current_user.tenant_id,
+                text=user_message,
+            ))
+        except Exception:
+            logger.warning("Failed to schedule embedding for message %s", user_msg_id, exc_info=True)
+
     try:
         # ---- 1-6. Resolve session config --------------------------------
-        cfg = await _resolve_session_config(db, session_data, tenant_id, current_user, file_ids=file_ids)
+        cfg = await _resolve_session_config(db, session_data, tenant_id, current_user, file_ids=file_ids, user_message=user_message)
 
         # ---- Build contextualized message (history + auto-summarization) --
         contextualized_message, summary_info = await _maybe_summarize_and_build_context(

--- a/backend/src/api/admin.py
+++ b/backend/src/api/admin.py
@@ -1242,6 +1242,9 @@ class AdminSkillCreate(BaseModel):
     default_model_id: str | None = None
     enabled: bool = True
     tool_ids: list[str] | None = None
+    cross_session_retrieval_enabled: bool = False
+    cross_session_max_snippets: int = 3
+    cross_session_min_score: float = 0.30
 
 
 class AdminSkillUpdate(BaseModel):
@@ -1257,6 +1260,9 @@ class AdminSkillUpdate(BaseModel):
     default_model_id: str | None = None
     enabled: bool | None = None
     tool_ids: list[str] | None = None
+    cross_session_retrieval_enabled: bool | None = None
+    cross_session_max_snippets: int | None = None
+    cross_session_min_score: float | None = None
 
 
 class AdminSkillResponse(BaseModel):
@@ -1272,6 +1278,9 @@ class AdminSkillResponse(BaseModel):
     default_prompt_id: str | None
     default_model_id: str | None
     enabled: bool
+    cross_session_retrieval_enabled: bool
+    cross_session_max_snippets: int
+    cross_session_min_score: float
     created_at: datetime
     updated_at: datetime
     tool_ids: list[str] = []
@@ -1352,6 +1361,9 @@ async def admin_create_skill(
         default_model_id=body.default_model_id,
         enabled=body.enabled,
         tool_ids=body.tool_ids,
+        cross_session_retrieval_enabled=body.cross_session_retrieval_enabled,
+        cross_session_max_snippets=body.cross_session_max_snippets,
+        cross_session_min_score=body.cross_session_min_score,
     )
     tools = await _svc_list_skill_tools(db, skill.id)
     resp = AdminSkillResponse.model_validate(skill)
@@ -1388,6 +1400,8 @@ async def admin_update_skill(
         "title", "description", "execution_type", "maf_target_key",
         "visibility", "template_id", "default_prompt_id", "default_model_id",
         "enabled",
+        "cross_session_retrieval_enabled", "cross_session_max_snippets",
+        "cross_session_min_score",
     ):
         val = getattr(body, field, None)
         if val is not None:

--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -439,6 +439,7 @@ async def get_session(
         "selected_model_id": data.get("selected_model_id"),
         "thinking_enabled": data.get("thinking_enabled"),
         "temperature": data.get("temperature"),
+        "cross_session_retrieval_enabled": data.get("cross_session_retrieval_enabled"),
         "tags": data.get("tags", []),
         "created_at": _parse_datetime(data.get("created_at")),
         "updated_at": _parse_datetime(data.get("updated_at")),

--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -79,6 +79,7 @@ class SessionUpdate(BaseModel):
     selected_model_id: str | None = None
     thinking_enabled: bool | None = None
     temperature: float | None = None
+    cross_session_retrieval_enabled: bool | None = None
 
 
 class TagResponse(BaseModel):
@@ -101,6 +102,7 @@ class SessionResponse(BaseModel):
     selected_model_id: str | None
     thinking_enabled: bool | None
     temperature: float | None
+    cross_session_retrieval_enabled: bool | None = None
     tags: list[TagResponse] = []
     created_at: datetime
     updated_at: datetime
@@ -198,6 +200,7 @@ def _session_to_dict(session: Session) -> dict[str, Any]:
         "selected_model_id": session.selected_model_id,
         "thinking_enabled": session.thinking_enabled,
         "temperature": session.temperature,
+        "cross_session_retrieval_enabled": session.cross_session_retrieval_enabled,
         "created_at": session.created_at.isoformat(),
         "updated_at": session.updated_at.isoformat(),
     }
@@ -474,6 +477,7 @@ async def update_session(
             "selected_model_id": data.get("selected_model_id"),
             "thinking_enabled": data.get("thinking_enabled"),
             "temperature": data.get("temperature"),
+            "cross_session_retrieval_enabled": data.get("cross_session_retrieval_enabled"),
             "tags": [],
             "created_at": _parse_datetime(data.get("created_at")),
             "updated_at": datetime.now(timezone.utc),

--- a/backend/src/api/skills.py
+++ b/backend/src/api/skills.py
@@ -33,6 +33,9 @@ class SkillCreate(BaseModel):
     default_model_id: str | None = None
     enabled: bool = True
     tool_ids: list[str] | None = None
+    cross_session_retrieval_enabled: bool = False
+    cross_session_max_snippets: int = 3
+    cross_session_min_score: float = 0.30
 
 
 class SkillUpdate(BaseModel):
@@ -45,6 +48,9 @@ class SkillUpdate(BaseModel):
     default_model_id: str | None = None
     enabled: bool | None = None
     tool_ids: list[str] | None = None
+    cross_session_retrieval_enabled: bool | None = None
+    cross_session_max_snippets: int | None = None
+    cross_session_min_score: float | None = None
 
 
 class SkillResponse(BaseModel):
@@ -60,6 +66,9 @@ class SkillResponse(BaseModel):
     default_prompt_id: str | None
     default_model_id: str | None
     enabled: bool
+    cross_session_retrieval_enabled: bool
+    cross_session_max_snippets: int
+    cross_session_min_score: float
     created_at: datetime
     updated_at: datetime
     tool_ids: list[str] = []
@@ -110,6 +119,9 @@ async def create_skill(
         default_model_id=body.default_model_id,
         enabled=body.enabled,
         tool_ids=body.tool_ids,
+        cross_session_retrieval_enabled=body.cross_session_retrieval_enabled,
+        cross_session_max_snippets=body.cross_session_max_snippets,
+        cross_session_min_score=body.cross_session_min_score,
     )
     tools = await _svc_list_skill_tools(db, skill.id)
     resp = SkillResponse.model_validate(skill)
@@ -136,6 +148,8 @@ async def update_skill(
     for field in (
         "title", "description", "execution_type", "maf_target_key",
         "template_id", "default_prompt_id", "default_model_id", "enabled",
+        "cross_session_retrieval_enabled", "cross_session_max_snippets",
+        "cross_session_min_score",
     ):
         val = getattr(body, field, None)
         if val is not None:

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -52,6 +52,9 @@ class Settings(BaseSettings):
     # --- Session ---
     TEMPORARY_SESSION_TTL_SECONDS: int = 86400  # 24 hours
 
+    # --- Cross-session memory (Issue #229) ---
+    CROSS_SESSION_EMBEDDING_MODEL: str = "text-embedding-3-small"
+
     # --- Security ---
     COOKIE_SECURE: bool = False
     CORS_ALLOWED_ORIGINS: str = "http://localhost:3000"

--- a/backend/src/db/migrations/versions/359185b6bb95_add_message_embeddings_and_cross_.py
+++ b/backend/src/db/migrations/versions/359185b6bb95_add_message_embeddings_and_cross_.py
@@ -1,0 +1,52 @@
+"""add_message_embeddings_and_cross_session_memory_config
+
+Revision ID: 359185b6bb95
+Revises: 852db3dd6183
+Create Date: 2026-05-22 07:03:02.644429
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision: str = '359185b6bb95'
+down_revision: Union[str, None] = '852db3dd6183'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ---- message_embeddings table (cross-session memory, Issue #229) ------
+    op.create_table('message_embeddings',
+        sa.Column('id', mysql.CHAR(length=36), nullable=False),
+        sa.Column('message_id', mysql.CHAR(length=36), nullable=False),
+        sa.Column('user_id', mysql.CHAR(length=36), nullable=False),
+        sa.Column('tenant_id', mysql.CHAR(length=36), nullable=False),
+        sa.Column('chunk_index', sa.Integer(), nullable=False),
+        sa.Column('embedding_json', sa.JSON(), nullable=True),
+        sa.Column('model', sa.String(length=64), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.ForeignKeyConstraint(['message_id'], ['messages.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['tenant_id'], ['tenants.id'], ),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+    # ---- Cross-session memory config columns on skills --------------------
+    op.add_column('skills', sa.Column('cross_session_retrieval_enabled', sa.Boolean(), nullable=False, server_default=sa.text('0')))
+    op.add_column('skills', sa.Column('cross_session_max_snippets', sa.Integer(), nullable=False, server_default=sa.text('3')))
+    op.add_column('skills', sa.Column('cross_session_min_score', sa.Float(), nullable=False, server_default=sa.text('0.70')))
+
+    # ---- Cross-session memory toggle on sessions (tri-state: NULL=inherit) -
+    op.add_column('sessions', sa.Column('cross_session_retrieval_enabled', sa.Boolean(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_table('message_embeddings')
+    op.drop_column('skills', 'cross_session_min_score')
+    op.drop_column('skills', 'cross_session_max_snippets')
+    op.drop_column('skills', 'cross_session_retrieval_enabled')
+    op.drop_column('sessions', 'cross_session_retrieval_enabled')

--- a/backend/src/db/orm/__init__.py
+++ b/backend/src/db/orm/__init__.py
@@ -19,6 +19,7 @@ from .sessions import Session, SessionActiveTool
 from .tags import Tag, SessionTag
 from .messages import Message, MessageFeedback
 from .memory import Memory
+from .message_embeddings import MessageEmbedding
 from .file_uploads import FileUpload
 from .rag import RAGDocument
 from .usage_logs import UsageLog
@@ -44,6 +45,7 @@ __all__ = [
     "Message",
     "MessageFeedback",
     "Memory",
+    "MessageEmbedding",
     "FileUpload",
     "RAGDocument",
     "UsageLog",

--- a/backend/src/db/orm/message_embeddings.py
+++ b/backend/src/db/orm/message_embeddings.py
@@ -1,0 +1,41 @@
+# =============================================================================
+# PH Agent Hub — ORM: Message Embeddings (Cross-Session Memory)
+# =============================================================================
+# Stores embedding vectors for user messages to enable semantic retrieval
+# across sessions (Issue #229).
+# =============================================================================
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import String, Integer, DateTime, JSON, ForeignKey, func
+from sqlalchemy.dialects.mysql import CHAR
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ..base import Base
+from .users import User
+from .tenants import Tenant
+from .messages import Message
+
+
+class MessageEmbedding(Base):
+    __tablename__ = "message_embeddings"
+
+    id: Mapped[str] = mapped_column(
+        CHAR(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    message_id: Mapped[str] = mapped_column(
+        CHAR(36), ForeignKey("messages.id", ondelete="CASCADE"), nullable=False
+    )
+    user_id: Mapped[str] = mapped_column(
+        CHAR(36), ForeignKey("users.id"), nullable=False
+    )
+    tenant_id: Mapped[str] = mapped_column(
+        CHAR(36), ForeignKey("tenants.id"), nullable=False
+    )
+    chunk_index: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    embedding_json: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    model: Mapped[str] = mapped_column(String(64), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )

--- a/backend/src/db/orm/sessions.py
+++ b/backend/src/db/orm/sessions.py
@@ -44,6 +44,11 @@ class Session(Base):
     )
     thinking_enabled: Mapped[bool | None] = mapped_column(Boolean, nullable=True, default=None)
     temperature: Mapped[float | None] = mapped_column(Float, nullable=True, default=None)
+
+    # ---- Cross-session memory (Issue #229) -- tri-state: None=inherit from skill
+    cross_session_retrieval_enabled: Mapped[bool | None] = mapped_column(
+        Boolean, nullable=True, default=None
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/src/db/orm/skills.py
+++ b/backend/src/db/orm/skills.py
@@ -5,7 +5,7 @@
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import String, Boolean, DateTime, Enum, ForeignKey, func
+from sqlalchemy import String, Boolean, Integer, Float, DateTime, Enum, ForeignKey, func
 from sqlalchemy.dialects.mysql import CHAR
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -49,6 +49,18 @@ class Skill(Base):
         Enum("tenant", "user", name="skill_visibility_enum"), nullable=False
     )
     enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+    # ---- Cross-session memory (Issue #229) -----------------------------------
+    cross_session_retrieval_enabled: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False
+    )
+    cross_session_max_snippets: Mapped[int] = mapped_column(
+        Integer, default=3, nullable=False
+    )
+    cross_session_min_score: Mapped[float] = mapped_column(
+        Float, default=0.30, nullable=False
+    )
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/src/services/embedding_service.py
+++ b/backend/src/services/embedding_service.py
@@ -1,0 +1,352 @@
+# =============================================================================
+# PH Agent Hub — Embedding Service (Cross-Session Memory, Issue #229)
+# =============================================================================
+# Handles embedding generation, storage, and semantic retrieval for past
+# conversations. Reuses the embedding client from rag_search.py.
+# =============================================================================
+
+import logging
+import math
+from datetime import datetime, timezone
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+DEFAULT_EMBEDDING_MODEL: str = "text-embedding-3-small"
+DEFAULT_TOP_K: int = 3
+DEFAULT_MIN_SCORE: float = 0.30
+
+
+# ---------------------------------------------------------------------------
+# Embedding helpers (reuse from rag_search.py)
+# ---------------------------------------------------------------------------
+
+async def _get_embeddings(
+    texts: list[str],
+    model: str = DEFAULT_EMBEDDING_MODEL,
+) -> list[list[float]]:
+    """Get embeddings for a list of texts.
+
+    Delegates to the same embedding client used by the RAG search tool.
+    Falls back to TF-IDF-like hashing if the API is unavailable.
+    """
+    if not texts:
+        return []
+
+    try:
+        from ..tools.rag_search import _get_embeddings as _rag_embed
+
+        return await _rag_embed(texts, model=model)
+    except Exception as exc:
+        logger.warning("Embedding via rag_search failed: %s", exc)
+        return []
+
+
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Compute cosine similarity between two vectors."""
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(x * x for x in b))
+    if na == 0 or nb == 0:
+        return 0.0
+    return dot / (na * nb)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def embed_message(
+    db: AsyncSession,
+    message_id: str,
+    user_id: str,
+    tenant_id: str,
+    text: str,
+    model: str | None = None,
+) -> None:
+    """Generate and store an embedding for a single user message.
+
+    This is called asynchronously after message persistence.
+    Temporary messages and empty/non-user messages are skipped.
+
+    Args:
+        db: Active async DB session.
+        message_id: The UUID of the persisted message.
+        user_id: The message author's user UUID.
+        tenant_id: The message's tenant UUID.
+        text: The plain text content of the message.
+        model: Embedding model name (default: settings.CROSS_SESSION_EMBEDDING_MODEL).
+    """
+    if not text or not text.strip():
+        return
+
+    embedding_model = model or getattr(settings, "CROSS_SESSION_EMBEDDING_MODEL", DEFAULT_EMBEDDING_MODEL)
+
+    try:
+        # Single-chunk for short messages, multi-chunk for long ones
+        chunks = _chunk_text(text) if len(text) > 500 else [text]
+
+        embeddings = await _get_embeddings(chunks, model=embedding_model)
+        if not embeddings:
+            logger.debug("No embeddings returned for message %s", message_id)
+            return
+
+        # Import here to avoid circular imports at module level
+        from ..db.orm.message_embeddings import MessageEmbedding
+
+        for i, (chunk, emb) in enumerate(zip(chunks, embeddings)):
+            if not emb:
+                continue
+            row = MessageEmbedding(
+                message_id=message_id,
+                user_id=user_id,
+                tenant_id=tenant_id,
+                chunk_index=i,
+                embedding_json=emb,
+                model=embedding_model,
+            )
+            db.add(row)
+
+        await db.commit()
+        logger.debug(
+            "Stored %d embedding(s) for message %s (%s)",
+            len(embeddings), message_id, embedding_model,
+        )
+    except Exception:
+        logger.exception("Failed to embed message %s", message_id)
+
+
+async def embed_query(
+    text: str,
+    model: str | None = None,
+) -> list[float] | None:
+    """Generate an embedding vector for a query string.
+
+    Args:
+        text: The query text (typically the current user message).
+        model: Embedding model name.
+
+    Returns:
+        A single embedding vector, or None on failure.
+    """
+    if not text or not text.strip():
+        return None
+
+    embedding_model = model or getattr(settings, "CROSS_SESSION_EMBEDDING_MODEL", DEFAULT_EMBEDDING_MODEL)
+
+    try:
+        results = await _get_embeddings([text], model=embedding_model)
+        if results and results[0]:
+            return results[0]
+        return None
+    except Exception:
+        logger.exception("Failed to embed query")
+        return None
+
+
+async def retrieve_similar(
+    db: AsyncSession,
+    user_id: str,
+    tenant_id: str,
+    query_embedding: list[float],
+    session_id: str | None = None,
+    top_k: int = DEFAULT_TOP_K,
+    min_score: float = DEFAULT_MIN_SCORE,
+) -> list[dict]:
+    """Retrieve past conversation snippets similar to the query embedding.
+
+    Loads all embeddings for the given user from the ``message_embeddings``
+    table, computes cosine similarity in Python, deduplicates by message,
+    and returns the top-K results with full message context.
+
+    Args:
+        db: Active async DB session.
+        user_id: The current user's UUID.
+        tenant_id: The current tenant's UUID.
+        query_embedding: The embedding vector of the current query.
+        session_id: Optional — exclude messages from this session
+                    (to avoid retrieving from the current conversation).
+        top_k: Maximum number of snippets to return.
+        min_score: Minimum cosine similarity threshold.
+
+    Returns:
+        A list of dicts, each containing:
+            - message_id (str)
+            - score (float)
+            - session_id (str)
+            - session_title (str)
+            - user_text (str)
+            - assistant_text (str | None)
+            - created_at (str | None)
+    """
+    if not query_embedding:
+        return []
+
+    from ..db.orm.message_embeddings import MessageEmbedding
+
+    try:
+        # Load all embeddings for this user
+        stmt = select(MessageEmbedding).where(
+            MessageEmbedding.user_id == user_id,
+            MessageEmbedding.tenant_id == tenant_id,
+        ).order_by(MessageEmbedding.created_at.desc())
+
+        result = await db.execute(stmt)
+        rows = list(result.scalars().all())
+
+        if not rows:
+            return []
+
+        # Score each embedding row, keep best per message_id
+        best_per_message: dict[str, tuple[float, MessageEmbedding]] = {}
+
+        for row in rows:
+            if not row.embedding_json:
+                continue
+            score = _cosine_similarity(query_embedding, row.embedding_json)
+            if score < min_score:
+                continue
+            existing_score, _ = best_per_message.get(row.message_id, (0.0, None))
+            if score > existing_score:
+                best_per_message[row.message_id] = (score, row)
+
+        if not best_per_message:
+            return []
+
+        # Sort by score descending, take top_k
+        scored = sorted(
+            best_per_message.items(),
+            key=lambda x: x[1][0],
+            reverse=True,
+        )[:top_k]
+
+        # Fetch full message context for each match
+        message_ids = [msg_id for msg_id, _ in scored]
+
+        # Fetch the messages table rows
+        from ..db.orm.messages import Message
+
+        msg_stmt = select(Message).where(Message.id.in_(message_ids))
+        msg_result = await db.execute(msg_stmt)
+        messages_map = {m.id: m for m in msg_result.scalars().all()}
+
+        # Also fetch the next assistant message after each matched message
+        results_list: list[dict] = []
+
+        for msg_id, (score, emb_row) in scored:
+            msg = messages_map.get(msg_id)
+            if not msg or not msg.content:
+                continue
+
+            # Extract user text from JSON content
+            user_text = _extract_text(msg.content)
+
+            if not user_text:
+                continue
+
+            # Try to find the assistant response that follows this user message
+            from ..db.orm.sessions import Session as SessionORM
+
+            assistant_text = None
+            try:
+                # Find the next assistant message in the same session
+                next_stmt = select(Message).where(
+                    Message.session_id == msg.session_id,
+                    Message.sender == "assistant",
+                    Message.created_at > msg.created_at,
+                    Message.is_deleted == False,  # noqa: E712
+                ).order_by(Message.created_at).limit(1)
+                next_result = await db.execute(next_stmt)
+                next_msg = next_result.scalar_one_or_none()
+                if next_msg and next_msg.content:
+                    assistant_text = _extract_text(next_msg.content, max_chars=500)
+            except Exception:
+                pass
+
+            # Get session title
+            session_title = ""
+            try:
+                s_stmt = select(SessionORM).where(SessionORM.id == msg.session_id)
+                s_result = await db.execute(s_stmt)
+                s_row = s_result.scalar_one_or_none()
+                if s_row:
+                    session_title = s_row.title
+            except Exception:
+                pass
+
+            results_list.append({
+                "message_id": msg_id,
+                "score": round(score, 4),
+                "session_id": msg.session_id,
+                "session_title": session_title,
+                "user_text": user_text[:500],
+                "assistant_text": assistant_text,
+                "created_at": msg.created_at.isoformat() if msg.created_at else None,
+            })
+
+        return results_list
+
+    except Exception:
+        logger.exception("Failed to retrieve similar messages for user=%s", user_id)
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _chunk_text(text: str, chunk_size: int = 500, chunk_overlap: int = 50) -> list[str]:
+    """Split text into overlapping chunks for embedding.
+
+    Delegates to the chunker from rag_search.py when available, otherwise
+    falls back to a simple paragraph-level split.
+    """
+    try:
+        from ..tools.rag_search import _chunk_text as _rag_chunk
+        return _rag_chunk(text, chunk_size=chunk_size, chunk_overlap=chunk_overlap)
+    except Exception:
+        # Simple fallback
+        if len(text) <= chunk_size:
+            return [text]
+        chunks = []
+        start = 0
+        while start < len(text):
+            end = min(start + chunk_size, len(text))
+            chunks.append(text[start:end])
+            start = end - chunk_overlap
+        return chunks
+
+
+def _extract_text(content: list | None, max_chars: int = 0) -> str:
+    """Extract plain text from a message's JSON content array.
+
+    Mirrors the logic in runner._extract_message_text but accepts
+    a max_chars parameter for truncation.
+    """
+    if not content or not isinstance(content, list):
+        return ""
+
+    parts: list[str] = []
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") == "text":
+            text = item.get("text", "")
+            if text:
+                parts.append(text)
+
+    result = "\n".join(parts)
+    if max_chars and len(result) > max_chars:
+        result = result[:max_chars] + "..."
+    return result

--- a/backend/src/services/skill_service.py
+++ b/backend/src/services/skill_service.py
@@ -116,6 +116,9 @@ async def create_skill(
     default_model_id: str | None = None,
     enabled: bool = True,
     tool_ids: list[str] | None = None,
+    cross_session_retrieval_enabled: bool = False,
+    cross_session_max_snippets: int = 3,
+    cross_session_min_score: float = 0.30,
 ) -> Skill:
     """Create a new skill with optional tool associations.
 
@@ -137,6 +140,9 @@ async def create_skill(
         default_prompt_id=default_prompt_id,
         default_model_id=default_model_id,
         enabled=enabled,
+        cross_session_retrieval_enabled=cross_session_retrieval_enabled,
+        cross_session_max_snippets=cross_session_max_snippets,
+        cross_session_min_score=cross_session_min_score,
     )
     db.add(skill)
     await db.flush()  # Get the skill ID before adding join rows

--- a/frontend/src/features/admin/resources/skills/SkillForm.tsx
+++ b/frontend/src/features/admin/resources/skills/SkillForm.tsx
@@ -90,6 +90,9 @@ export function SkillForm({ open, skill, duplicateFrom, onClose }: SkillFormProp
           default_model_id: duplicateFrom.default_model_id,
           enabled: duplicateFrom.enabled,
           tool_ids: duplicateFrom.tool_ids || [],
+          cross_session_retrieval_enabled: duplicateFrom.cross_session_retrieval_enabled ?? false,
+          cross_session_max_snippets: duplicateFrom.cross_session_max_snippets ?? 3,
+          cross_session_min_score: duplicateFrom.cross_session_min_score ?? 0.30,
         });
       } else if (skill) {
         form.setFieldsValue({
@@ -104,6 +107,9 @@ export function SkillForm({ open, skill, duplicateFrom, onClose }: SkillFormProp
           default_model_id: skill.default_model_id,
           enabled: skill.enabled,
           tool_ids: skill.tool_ids || [],
+          cross_session_retrieval_enabled: skill.cross_session_retrieval_enabled ?? false,
+          cross_session_max_snippets: skill.cross_session_max_snippets ?? 3,
+          cross_session_min_score: skill.cross_session_min_score ?? 0.30,
         });
       } else {
         form.resetFields();
@@ -114,6 +120,9 @@ export function SkillForm({ open, skill, duplicateFrom, onClose }: SkillFormProp
           visibility: "tenant",
           enabled: true,
           tool_ids: [],
+          cross_session_retrieval_enabled: false,
+          cross_session_max_snippets: 3,
+          cross_session_min_score: 0.30,
         });
       }
     }
@@ -279,6 +288,34 @@ export function SkillForm({ open, skill, duplicateFrom, onClose }: SkillFormProp
         </Form.Item>
         <Form.Item name="enabled" label="Enabled" valuePropName="checked">
           <Switch />
+        </Form.Item>
+
+        {/* ---- Cross-session memory (Issue #229) ---- */}
+        <Form.Item
+          label="Cross-Session Memory"
+          style={{ marginBottom: 0 }}
+        >
+          <Form.Item
+            name="cross_session_retrieval_enabled"
+            valuePropName="checked"
+            style={{ display: "inline-block", marginRight: 32 }}
+          >
+            <Switch checkedChildren="Enabled" unCheckedChildren="Disabled" />
+          </Form.Item>
+          <Form.Item
+            name="cross_session_max_snippets"
+            label="Max Snippets"
+            style={{ display: "inline-block", width: 120, marginRight: 32 }}
+          >
+            <Input type="number" min={1} max={10} />
+          </Form.Item>
+          <Form.Item
+            name="cross_session_min_score"
+            label="Min Score"
+            style={{ display: "inline-block", width: 120 }}
+          >
+            <Input type="number" min={0} max={1} step={0.05} />
+          </Form.Item>
         </Form.Item>
       </Form>
     </Modal>

--- a/frontend/src/features/admin/services/admin.ts
+++ b/frontend/src/features/admin/services/admin.ts
@@ -138,6 +138,9 @@ export interface SkillData {
   created_at: string;
   updated_at: string;
   tool_ids: string[];
+  cross_session_retrieval_enabled?: boolean;
+  cross_session_max_snippets?: number;
+  cross_session_min_score?: number;
 }
 
 export interface UsageData {

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -61,6 +61,7 @@ interface ChatWindowProps {
   selectedTemplateId?: string;
   selectedSkillId?: string;
   temperature?: number | null;
+  crossSessionMemoryEnabled?: boolean | null;
   onSessionUpdate?: (data: Record<string, unknown>) => void;
 }
 
@@ -71,6 +72,7 @@ export function ChatWindow({
   selectedTemplateId,
   selectedSkillId,
   temperature,
+  crossSessionMemoryEnabled = null,
   onSessionUpdate,
 }: ChatWindowProps) {
   const [inputValue, setInputValue] = useState("");
@@ -80,6 +82,7 @@ export function ChatWindow({
   const [streamError, setStreamError] = useState<string | null>(null);
   const [streamingTokens, setStreamingTokens] = useState<{ tokens_in: number; tokens_out: number } | null>(null);
   const [thinkingEnabled, setThinkingEnabled] = useState<boolean | null>(null);
+  const [localCrossSessionMemory, setLocalCrossSessionMemory] = useState<boolean | null>(crossSessionMemoryEnabled);
   const [sessionTemperature, setSessionTemperature] = useState<number | null>(
     temperature ?? null,
   );
@@ -155,7 +158,8 @@ export function ChatWindow({
     setEditingMsgId(null);
     setRegeneratingMsgId(null);
     setSessionTemperature(temperature ?? null);
-  }, [sessionId, temperature]);
+    setLocalCrossSessionMemory(crossSessionMemoryEnabled ?? null);
+  }, [sessionId, temperature, crossSessionMemoryEnabled]);
 
   // Clear editing state once the edited message is confirmed gone from the list
   useEffect(() => {
@@ -670,10 +674,12 @@ export function ChatWindow({
           </Button>
           <Switch
             size="small"
+            checked={localCrossSessionMemory ?? false}
             checkedChildren="🧠 Memory"
             unCheckedChildren="🧠 Memory"
             title="Cross-session memory"
             onChange={(v) => {
+              setLocalCrossSessionMemory(v);
               onSessionUpdate?.({ cross_session_retrieval_enabled: v });
             }}
           />
@@ -784,6 +790,17 @@ export function ChatWindow({
               }}
             />
           )}
+          <Switch
+            size="small"
+            checked={localCrossSessionMemory ?? false}
+            checkedChildren="🧠 Memory"
+            unCheckedChildren="🧠 Memory"
+            title="Cross-session memory"
+            onChange={(v) => {
+              setLocalCrossSessionMemory(v);
+              onSessionUpdate?.({ cross_session_retrieval_enabled: v });
+            }}
+          />
           <div style={{ width: "100%" }}>
             <Space direction="vertical" style={{ width: "100%" }}>
               <Text type="secondary" style={{ fontSize: 12 }}>

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -668,6 +668,15 @@ export function ChatWindow({
           >
             Summarize
           </Button>
+          <Switch
+            size="small"
+            checkedChildren="🧠 Memory"
+            unCheckedChildren="🧠 Memory"
+            title="Cross-session memory"
+            onChange={(v) => {
+              onSessionUpdate?.({ cross_session_retrieval_enabled: v });
+            }}
+          />
           {modelSupportsThinking && (
             <Switch
               size="small"

--- a/frontend/src/features/chat/routes/ChatPage.tsx
+++ b/frontend/src/features/chat/routes/ChatPage.tsx
@@ -111,6 +111,7 @@ export function ChatPage() {
             selectedTemplateId={session.selected_template_id ?? undefined}
             selectedSkillId={session.selected_skill_id ?? undefined}
             temperature={session.temperature ?? null}
+            crossSessionMemoryEnabled={session.cross_session_retrieval_enabled ?? null}
             onSessionUpdate={handleSessionUpdate}
           />
         ) : (

--- a/frontend/src/features/chat/services/chat.ts
+++ b/frontend/src/features/chat/services/chat.ts
@@ -29,6 +29,7 @@ export interface SessionData {
   selected_model_id: string | null;
   thinking_enabled?: boolean | null;
   temperature?: number | null;
+  cross_session_retrieval_enabled?: boolean | null;
   tags?: TagData[];
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
Enhance the chat system by enabling semantic retrieval of past conversations across sessions. This implementation includes adding a new embedding column to the database, embedding messages asynchronously, and conducting similarity searches to inject relevant past exchanges into the current session's context. Configuration options allow for toggling retrieval features and setting limits on the number of snippets retrieved.

Fixes #229