### PR TITLE
feat: Implement tenant-gating for free vs paid licensing model

### DIFF
--- a/backend/scripts/generate_license.py
+++ b/backend/scripts/generate_license.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+# =============================================================================
+# PH Agent Hub — License Key Generator (Issue #243)
+# =============================================================================
+# Generates Ed25519-signed license tokens for Pro customers.
+#
+# Usage:
+#   python scripts/generate_license.py --licensee "Acme Corp" --max-tenants -1 --expires 2027-12-31
+#   python scripts/generate_license.py --licensee "Startup Inc" --max-tenants 10 --expires 2026-06-01
+#
+# Requirements:
+#   pip install cryptography
+#
+# The private key must be stored securely (NOT in the repository).
+# By default this script looks for it in the LICENSE_PRIVATE_KEY env var,
+# or you can pass it via --private-key-file.
+# =============================================================================
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+
+def generate_keypair() -> tuple[Ed25519PrivateKey, bytes]:
+    """Generate a new Ed25519 keypair.
+
+    Returns (private_key, public_key_bytes).
+    The public_key_bytes (32 bytes) should be base64-encoded and set as
+    LICENSE_PUBLIC_KEY in the deployment environment.
+    The private key must be stored securely and NEVER committed to the repo.
+    """
+    private_key = Ed25519PrivateKey.generate()
+    public_bytes = private_key.public_key().public_bytes_raw()
+    return private_key, public_bytes
+
+
+def sign_license(
+    private_key: Ed25519PrivateKey,
+    licensee: str,
+    max_tenants: int,
+    expires_at: datetime,
+    issued_at: datetime | None = None,
+) -> str:
+    """Sign a license payload and return the license key string.
+
+    Format: base64url(signature) . base64url(payload_json)
+    """
+    if issued_at is None:
+        issued_at = datetime.now(timezone.utc)
+
+    payload = {
+        "v": 1,
+        "sub": licensee,
+        "max_tenants": max_tenants,  # -1 = unlimited
+        "exp": expires_at.isoformat(),
+        "iat": issued_at.isoformat(),
+    }
+
+    payload_json = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    signature = private_key.sign(payload_json)
+
+    sig_b64 = base64.urlsafe_b64encode(signature).rstrip(b"=").decode("ascii")
+    payload_b64 = base64.urlsafe_b64encode(payload_json).rstrip(b"=").decode("ascii")
+
+    return f"{sig_b64}.{payload_b64}"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate a PH Agent Hub Pro license key",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Generate a license for unlimited tenants, expiring end of 2027
+  python generate_license.py --licensee "Acme Corp" --max-tenants -1 --expires 2027-12-31
+
+  # Generate a keypair (first time setup)
+  python generate_license.py --generate-keypair
+
+  # Use a specific private key file
+  python generate_license.py --private-key-file /secure/license_private.pem \\
+      --licensee "Startup Inc" --max-tenants 10 --expires 2026-06-01
+        """,
+    )
+    parser.add_argument(
+        "--licensee", "-l",
+        help="Name of the licensee (company or individual)",
+    )
+    parser.add_argument(
+        "--max-tenants", "-m",
+        type=int,
+        default=-1,
+        help="Maximum tenants allowed (-1 = unlimited, default: -1)",
+    )
+    parser.add_argument(
+        "--expires", "-e",
+        help="Expiration date (ISO format, e.g. 2027-12-31 or 2027-12-31T00:00:00Z)",
+    )
+    parser.add_argument(
+        "--issued-at",
+        help="Issue date (ISO format, defaults to now)",
+    )
+    parser.add_argument(
+        "--private-key-file", "-k",
+        help="Path to the Ed25519 private key PEM file",
+    )
+    parser.add_argument(
+        "--generate-keypair", "-g",
+        action="store_true",
+        help="Generate a new Ed25519 keypair and print public/private keys",
+    )
+    parser.add_argument(
+        "--output-public-key",
+        help="Also write the public key (base64) to this file (used with --generate-keypair)",
+    )
+
+    args = parser.parse_args()
+
+    # --- Mode 1: Generate keypair ---
+    if args.generate_keypair:
+        private_key, public_bytes = generate_keypair()
+        private_pem = private_key.private_bytes_raw()
+
+        pub_b64 = base64.b64encode(public_bytes).decode("ascii")
+        priv_b64 = base64.b64encode(private_pem).decode("ascii")
+
+        print("=" * 65)
+        print("  NEW ED25519 KEYPAIR")
+        print("=" * 65)
+        print()
+        print("Public key (set as LICENSE_PUBLIC_KEY in your .env):")
+        print(f"  {pub_b64}")
+        print()
+        print("Private key (STORE SECURELY — never commit to git!):")
+        print(f"  {priv_b64}")
+        print()
+        print("=" * 65)
+        print("Add this to your infrastructure/env:")
+        print(f'LICENSE_PUBLIC_KEY={pub_b64}')
+        print("=" * 65)
+
+        if args.output_public_key:
+            with open(args.output_public_key, "w") as f:
+                f.write(pub_b64)
+            print(f"Public key also written to: {args.output_public_key}")
+
+        return
+
+    # --- Mode 2: Generate license ---
+    if not args.licensee:
+        parser.error("--licensee is required when generating a license")
+    if not args.expires:
+        parser.error("--expires is required when generating a license")
+
+    # Parse expiration
+    try:
+        expires_at = datetime.fromisoformat(args.expires)
+    except ValueError:
+        # Try appending time
+        try:
+            expires_at = datetime.fromisoformat(args.expires + "T23:59:59")
+        except ValueError:
+            parser.error(f"Cannot parse date: {args.expires}")
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+
+    # Parse issued-at
+    issued_at = None
+    if args.issued_at:
+        try:
+            issued_at = datetime.fromisoformat(args.issued_at)
+        except ValueError:
+            parser.error(f"Cannot parse date: {args.issued_at}")
+        if issued_at.tzinfo is None:
+            issued_at = issued_at.replace(tzinfo=timezone.utc)
+
+    # Load private key
+    if args.private_key_file:
+        with open(args.private_key_file, "r") as f:
+            key_data = f.read().strip()
+        raw = base64.b64decode(key_data)
+        private_key = Ed25519PrivateKey.from_private_bytes(raw)
+    else:
+        priv_b64 = os.environ.get("LICENSE_PRIVATE_KEY", "")
+        if not priv_b64:
+            print(
+                "ERROR: No private key provided.\n"
+                "  Set the LICENSE_PRIVATE_KEY environment variable, or\n"
+                "  use --private-key-file to specify a file.\n"
+                "  Use --generate-keypair to create a new keypair first.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        raw = base64.b64decode(priv_b64)
+        private_key = Ed25519PrivateKey.from_private_bytes(raw)
+
+    # Sign
+    license_key = sign_license(
+        private_key=private_key,
+        licensee=args.licensee,
+        max_tenants=args.max_tenants,
+        expires_at=expires_at,
+        issued_at=issued_at,
+    )
+
+    print("=" * 65)
+    print("  LICENSE KEY")
+    print("=" * 65)
+    print()
+    print(f"  Licensee:    {args.licensee}")
+    print(f"  Max tenants: {'Unlimited' if args.max_tenants == -1 else args.max_tenants}")
+    print(f"  Expires:     {expires_at.isoformat()}")
+    if issued_at:
+        print(f"  Issued:      {issued_at.isoformat()}")
+    print()
+    print("  License key (copy the entire line below):")
+    print(f"  {license_key}")
+    print()
+    print("=" * 65)
+    print("The customer should paste this key into Admin → Settings → License Key.")
+    print("=" * 65)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/src/api/admin.py
+++ b/backend/src/api/admin.py
@@ -29,6 +29,7 @@ from ..core.pagination import PaginatedResponse
 from ..db.orm.users import User as UserORM
 from ..services.audit_service import list_audit_logs, write_audit_log
 from ..services.tenant_service import (
+    count_tenants,
     create_tenant as _svc_create_tenant,
     delete_tenant as _svc_delete_tenant,
     force_delete_tenant as _svc_force_delete_tenant,
@@ -420,7 +421,21 @@ async def create_tenant(
     db: AsyncSession = Depends(get_db),
     _admin: UserORM = Depends(require_admin),
 ):
-    """Create a new tenant (admin only)."""
+    """Create a new tenant (admin only).
+
+    Gated by licensing (Issue #243): free tier allows up to MAX_FREE_TENANTS
+    (default 3). A valid Pro license key removes this limit.
+    """
+    from ..services.license_service import can_create_tenant
+
+    current_count = await count_tenants(db)
+    allowed, reason = await can_create_tenant(db, current_count)
+    if not allowed:
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail=reason,
+        )
+
     tenant = await _svc_create_tenant(db, body.name)
     await write_audit_log(
         db,
@@ -2132,8 +2147,16 @@ async def get_settings(
     db: AsyncSession = Depends(get_db),
     _admin: UserORM = Depends(require_admin),
 ):
-    """Get all application settings (admin only)."""
+    """Get all application settings (admin only).
+
+    The response includes a 'license_status' key (VALID, INVALID, EXPIRED,
+    or NOT_SET) that reflects the current state of the stored license key.
+    """
+    from ..services.license_service import get_license_status
+
     settings = await get_all_settings(db)
+    license_status, _ = await get_license_status(db)
+    settings["license_status"] = license_status.value
     return SettingsResponse(settings=settings)
 
 
@@ -2143,6 +2166,116 @@ async def update_settings(
     db: AsyncSession = Depends(get_db),
     _admin: UserORM = Depends(require_admin),
 ):
-    """Bulk update application settings (admin only)."""
+    """Bulk update application settings (admin only).
+
+    If a 'license_key' is provided, it is validated before saving.
+    Invalid or expired license keys are rejected with a clear error.
+    """
+    from ..services.license_service import verify_license_key, _is_expired
+
+    license_key = body.get("license_key")
+    if license_key is not None and license_key.strip():
+        info = verify_license_key(license_key)
+        if info is None:
+            if _is_expired(license_key):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="License key has expired. Please obtain a new license.",
+                )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "Invalid license key. The key could not be verified. "
+                    "Please check that you entered it correctly."
+                ),
+            )
+
     settings = await set_settings(db, body)
     return SettingsResponse(settings=settings)
+
+
+# =============================================================================
+# License & Tenant Status Endpoints (Issue #243)
+# =============================================================================
+
+
+class LicenseStatusResponse(BaseModel):
+    status: str  # valid | invalid | expired | not_set
+    licensee: str | None = None
+    max_tenants: int | None = None
+    expires_at: str | None = None
+    tenant_count: int = 0
+    tenant_limit: int = 3
+
+
+class TenantStatusResponse(BaseModel):
+    total_tenants: int
+    effective_limit: int
+    license_status: str
+    can_create: bool
+    message: str | None = None
+
+
+@router.get("/license/status", response_model=LicenseStatusResponse)
+async def get_license_status_endpoint(
+    db: AsyncSession = Depends(get_db),
+    _admin: UserORM = Depends(require_admin),
+):
+    """Get detailed license status (admin only).
+
+    Returns the current license state, tenant count, and effective limit.
+    Used by the frontend for real-time license validation feedback.
+    """
+    from ..services.license_service import (
+        get_license_status,
+        get_effective_tenant_limit,
+    )
+
+    status, info = await get_license_status(db)
+    limit = await get_effective_tenant_limit(db)
+    from ..services.tenant_service import count_tenants
+    total = await count_tenants(db)
+
+    # Format limit for display: -1 / large sentinel → "Unlimited"
+    display_limit = limit
+    if limit >= 1_000_000:
+        display_limit = -1  # signal unlimited to frontend
+
+    return LicenseStatusResponse(
+        status=status.value,
+        licensee=info.licensee if info else None,
+        max_tenants=info.max_tenants if info else None,
+        expires_at=info.expires_at.isoformat() if info else None,
+        tenant_count=total,
+        tenant_limit=display_limit,
+    )
+
+
+@router.get("/tenant-status", response_model=TenantStatusResponse)
+async def get_tenant_status(
+    db: AsyncSession = Depends(get_db),
+    _admin: UserORM = Depends(require_admin),
+):
+    """Get tenant capacity status for UI banners (admin only).
+
+    Returns whether new tenants can be created and an appropriate message.
+    """
+    from ..services.license_service import (
+        can_create_tenant,
+        get_license_status,
+        get_effective_tenant_limit,
+    )
+    from ..services.tenant_service import count_tenants
+
+    total = await count_tenants(db)
+    limit = await get_effective_tenant_limit(db)
+    status, _ = await get_license_status(db)
+    allowed, message = await can_create_tenant(db, total)
+
+    return TenantStatusResponse(
+        total_tenants=total,
+        effective_limit=limit if limit < 1_000_000 else -1,
+        license_status=status.value,
+        can_create=allowed,
+        message=message if not allowed else None,
+    )

--- a/backend/src/api/auth.py
+++ b/backend/src/api/auth.py
@@ -20,6 +20,8 @@ from ..core.limiter import limiter
 from ..core.redis import add_to_denylist, is_denylisted
 from ..core.security import verify_password
 from ..db.orm.users import User
+from ..services.license_service import is_tenant_accessible
+from ..services.tenant_service import count_tenants, get_tenant_ordinal
 from ..services.user_service import get_user_by_email, get_user_by_id
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -65,6 +67,22 @@ async def login(
         raise UnauthorizedError("Invalid email or password")
     if not user.is_active:
         raise UnauthorizedError("User account is inactive")
+
+    # --- License gating (Issue #243) ---
+    # Check that this tenant is within the effective limit.
+    # Admin users always bypass (they need access to manage licenses).
+    if user.role != "admin":
+        tenant_ordinal = await get_tenant_ordinal(db, user.tenant_id)
+        if tenant_ordinal is not None:
+            accessible = await is_tenant_accessible(db, tenant_ordinal)
+            if not accessible:
+                total = await count_tenants(db)
+                raise UnauthorizedError(
+                    "License expired or tenant limit reached. "
+                    f"This instance has {total} tenants but only "
+                    "the first 3 are accessible on the free tier. "
+                    "Contact your administrator to upgrade to Pro."
+                )
 
     jti = str(uuid.uuid4())
 

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -64,6 +64,10 @@ class Settings(BaseSettings):
     # --- Logging ---
     LOG_LEVEL: str = "INFO"
 
+    # --- Licensing (Issue #243) ---
+    MAX_FREE_TENANTS: int = 3
+    LICENSE_PUBLIC_KEY: str = ""
+
     model_config = {"env_file": ".env", "extra": "ignore"}
 
     def __init__(self, **kwargs):

--- a/backend/src/services/license_service.py
+++ b/backend/src/services/license_service.py
@@ -1,0 +1,309 @@
+# =============================================================================
+# PH Agent Hub — License Service (Issue #243)
+# =============================================================================
+# Ed25519 public-key license verification.
+# The private key is held by the vendor; the public key is embedded here.
+# License tokens are base64-encoded JSON payloads signed with Ed25519.
+#
+# Payload format:
+#   {
+#     "v": 1,
+#     "sub": "licensee-name",
+#     "max_tenants": -1,        # -1 = unlimited
+#     "exp": "2027-06-01T00:00:00Z",
+#     "iat": "2026-06-01T00:00:00Z"
+#   }
+# =============================================================================
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core.config import settings
+from .settings_service import get_setting
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+LICENSE_SETTING_KEY = "license_key"
+UNLIMITED_TENANTS = -1
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+class LicenseStatus(str, Enum):
+    VALID = "valid"
+    INVALID = "invalid"
+    EXPIRED = "expired"
+    NOT_SET = "not_set"
+
+
+@dataclass
+class LicenseInfo:
+    """Parsed and verified license information."""
+
+    licensee: str
+    max_tenants: int  # -1 = unlimited
+    expires_at: datetime
+    issued_at: datetime
+    raw_token: str = field(repr=False)
+
+
+# ---------------------------------------------------------------------------
+# Public-key loading
+# ---------------------------------------------------------------------------
+
+
+def _load_public_key() -> Ed25519PublicKey | None:
+    """Load the Ed25519 public key from config.
+
+    Returns None if no public key is configured (graceful degradation —
+    license verification always fails, gating falls back to free tier).
+    """
+    key_pem = settings.LICENSE_PUBLIC_KEY.strip()
+    if not key_pem:
+        logger.warning(
+            "LICENSE_PUBLIC_KEY is not configured — license verification disabled"
+        )
+        return None
+
+    try:
+        # Support both raw base64 and PEM-wrapped keys
+        if "-----BEGIN PUBLIC KEY-----" in key_pem:
+            return serialization.load_pem_public_key(key_pem.encode("utf-8"))
+        else:
+            raw = base64.b64decode(key_pem)
+            return Ed25519PublicKey.from_public_bytes(raw)
+    except Exception:
+        logger.exception("Failed to load LICENSE_PUBLIC_KEY")
+        return None
+
+
+# Cache the public key at module load time
+_PUBLIC_KEY: Ed25519PublicKey | None = None
+
+
+def _get_public_key() -> Ed25519PublicKey | None:
+    """Lazy-load and cache the public key."""
+    global _PUBLIC_KEY
+    if _PUBLIC_KEY is None and settings.LICENSE_PUBLIC_KEY:
+        _PUBLIC_KEY = _load_public_key()
+    return _PUBLIC_KEY
+
+
+# ---------------------------------------------------------------------------
+# Core verification
+# ---------------------------------------------------------------------------
+
+
+def verify_license_key(raw_key: str) -> LicenseInfo | None:
+    """Verify a license key string and return parsed LicenseInfo, or None.
+
+    The key format is:  base64(signature) . base64(payload_json)
+
+    Returns None if:
+    - The key is malformed
+    - The signature is invalid
+    - The license has expired
+    - The public key is not configured
+    """
+    public_key = _get_public_key()
+    if public_key is None:
+        logger.warning("Cannot verify license — no public key configured")
+        return None
+
+    raw_key = raw_key.strip()
+
+    # Split signature and payload
+    parts = raw_key.split(".", 1)
+    if len(parts) != 2:
+        logger.warning("License key is malformed (missing dot separator)")
+        return None
+
+    sig_b64, payload_b64 = parts
+
+    try:
+        signature = base64.urlsafe_b64decode(sig_b64 + "==")
+        payload_json = base64.urlsafe_b64decode(payload_b64 + "==")
+    except Exception:
+        logger.warning("License key contains invalid base64")
+        return None
+
+    # Verify Ed25519 signature
+    try:
+        public_key.verify(signature, payload_json)
+    except InvalidSignature:
+        logger.warning("License key signature verification failed")
+        return None
+    except Exception:
+        logger.exception("Unexpected error during signature verification")
+        return None
+
+    # Parse payload
+    try:
+        payload = json.loads(payload_json)
+    except json.JSONDecodeError:
+        logger.warning("License key payload is not valid JSON")
+        return None
+
+    # Validate payload fields
+    version = payload.get("v")
+    if version != 1:
+        logger.warning("License key has unsupported version: %s", version)
+        return None
+
+    licensee = payload.get("sub")
+    max_tenants = payload.get("max_tenants")
+    exp_str = payload.get("exp")
+    iat_str = payload.get("iat")
+
+    if not licensee or max_tenants is None or not exp_str or not iat_str:
+        logger.warning("License key payload is missing required fields")
+        return None
+
+    try:
+        expires_at = datetime.fromisoformat(exp_str)
+        issued_at = datetime.fromisoformat(iat_str)
+    except ValueError:
+        logger.warning("License key has invalid date format")
+        return None
+
+    # Ensure timezone-aware comparison
+    now = datetime.now(timezone.utc)
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+
+    if now > expires_at:
+        logger.info(
+            "License for '%s' expired on %s", licensee, expires_at.isoformat()
+        )
+        return None
+
+    return LicenseInfo(
+        licensee=licensee,
+        max_tenants=int(max_tenants),
+        expires_at=expires_at,
+        issued_at=issued_at,
+        raw_token=raw_key,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Service functions (require DB)
+# ---------------------------------------------------------------------------
+
+
+async def get_license_status(db: AsyncSession) -> tuple[LicenseStatus, LicenseInfo | None]:
+    """Read the stored license key and determine its status.
+
+    Returns (status, info) where status is one of:
+    - NOT_SET: no license key stored
+    - VALID: license is present and valid
+    - EXPIRED: license was valid but has expired
+    - INVALID: license key is present but signature or format is invalid
+    """
+    raw_key = await get_setting(db, LICENSE_SETTING_KEY)
+
+    if not raw_key or not raw_key.strip():
+        return LicenseStatus.NOT_SET, None
+
+    info = verify_license_key(raw_key)
+
+    if info is None:
+        # Could be invalid signature, malformed, or expired.
+        # We distinguish expired by attempting a lenient parse.
+        if _is_expired(raw_key):
+            return LicenseStatus.EXPIRED, None
+        return LicenseStatus.INVALID, None
+
+    return LicenseStatus.VALID, info
+
+
+async def get_effective_tenant_limit(db: AsyncSession) -> int:
+    """Return the maximum number of tenants allowed.
+
+    If a valid license is present with max_tenants = -1, returns a very
+    large sentinel (1_000_000) to represent unlimited.
+    Otherwise, returns MAX_FREE_TENANTS (default: 3).
+    """
+    status, info = await get_license_status(db)
+
+    if status == LicenseStatus.VALID and info is not None:
+        if info.max_tenants == UNLIMITED_TENANTS:
+            return 1_000_000  # effectively unlimited
+        return info.max_tenants
+
+    return settings.MAX_FREE_TENANTS
+
+
+async def is_tenant_accessible(
+    db: AsyncSession, tenant_ordinal: int
+) -> bool:
+    """Check whether a tenant at the given ordinal position (1-indexed) is
+    within the current effective limit."""
+    limit = await get_effective_tenant_limit(db)
+    return tenant_ordinal <= limit
+
+
+async def can_create_tenant(db: AsyncSession, current_count: int) -> tuple[bool, str]:
+    """Check if a new tenant can be created.
+
+    Returns (allowed, message) where message is the reason when blocked.
+    """
+    limit = await get_effective_tenant_limit(db)
+
+    if current_count >= limit:
+        status, _ = await get_license_status(db)
+        if status == LicenseStatus.VALID:
+            return False, (
+                f"Tenant limit reached ({limit}). "
+                "Contact support to increase your license limit."
+            )
+        else:
+            return False, (
+                f"Free tier is limited to {settings.MAX_FREE_TENANTS} tenants. "
+                "Upgrade to Pro for unlimited tenants."
+            )
+
+    return True, ""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_expired(raw_key: str) -> bool:
+    """Lenient check — try to decode payload without verifying signature,
+    to determine if an otherwise-valid token has simply expired."""
+    try:
+        parts = raw_key.strip().split(".", 1)
+        if len(parts) != 2:
+            return False
+        payload_json = base64.urlsafe_b64decode(parts[1] + "==")
+        payload = json.loads(payload_json)
+        exp_str = payload.get("exp")
+        if not exp_str:
+            return False
+        expires_at = datetime.fromisoformat(exp_str)
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        return datetime.now(timezone.utc) > expires_at
+    except Exception:
+        return False

--- a/backend/src/services/license_service.py
+++ b/backend/src/services/license_service.py
@@ -129,6 +129,9 @@ def verify_license_key(raw_key: str) -> LicenseInfo | None:
         return None
 
     raw_key = raw_key.strip()
+    # Strip all internal whitespace/newlines in case the key was copied from
+    # a multi-line terminal output (Issue #243 — Issue #243).
+    raw_key = "".join(raw_key.split())
 
     # Split signature and payload
     parts = raw_key.split(".", 1)

--- a/backend/src/services/tenant_service.py
+++ b/backend/src/services/tenant_service.py
@@ -41,6 +41,25 @@ async def get_tenant_by_id(db: AsyncSession, tenant_id: str) -> Tenant | None:
     return result.scalar_one_or_none()
 
 
+async def count_tenants(db: AsyncSession) -> int:
+    """Return the total number of tenants in the system."""
+    result = await db.execute(select(func.count()).select_from(Tenant))
+    return result.scalar() or 0
+
+
+async def get_tenant_ordinal(db: AsyncSession, tenant_id: str) -> int | None:
+    """Return the 1-based ordinal position of a tenant ordered by creation date.
+    Returns None if the tenant is not found."""
+    result = await db.execute(
+        select(Tenant).order_by(Tenant.created_at.asc())
+    )
+    tenants = result.scalars().all()
+    for idx, t in enumerate(tenants, start=1):
+        if t.id == tenant_id:
+            return idx
+    return None
+
+
 async def create_tenant(db: AsyncSession, name: str) -> Tenant:
     """Create a new tenant. Raises ConflictError if the name already exists."""
     existing = await db.execute(select(Tenant).where(Tenant.name == name))

--- a/frontend/src/features/admin/pages/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin/pages/settings/SettingsPage.tsx
@@ -1,16 +1,46 @@
 // =============================================================================
 // PH Agent Hub — Admin SettingsPage
 // =============================================================================
-// Admin only; manages application-wide settings (starting with currency).
+// Admin only; manages application-wide settings (currency, license key).
+// Includes real-time license validation feedback (Issue #243).
 // =============================================================================
 
-import { Card, Typography, Form, Select, Button, message, Spin } from "antd";
-import { SettingOutlined } from "@ant-design/icons";
+import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  Card,
+  Typography,
+  Form,
+  Select,
+  Input,
+  Button,
+  message,
+  Spin,
+  Tag,
+  Space,
+  Alert,
+  Descriptions,
+} from "antd";
+import {
+  SettingOutlined,
+  KeyOutlined,
+  CheckCircleOutlined,
+  CloseCircleOutlined,
+  WarningOutlined,
+  InfoCircleOutlined,
+  EyeInvisibleOutlined,
+  EyeOutlined,
+} from "@ant-design/icons";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getSettings, updateSettings } from "../../services/admin";
+import {
+  getSettings,
+  updateSettings,
+  getLicenseStatus,
+  getTenantStatus,
+} from "../../services/admin";
+import type { LicenseStatusData, TenantStatusData } from "../../services/admin";
 import { setCurrency } from "../../../../shared/utils/formatCurrency";
 
-const { Title } = Typography;
+const { Title, Text } = Typography;
 
 const CURRENCY_OPTIONS = [
   { value: "EUR", label: "€  EUR" },
@@ -20,15 +50,79 @@ const CURRENCY_OPTIONS = [
   { value: "CNY", label: "¥  CNY" },
 ];
 
+// ---------------------------------------------------------------------------
+// License status badge
+// ---------------------------------------------------------------------------
+
+function LicenseStatusBadge({ status }: { status: string }) {
+  switch (status) {
+    case "valid":
+      return (
+        <Tag icon={<CheckCircleOutlined />} color="success">
+          Valid — Pro License
+        </Tag>
+      );
+    case "expired":
+      return (
+        <Tag icon={<WarningOutlined />} color="warning">
+          License Expired
+        </Tag>
+      );
+    case "invalid":
+      return (
+        <Tag icon={<CloseCircleOutlined />} color="error">
+          Invalid License
+        </Tag>
+      );
+    default:
+      return (
+        <Tag icon={<InfoCircleOutlined />} color="default">
+          No License — Free Tier
+        </Tag>
+      );
+  }
+}
+
+function formatTenantLimit(limit: number): string {
+  return limit === -1 || limit >= 1_000_000 ? "Unlimited" : String(limit);
+}
+
+// ---------------------------------------------------------------------------
+// SettingsPage
+// ---------------------------------------------------------------------------
+
 export function SettingsPage() {
   const [form] = Form.useForm();
   const queryClient = useQueryClient();
+  const [licenseInput, setLicenseInput] = useState("");
+  const [showKey, setShowKey] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const { data: settingsData, isLoading } = useQuery({
+  // Fetch settings
+  const { data: settingsData, isLoading: settingsLoading } = useQuery({
     queryKey: ["admin-settings"],
     queryFn: getSettings,
   });
 
+  // Fetch license status
+  const {
+    data: licenseData,
+    isLoading: licenseLoading,
+    refetch: refetchLicense,
+  } = useQuery<LicenseStatusData>({
+    queryKey: ["admin-license-status"],
+    queryFn: getLicenseStatus,
+    refetchOnWindowFocus: false,
+  });
+
+  // Fetch tenant status
+  const { data: tenantData, isLoading: tenantLoading } = useQuery<TenantStatusData>({
+    queryKey: ["admin-tenant-status"],
+    queryFn: getTenantStatus,
+    refetchOnWindowFocus: false,
+  });
+
+  // Save settings mutation
   const mutation = useMutation({
     mutationFn: updateSettings,
     onSuccess: (data) => {
@@ -37,13 +131,44 @@ export function SettingsPage() {
       }
       message.success("Settings saved");
       queryClient.invalidateQueries({ queryKey: ["admin-settings"] });
+      queryClient.invalidateQueries({ queryKey: ["admin-license-status"] });
+      queryClient.invalidateQueries({ queryKey: ["admin-tenant-status"] });
     },
-    onError: () => {
-      message.error("Failed to save settings");
+    onError: (err: Error) => {
+      message.error(err.message || "Failed to save settings");
     },
   });
 
-  if (isLoading) {
+  // Debounced license validation on input change
+  const debouncedValidate = useCallback(
+    (value: string) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        refetchLicense();
+      }, 800);
+    },
+    [refetchLicense],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  // Set initial form values when data loads
+  useEffect(() => {
+    if (settingsData?.settings) {
+      const storedLicense = settingsData.settings.license_key || "";
+      form.setFieldsValue({
+        currency: settingsData.settings.currency || "EUR",
+        license_key: storedLicense,
+      });
+      setLicenseInput(storedLicense);
+    }
+  }, [settingsData, form]);
+
+  if (settingsLoading || licenseLoading || tenantLoading) {
     return (
       <div style={{ textAlign: "center", padding: 48 }}>
         <Spin />
@@ -51,44 +176,168 @@ export function SettingsPage() {
     );
   }
 
-  const currentCurrency = settingsData?.settings?.currency || "EUR";
-  // Keep the formatCurrency utility in sync on first load
-  setCurrency(currentCurrency);
-
   const handleSave = (values: Record<string, string>) => {
-    mutation.mutate(values);
+    // Only include license_key if it was changed
+    const payload: Record<string, string> = { currency: values.currency };
+    if (values.license_key !== undefined) {
+      payload.license_key = values.license_key || "";
+    }
+    mutation.mutate(payload);
   };
+
+  const handleLicenseChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setLicenseInput(value);
+    form.setFieldsValue({ license_key: value });
+    debouncedValidate(value);
+  };
+
+  const licenseStatus = licenseData?.status || "not_set";
+  const tenantCount = tenantData?.total_tenants ?? 0;
+  const tenantLimit = tenantData?.effective_limit ?? 3;
 
   return (
     <div>
       <Title level={4}>
         <SettingOutlined /> Settings
       </Title>
-      <Card style={{ maxWidth: 500 }}>
-        <Form
-          form={form}
-          layout="vertical"
-          initialValues={{ currency: currentCurrency }}
-          onFinish={handleSave}
-        >
-          <Form.Item
-            name="currency"
-            label="Currency"
-            tooltip="Used to format cost values across the app"
+
+      <Space direction="vertical" size="large" style={{ width: "100%", maxWidth: 600 }}>
+        {/* Tenant capacity banner */}
+        {tenantData && !tenantData.can_create && (
+          <Alert
+            type={licenseStatus === "valid" ? "warning" : "info"}
+            showIcon
+            message={
+              licenseStatus === "valid"
+                ? "Tenant limit reached"
+                : "Free tier limit reached"
+            }
+            description={tenantData.message || ""}
+            action={
+              licenseStatus !== "valid" ? (
+                <Button size="small" type="primary" href="#license">
+                  <KeyOutlined /> Enter License Key
+                </Button>
+              ) : undefined
+            }
+          />
+        )}
+
+        {/* License status summary */}
+        {licenseStatus !== "not_set" && (
+          <Card size="small" id="license">
+            <Space direction="vertical" style={{ width: "100%" }}>
+              <Space>
+                <LicenseStatusBadge status={licenseStatus} />
+                <Text type="secondary">
+                  {tenantCount} of {formatTenantLimit(tenantLimit)} tenants used
+                </Text>
+              </Space>
+              {licenseData?.licensee && licenseStatus === "valid" && (
+                <Descriptions size="small" column={2}>
+                  <Descriptions.Item label="Licensed to">
+                    {licenseData.licensee}
+                  </Descriptions.Item>
+                  {licenseData.expires_at && (
+                    <Descriptions.Item label="Expires">
+                      {new Date(licenseData.expires_at).toLocaleDateString()}
+                    </Descriptions.Item>
+                  )}
+                  {licenseData.max_tenants !== null && (
+                    <Descriptions.Item label="Max tenants">
+                      {formatTenantLimit(licenseData.max_tenants)}
+                    </Descriptions.Item>
+                  )}
+                </Descriptions>
+              )}
+            </Space>
+          </Card>
+        )}
+
+        {/* Settings form */}
+        <Card>
+          <Form
+            form={form}
+            layout="vertical"
+            onFinish={handleSave}
           >
-            <Select options={CURRENCY_OPTIONS} />
-          </Form.Item>
-          <Form.Item>
-            <Button
-              type="primary"
-              htmlType="submit"
-              loading={mutation.isPending}
+            {/* Currency */}
+            <Form.Item
+              name="currency"
+              label="Currency"
+              tooltip="Used to format cost values across the app"
             >
-              Save
-            </Button>
-          </Form.Item>
-        </Form>
-      </Card>
+              <Select options={CURRENCY_OPTIONS} />
+            </Form.Item>
+
+            {/* License Key */}
+            <Form.Item
+              name="license_key"
+              label={
+                <Space>
+                  <KeyOutlined />
+                  <span>License Key</span>
+                  <LicenseStatusBadge status={licenseStatus} />
+                </Space>
+              }
+              tooltip="Enter a Pro license key to unlock unlimited tenants and priority support"
+            >
+              <Input
+                placeholder="Paste your license key here"
+                value={licenseInput}
+                onChange={handleLicenseChange}
+                suffix={
+                  <Button
+                    type="text"
+                    size="small"
+                    icon={showKey ? <EyeOutlined /> : <EyeInvisibleOutlined />}
+                    onClick={() => setShowKey(!showKey)}
+                    tabIndex={-1}
+                  />
+                }
+                type={showKey ? "text" : "password"}
+              />
+            </Form.Item>
+
+            {/* Help text based on status */}
+            {licenseStatus === "not_set" && (
+              <Alert
+                type="info"
+                message="Free Tier"
+                description={`You can create up to ${tenantLimit} tenants for free. Upgrade to Pro for unlimited tenants.`}
+                style={{ marginBottom: 16 }}
+              />
+            )}
+            {licenseStatus === "invalid" && (
+              <Alert
+                type="error"
+                message="Invalid License"
+                description="The license key could not be verified. Please check that you copied the entire key correctly."
+                style={{ marginBottom: 16 }}
+              />
+            )}
+            {licenseStatus === "expired" && (
+              <Alert
+                type="warning"
+                message="License Expired"
+                description="Your Pro license has expired. Tenants beyond the free tier limit are no longer accessible. Renew your license to restore access."
+                style={{ marginBottom: 16 }}
+              />
+            )}
+
+            <Form.Item>
+              <Button
+                type="primary"
+                htmlType="submit"
+                loading={mutation.isPending}
+              >
+                Save Settings
+              </Button>
+            </Form.Item>
+          </Form>
+        </Card>
+      </Space>
     </div>
   );
 }

--- a/frontend/src/features/admin/pages/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin/pages/settings/SettingsPage.tsx
@@ -241,7 +241,15 @@ export function SettingsPage() {
                   </Descriptions.Item>
                   {licenseData.expires_at && (
                     <Descriptions.Item label="Expires">
-                      {new Date(licenseData.expires_at).toLocaleDateString()}
+                      {(() => {
+                        const d = new Date(licenseData.expires_at);
+                        const day = d.getDate().toString().padStart(2, "0");
+                        const months = [
+                          "Jan","Feb","Mar","Apr","May","Jun",
+                          "Jul","Aug","Sep","Oct","Nov","Dec",
+                        ];
+                        return `${day}-${months[d.getMonth()]}-${d.getFullYear()}`;
+                      })()}
                     </Descriptions.Item>
                   )}
                   {licenseData.max_tenants !== null && (

--- a/frontend/src/features/admin/resources/tenants/TenantForm.tsx
+++ b/frontend/src/features/admin/resources/tenants/TenantForm.tsx
@@ -34,6 +34,7 @@ export function TenantForm({ open, tenant, onClose }: TenantFormProps) {
     mutationFn: (data: { name: string }) => createTenant(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["admin-tenants"] });
+      queryClient.invalidateQueries({ queryKey: ["admin-tenant-status"] });
       message.success("Tenant created");
       onClose();
     },
@@ -47,6 +48,7 @@ export function TenantForm({ open, tenant, onClose }: TenantFormProps) {
       updateTenant(id, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["admin-tenants"] });
+      queryClient.invalidateQueries({ queryKey: ["admin-tenant-status"] });
       message.success("Tenant updated");
       onClose();
     },

--- a/frontend/src/features/admin/resources/tenants/TenantList.tsx
+++ b/frontend/src/features/admin/resources/tenants/TenantList.tsx
@@ -17,14 +17,24 @@ import {
   Card,
   Typography,
   Input,
+  Alert,
+  Tooltip,
 } from "antd";
-import { EditOutlined, DeleteOutlined, SearchOutlined } from "@ant-design/icons";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  EditOutlined,
+  DeleteOutlined,
+  SearchOutlined,
+  WarningOutlined,
+  KeyOutlined,
+} from "@ant-design/icons";
+import { useMutation, useQueryClient, useQuery } from "@tanstack/react-query";
 import {
   listTenants,
   deleteTenant,
+  getTenantStatus,
   TenantData,
 } from "../../services/admin";
+import type { TenantStatusData } from "../../services/admin";
 import { useAdminTable } from "../../hooks/useAdminTable";
 import { useDebounce } from "../../hooks/useDebounce";
 import { TenantForm } from "./TenantForm";
@@ -42,6 +52,13 @@ export function TenantList() {
   const isMobile = !screens.md;
   const queryClient = useQueryClient();
 
+  // Tenant capacity status (Issue #243)
+  const { data: tenantStatus, isLoading: statusLoading } = useQuery<TenantStatusData>({
+    queryKey: ["admin-tenant-status"],
+    queryFn: getTenantStatus,
+    refetchOnWindowFocus: false,
+  });
+
   const debouncedSearch = useDebounce(searchText, 300);
 
   const { data, isLoading, updateParams, handleTableChange, setSearch } = useAdminTable(
@@ -57,6 +74,7 @@ export function TenantList() {
     mutationFn: (id: string) => deleteTenant(id, { force: forceDelete }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["admin-tenants"] });
+      queryClient.invalidateQueries({ queryKey: ["admin-tenant-status"] });
       message.success("Tenant deleted");
       setForceDelete(false);
     },
@@ -108,13 +126,66 @@ export function TenantList() {
 
   const tenantsData = data?.items || [];
   const totalTenants = data?.total || 0;
+  const atLimit = tenantStatus && !tenantStatus.can_create;
+  const nearLimit = !atLimit && tenantStatus && tenantStatus.license_status !== "valid"
+    && tenantStatus.total_tenants >= tenantStatus.effective_limit - 1;
 
   return (
     <div>
+      {/* Tenant capacity banner (Issue #243) */}
+      {!statusLoading && tenantStatus && (
+        <div style={{ marginBottom: 16 }}>
+          {atLimit ? (
+            <Alert
+              type={tenantStatus.license_status === "valid" ? "warning" : "info"}
+              icon={<WarningOutlined />}
+              message={
+                tenantStatus.license_status === "valid"
+                  ? "Tenant limit reached"
+                  : "Free tier limit reached"
+              }
+              description={
+                <span>
+                  {tenantStatus.message || ""}
+                  {tenantStatus.license_status !== "valid" && (
+                    <>
+                      {" "}
+                      — <a href="/admin/settings"><KeyOutlined /> Upgrade to Pro</a>
+                    </>
+                  )}
+                </span>
+              }
+              showIcon
+              style={{ marginBottom: 12 }}
+            />
+          ) : nearLimit && (
+            <Alert
+              type="info"
+              message={`${tenantStatus.total_tenants} of ${tenantStatus.effective_limit} tenants used`}
+              description={
+                <span>
+                  You are approaching the free tier limit.{" "}
+                  <a href="/admin/settings"><KeyOutlined /> Upgrade to Pro</a> for unlimited tenants.
+                </span>
+              }
+              showIcon
+              closable
+              style={{ marginBottom: 12 }}
+            />
+          )}
+        </div>
+      )}
+
       <Space style={{ marginBottom: 16 }} wrap>
-        <Button type="primary" onClick={() => setCreating(true)}>
-          Create Tenant
-        </Button>
+        <Tooltip title={atLimit ? (tenantStatus?.message || "Tenant limit reached") : undefined}>
+          <Button
+            type="primary"
+            onClick={() => setCreating(true)}
+            disabled={atLimit}
+          >
+            Create Tenant
+          </Button>
+        </Tooltip>
         <Checkbox
           checked={forceDelete}
           onChange={(e) => setForceDelete(e.target.checked)}

--- a/frontend/src/features/admin/services/admin.ts
+++ b/frontend/src/features/admin/services/admin.ts
@@ -164,6 +164,23 @@ export interface SettingsData {
   settings: Record<string, string>;
 }
 
+export interface LicenseStatusData {
+  status: 'valid' | 'invalid' | 'expired' | 'not_set';
+  licensee: string | null;
+  max_tenants: number | null;
+  expires_at: string | null;
+  tenant_count: number;
+  tenant_limit: number;  // -1 = unlimited
+}
+
+export interface TenantStatusData {
+  total_tenants: number;
+  effective_limit: number;  // -1 = unlimited
+  license_status: string;
+  can_create: boolean;
+  message: string | null;
+}
+
 export interface AuditData {
   id: string;
   tenant_id: string | null;
@@ -425,6 +442,14 @@ export function getSettings(): Promise<SettingsData> {
 
 export function updateSettings(settings: Record<string, string>): Promise<SettingsData> {
   return api<SettingsData>("/admin/settings", { method: "PUT", body: settings });
+}
+
+export function getLicenseStatus(): Promise<LicenseStatusData> {
+  return api<LicenseStatusData>("/admin/license/status");
+}
+
+export function getTenantStatus(): Promise<TenantStatusData> {
+  return api<TenantStatusData>("/admin/tenant-status");
 }
 
 export function listAuditLogs(

--- a/infrastructure/env.example
+++ b/infrastructure/env.example
@@ -44,6 +44,12 @@ SEED_ALLOW_WEAK_PASSWORD=true
 # Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 ENCRYPTION_KEY=
 
+# Max tenants allowed on the free tier (default: 3)
+MAX_FREE_TENANTS=3
+# Ed25519 public key for license verification (base64-encoded, 32 bytes)
+# Leave empty to disable license verification (free tier only)
+LICENSE_PUBLIC_KEY=
+
 # --- Frontend ---
 VITE_API_URL=/api
 


### PR DESCRIPTION
Introduce a licensing system that allows up to 3 tenants for free instances of PH Agent Hub. Implement backend checks to enforce tenant limits, add a license key input in the Admin UI, and provide user feedback when attempting to exceed the tenant limit. Ensure existing tenants remain unaffected and store the license key in the configuration.

Fixes #243