### PR TITLE
Fix tools selection display in chat window

### DIFF
--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -318,7 +318,7 @@ async def create_session(
     If ``active_tool_ids`` is not provided, auto-activates tools that the
     user has marked as "always on" in their preferences.
     """
-    # Resolve active tool IDs: explicit list > always-on preferences > empty
+    # Resolve active tool IDs: explicit list > always-on + skill tools > empty
     active_tool_ids = body.active_tool_ids
     if active_tool_ids is None:
         pref_result = await db.execute(
@@ -327,8 +327,21 @@ async def create_session(
                 UserToolPreference.always_on == True,  # noqa: E712
             )
         )
-        always_on_ids = [row[0] for row in pref_result.all()]
-        active_tool_ids = always_on_ids
+        always_on_ids = {row[0] for row in pref_result.all()}
+
+        # Include skill's tools if a skill is selected
+        skill_tool_ids: set[str] = set()
+        if body.selected_skill_id:
+            from ..db.orm.skills import SkillAllowedTool
+
+            result = await db.execute(
+                select(SkillAllowedTool.tool_id).where(
+                    SkillAllowedTool.skill_id == body.selected_skill_id
+                )
+            )
+            skill_tool_ids = {row[0] for row in result.all()}
+
+        active_tool_ids = list(always_on_ids | skill_tool_ids)
 
     if body.is_temporary:
         # Create in Redis
@@ -458,12 +471,55 @@ async def update_session(
     await _require_session_owner(data, current_user)
 
     is_temp = data.get("is_temporary", False)
+    update_fields = body.model_dump(exclude_unset=True)
+
+    # Detect skill change
+    old_skill_id = data.get("selected_skill_id")
+    skill_changed = "selected_skill_id" in update_fields
+    new_skill_id = update_fields.get("selected_skill_id") if skill_changed else None
 
     if is_temp:
         # Update Redis blob
-        update_fields = body.model_dump(exclude_unset=True)
         data.update(update_fields)
         data["updated_at"] = datetime.now(timezone.utc).isoformat()
+
+        # Sync skill tools in Redis blob
+        if skill_changed:
+            pref_result = await db.execute(
+                select(UserToolPreference.tool_id).where(
+                    UserToolPreference.user_id == current_user.id,
+                    UserToolPreference.always_on == True,  # noqa: E712
+                )
+            )
+            always_on_ids = {row[0] for row in pref_result.all()}
+
+            # Fetch old skill tool IDs
+            from ..db.orm.skills import SkillAllowedTool
+
+            old_tool_ids: set[str] = set()
+            if old_skill_id:
+                result = await db.execute(
+                    select(SkillAllowedTool.tool_id).where(
+                        SkillAllowedTool.skill_id == old_skill_id
+                    )
+                )
+                old_tool_ids = {row[0] for row in result.all()}
+
+            # Fetch new skill tool IDs
+            new_tool_ids: set[str] = set()
+            if new_skill_id:
+                result = await db.execute(
+                    select(SkillAllowedTool.tool_id).where(
+                        SkillAllowedTool.skill_id == new_skill_id
+                    )
+                )
+                new_tool_ids = {row[0] for row in result.all()}
+
+            current_active = set(data.get("active_tool_ids", []))
+            to_remove = old_tool_ids - new_tool_ids - always_on_ids
+            to_add = new_tool_ids - current_active
+            data["active_tool_ids"] = list((current_active - to_remove) | to_add)
+
         await store_temp_session(session_id, data)
 
         return {
@@ -487,8 +543,26 @@ async def update_session(
         session = await session_service.update_session(
             db=db,
             session_id=session_id,
-            **body.model_dump(exclude_unset=True),
+            **update_fields,
         )
+
+        if skill_changed:
+            pref_result = await db.execute(
+                select(UserToolPreference.tool_id).where(
+                    UserToolPreference.user_id == current_user.id,
+                    UserToolPreference.always_on == True,  # noqa: E712
+                )
+            )
+            always_on_ids = [row[0] for row in pref_result.all()]
+            await session_service.sync_session_tools_for_skill(
+                db=db,
+                session_id=session_id,
+                old_skill_id=old_skill_id,
+                new_skill_id=new_skill_id,
+                tenant_id=current_user.tenant_id,
+                always_on_ids=always_on_ids,
+            )
+
         return SessionResponse.model_validate(session)
 
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -81,7 +81,7 @@ async def lifespan(app: FastAPI):
     task.cancel()
 
 
-app = FastAPI(title="PH Agent Hub", version="1.9.1", lifespan=lifespan)
+app = FastAPI(title="PH Agent Hub", version="1.9.2", lifespan=lifespan)
 
 # ---------------------------------------------------------------------------
 # Middleware

--- a/backend/src/services/session_service.py
+++ b/backend/src/services/session_service.py
@@ -9,6 +9,7 @@ from ..core.exceptions import NotFoundError, ValidationError
 from ..db.orm.sessions import Session, SessionActiveTool
 from ..db.orm.tools import Tool
 from ..db.orm.users import User
+from ..db.orm.skills import Skill, SkillAllowedTool
 from ..services.model_service import list_models as _svc_list_models
 
 
@@ -344,6 +345,80 @@ async def remove_session_tool(
     if result.rowcount == 0:
         raise NotFoundError("Tool not active for this session")
     await db.commit()
+
+
+async def sync_session_tools_for_skill(
+    db: AsyncSession,
+    session_id: str,
+    old_skill_id: str | None,
+    new_skill_id: str | None,
+    tenant_id: str,
+    always_on_ids: list[str] | None = None,
+) -> None:
+    """Sync the session's active tools when the selected skill changes.
+
+    When a skill is selected, its tools are auto-activated. When the skill
+    is changed or cleared, the previous skill's tools are removed.
+    Always-on tools are never removed.
+
+    Resolution:
+        to_remove = old_skill_tool_ids − new_skill_tool_ids − always_on_ids
+        to_add    = new_skill_tool_ids − current_active_ids
+    """
+    always_on_set = set(always_on_ids or [])
+
+    # Fetch tool IDs for old skill
+    old_skill_tool_ids: set[str] = set()
+    if old_skill_id:
+        result = await db.execute(
+            select(SkillAllowedTool.tool_id).where(
+                SkillAllowedTool.skill_id == old_skill_id
+            )
+        )
+        old_skill_tool_ids = {row[0] for row in result.all()}
+
+    # Fetch tool IDs for new skill
+    new_skill_tool_ids: set[str] = set()
+    if new_skill_id:
+        result = await db.execute(
+            select(SkillAllowedTool.tool_id).where(
+                SkillAllowedTool.skill_id == new_skill_id
+            )
+        )
+        new_skill_tool_ids = {row[0] for row in result.all()}
+
+    # Get current session active tool IDs
+    current_ids = set(await _get_session_tool_ids(db, session_id))
+
+    # Compute diff
+    to_remove = old_skill_tool_ids - new_skill_tool_ids - always_on_set
+    to_add = new_skill_tool_ids - current_ids
+
+    # Apply changes
+    for tool_id in to_remove:
+        await db.execute(
+            delete(SessionActiveTool).where(
+                SessionActiveTool.session_id == session_id,
+                SessionActiveTool.tool_id == tool_id,
+            )
+        )
+
+    for tool_id in to_add:
+        # Validate tool exists, is enabled, and belongs to tenant
+        result = await db.execute(
+            select(Tool).where(
+                Tool.id == tool_id,
+                Tool.enabled == True,  # noqa: E712
+                Tool.tenant_id == tenant_id,
+            )
+        )
+        tool = result.scalar_one_or_none()
+        if tool is None:
+            continue  # Skip invalid tools silently
+        db.add(SessionActiveTool(session_id=session_id, tool_id=tool_id))
+
+    if to_remove or to_add:
+        await db.commit()
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ph-agent-hub-frontend",
   "private": true,
-  "version": "1.9.1",
+  "version": "1.9.2",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000 --host",

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -1130,6 +1130,7 @@ export function ChatWindow({
         sessionId={sessionId}
         open={toolsOpen}
         onClose={() => setToolsOpen(false)}
+        selectedSkillId={selectedSkillId}
       />
     </div>
   );

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -92,6 +92,17 @@ export function ChatWindow({
   const queryClient = useQueryClient();
   const screens = useBreakpoint();
   const isMobile = !screens.md;
+
+  // Invalidate session tools when the selected skill changes (backend syncs
+  // active tools on skill change, but the sidebar needs to know to refetch).
+  const prevSkillRef = useRef(selectedSkillId);
+  useEffect(() => {
+    if (prevSkillRef.current !== selectedSkillId) {
+      prevSkillRef.current = selectedSkillId;
+      queryClient.invalidateQueries({ queryKey: ["session-tools", sessionId] });
+      queryClient.invalidateQueries({ queryKey: ["skills"] });
+    }
+  }, [selectedSkillId, sessionId, queryClient]);
   const [toolsOpen, setToolsOpen] = useState(false);
   const [memoryOpen, setMemoryOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);

--- a/frontend/src/features/chat/components/SessionToolActivation.tsx
+++ b/frontend/src/features/chat/components/SessionToolActivation.tsx
@@ -57,12 +57,14 @@ interface SessionToolActivationProps {
   sessionId: string;
   open: boolean;
   onClose: () => void;
+  selectedSkillId?: string;
 }
 
 export function SessionToolActivation({
   sessionId,
   open,
   onClose,
+  selectedSkillId,
 }: SessionToolActivationProps) {
   const queryClient = useQueryClient();
 
@@ -89,6 +91,15 @@ export function SessionToolActivation({
 
   const alwaysOnSet = new Set(alwaysOnIds || []);
   const activeIds = new Set((activeTools || []).map((t) => t.id));
+
+  // Fetch the selected skill's tool IDs (for "from skill" badge)
+  const { data: allSkills } = useQuery({
+    queryKey: ["skills"],
+    queryFn: () => api<{ id: string; tool_ids: string[] }[]>("/skills"),
+    enabled: open && !!selectedSkillId,
+  });
+  const selectedSkill = allSkills?.find((s) => s.id === selectedSkillId);
+  const skillToolIds = new Set(selectedSkill?.tool_ids ?? []);
 
   // Group tools by category, excluding hidden categories
   const groupedTools = useMemo(() => {
@@ -192,7 +203,16 @@ export function SessionToolActivation({
                   ]}
                 >
                   <List.Item.Meta
-                    title={tool.name}
+                    title={
+                      <Space size={4}>
+                        {tool.name}
+                        {skillToolIds.has(tool.id) && (
+                          <Text type="secondary" style={{ fontSize: 11, fontStyle: "italic" }}>
+                            from skill
+                          </Text>
+                        )}
+                      </Space>
+                    }
                     description={
                       <Space direction="vertical" size={0}>
                         <Text type="secondary">


### PR DESCRIPTION
The update ensures that the "Session Tools" sidebar reflects the tools associated with the selected skill in the chat window. It invalidates session tools when the skill changes, prompting the sidebar to refresh and display the correct tools.

Fixes #239