### PR TITLE
Ollama / Local Model Support

### DIFF
--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -1,5 +1,6 @@
 """PH Agent Hub — MAF model provider client factory."""
 
 from .base import get_chat_client
+from .ollama import build_ollama_client
 
-__all__ = ["get_chat_client"]
+__all__ = ["get_chat_client", "build_ollama_client"]

--- a/backend/src/models/base.py
+++ b/backend/src/models/base.py
@@ -10,6 +10,7 @@ from agent_framework import BaseChatClient
 from ..db.orm.models import Model
 from .anthropic import build_anthropic_client
 from .deepseek import build_deepseek_client
+from .ollama import build_ollama_client
 from .openai import build_openai_client
 
 
@@ -24,6 +25,7 @@ def get_chat_client(
       - "openai"    → OpenAIChatClient
       - "deepseek"  → DeepSeekThinkingClient with custom base_url
       - "anthropic" → AnthropicChatClient
+      - "ollama"    → OpenAIChatClient (OpenAI-compatible local API)
 
     Raises NotImplementedError for unsupported providers.
     """
@@ -39,6 +41,8 @@ def get_chat_client(
         )
     elif provider == "anthropic":
         return build_anthropic_client(model)
+    elif provider == "ollama":
+        return build_ollama_client(model)
     else:
         raise NotImplementedError(
             f"Provider '{model.provider}' is not supported"

--- a/backend/src/models/ollama.py
+++ b/backend/src/models/ollama.py
@@ -1,0 +1,37 @@
+# =============================================================================
+# PH Agent Hub — Ollama Provider Client
+# =============================================================================
+# Ollama exposes an OpenAI-compatible chat API at /v1/chat/completions,
+# so we reuse OpenAIChatClient from agent_framework.
+# No API key is required — a dummy "ollama" placeholder is used.
+# =============================================================================
+
+from agent_framework.openai import OpenAIChatClient
+
+from ..db.orm.models import Model
+
+
+def build_ollama_client(model: Model) -> OpenAIChatClient:
+    """Build an OpenAI-compatible chat client for an Ollama-hosted model.
+
+    The model.api_key is already decrypted by the EncryptedString ORM type.
+    For Ollama, the key is a dummy placeholder ("ollama") since the local
+    server does not require authentication.
+
+    The admin must set model.base_url to point at their Ollama instance,
+    e.g. ``http://localhost:11434/v1``.
+    """
+    import openai
+
+    openai_client_args: dict = {
+        "api_key": model.api_key or "ollama",
+        "max_retries": 0,  # Local — no need to retry on transient network errors
+        "timeout": 900.0,
+    }
+    if model.base_url:
+        openai_client_args["base_url"] = model.base_url
+
+    return OpenAIChatClient(
+        model=model.model_id or model.name,
+        async_client=openai.AsyncOpenAI(**openai_client_args),
+    )

--- a/backend/src/services/model_service.py
+++ b/backend/src/services/model_service.py
@@ -105,7 +105,15 @@ async def create_model(
     output_price_per_1m: float | None = None,
     cache_hit_price_per_1m: float | None = None,
 ) -> Model:
-    """Create a new model. api_key is transparently encrypted by the ORM."""
+    """Create a new model. api_key is transparently encrypted by the ORM.
+
+    For Ollama models, api_key is auto-filled with "ollama" when empty
+    (Ollama does not require authentication but the column is non-nullable).
+    """
+    # Auto-fill api_key for Ollama (no auth required)
+    if provider.lower() == "ollama" and not api_key:
+        api_key = "ollama"
+
     model = Model(
         tenant_id=tenant_id,
         name=name,
@@ -132,10 +140,20 @@ async def create_model(
 
 
 async def update_model(db: AsyncSession, model_id: str, **fields) -> Model:
-    """Update a model's fields. Raises NotFoundError if missing."""
+    """Update a model's fields. Raises NotFoundError if missing.
+
+    For Ollama models, api_key is auto-filled with "ollama" when empty
+    (Ollama does not require authentication but the column is non-nullable).
+    """
     model = await get_model_by_id(db, model_id)
     if model is None:
         raise NotFoundError("Model not found")
+
+    # Determine effective provider: use the incoming value if provided,
+    # otherwise fall back to the current provider from DB.
+    provider = fields.get("provider", model.provider)
+    if "api_key" in fields and not fields["api_key"] and provider.lower() == "ollama":
+        fields["api_key"] = "ollama"
 
     for key, value in fields.items():
         if hasattr(model, key):

--- a/docs/agent-framework-integration.md
+++ b/docs/agent-framework-integration.md
@@ -22,7 +22,7 @@ MAF is a production-grade Python framework for building AI agents and multi-agen
 | Middleware | DeepSeek stabilization patches, request/response processing |
 | Streaming | Token and event streaming to the frontend |
 | OpenTelemetry integration | Observability (tracing and monitoring) |
-| Multiple provider support | DeepSeek, OpenAI, Anthropic, local models |
+| Multiple provider support | DeepSeek, OpenAI, Anthropic, Ollama, local models |
 
 ---
 
@@ -84,6 +84,7 @@ MAF supports multiple model providers. PH Agent Hub uses MAF provider clients co
 | DeepSeek | `OpenAIChatClient` with custom `base_url` (DeepSeek exposes an OpenAI-compatible API) |
 | OpenAI | `OpenAIChatClient` |
 | Anthropic | `AnthropicChatClient` |
+| Ollama | `OpenAIChatClient` (Ollama exposes an OpenAI-compatible `/v1/chat/completions` endpoint) |
 | Local / custom | Custom provider implementing the MAF `ChatClient` interface |
 
 The backend resolves the correct client at request time from the `models` table, using the tenant- and session-selected model.

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -22,7 +22,7 @@ PH Agent Hub is built around a clean separation of responsibilities:
 The backend is the core of the platform. It provides:
 
 - Agent execution using the [Microsoft Agent Framework (MAF)](agent-framework-integration.md) — Python, `pip install agent-framework`
-- Multi-model orchestration (DeepSeek, OpenAI, Anthropic, etc.)
+- Multi-model orchestration (DeepSeek, OpenAI, Anthropic, Ollama, etc.)
 - Tool calling and workflow coordination
 - MCP (Model Context Protocol) client support — connect any MCP-compliant server for dynamically discovered tools
 - DeepSeek-compatible stabilization layer (JSON repair, retry logic, output filtering)

--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -18,7 +18,7 @@ The backend provides the following core capabilities:
 - Supports streaming responses and agent events to the chat area via SSE
 
 ### **1.2 Model Orchestration**
-- Supports multiple model providers (DeepSeek, OpenAI, Anthropic, local models, etc.)
+- Supports multiple model providers (DeepSeek, OpenAI, Anthropic, Ollama, local models, etc.)
 - Allows per‑tenant model configuration
 - Allows administrators to enable/disable models
 - Provides routing logic for selecting the correct model per request

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -200,6 +200,65 @@ Production uses Traefik (external stack) with Let's Encrypt auto-SSL. Each servi
 
 ---
 
+# 7. Ollama Setup (Local Models)
+
+PH Agent Hub supports local LLMs via [Ollama](https://ollama.com). Ollama provides an OpenAI-compatible API, so it integrates as a first-class model provider alongside cloud providers.
+
+## 7.1 Install Ollama
+
+```bash
+# Linux (curl method)
+curl -fsSL https://ollama.com/install.sh | sh
+
+# macOS — download from https://ollama.com
+# Docker — see https://hub.docker.com/r/ollama/ollama
+```
+
+## 7.2 Pull a Model
+
+```bash
+ollama pull llama3.2
+# or
+ollama pull mistral
+# or
+ollama pull qwen2.5
+```
+
+## 7.3 Verify Ollama is Running
+
+```bash
+# Ollama serves its API on port 11434 by default
+curl http://localhost:11434/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"llama3.2","messages":[{"role":"user","content":"Hello"}]}'
+```
+
+## 7.4 Configure in PH Agent Hub
+
+1. Go to **Admin → Models → Create Model**
+2. Set **Provider** to `Ollama`
+3. Set **Model ID** to the model name you pulled (e.g., `llama3.2`)
+4. Set **Base URL** to your Ollama server URL (e.g., `http://localhost:11434/v1` or `http://host.docker.internal:11434/v1` when running PH Agent Hub in Docker and Ollama on the host)
+5. **API Key** is not required for Ollama — it's auto-filled with a placeholder
+6. Set **Max Tokens**, **Temperature**, and **Context Window** as desired (these are for PH Agent Hub's internal context management, not passed to Ollama)
+7. Click **OK**
+
+## 7.5 Docker Considerations
+
+When running PH Agent Hub in Docker:
+
+- If Ollama is on the **host machine**, use `http://host.docker.internal:11434/v1` as Base URL (Docker Desktop) or the host's LAN IP
+- If Ollama runs in its **own container**, add it to the `phagent-network` and use `http://ollama:11434/v1`
+- Local models run on CPU by default. For GPU acceleration, install the NVIDIA Container Toolkit and add GPU reservations to the Ollama container
+
+## 7.6 Limitations
+
+- **Thinking/reasoning mode** is not supported (most local models don't emit reasoning tokens)
+- **Tool calling** depends on the model — only recent models (e.g., `llama3.2`, `qwen2.5`) support native function calling
+- **Performance** varies by hardware — Ollama runs on CPU by default; GPU acceleration significantly improves throughput
+
+---
+
 # 7. Deployment Modes
 
 ## **7.1 Local Development**

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -88,6 +88,8 @@ Use the model selector in the top bar to choose which AI model to use. You can o
 - Your administrator has enabled for your tenant
 - Are currently active
 
+Models from various providers may be available, including cloud providers (OpenAI, Anthropic, DeepSeek) and **local models** running via Ollama. Local models appear in the selector with an `(ollama)` label.
+
 Different models have different strengths — try a few to find what works best for your use case.
 
 ---

--- a/frontend/src/features/admin/resources/models/ModelForm.tsx
+++ b/frontend/src/features/admin/resources/models/ModelForm.tsx
@@ -248,15 +248,28 @@ export function ModelForm({ open, model, duplicateFrom, onClose }: ModelFormProp
               { label: "OpenAI", value: "openai" },
               { label: "Anthropic", value: "anthropic" },
               { label: "DeepSeek", value: "deepseek" },
+              { label: "Ollama", value: "ollama" },
             ]}
           />
         </Form.Item>
-        <Form.Item name="api_key" label="API Key">
-          <Input.Password
-            placeholder={
-              isEdit ? "Leave blank to keep current" : "Enter API key"
-            }
-          />
+        <Form.Item shouldUpdate noStyle>
+          {() => {
+            const provider = form.getFieldValue("provider");
+            const isOllama = provider === "ollama";
+            return (
+              <Form.Item name="api_key" label={isOllama ? "API Key (optional)" : "API Key"}>
+                <Input.Password
+                  placeholder={
+                    isOllama
+                      ? "Not required for local models"
+                      : isEdit
+                        ? "Leave blank to keep current"
+                        : "Enter API key"
+                  }
+                />
+              </Form.Item>
+            );
+          }}
         </Form.Item>
         <Form.Item name="base_url" label="Base URL">
           <Input placeholder="e.g., https://api.openai.com/v1" />
@@ -297,8 +310,11 @@ export function ModelForm({ open, model, duplicateFrom, onClose }: ModelFormProp
         </Form.Item>
 
         <Form.Item shouldUpdate noStyle>
-          {() =>
-            form.getFieldValue("provider") === "deepseek" ? (
+          {() => {
+            const provider = form.getFieldValue("provider");
+            // Only DeepSeek supports thinking/reasoning mode
+            if (provider !== "deepseek") return null;
+            return (
               <>
                 <Form.Item
                   name="thinking_enabled"
@@ -323,8 +339,8 @@ export function ModelForm({ open, model, duplicateFrom, onClose }: ModelFormProp
                   </Form.Item>
                 )}
               </>
-            ) : null
-          }
+            );
+          }}
         </Form.Item>
         <Form.Item
           name="follow_up_questions_enabled"


### PR DESCRIPTION
Integrate support for running local LLMs via Ollama, allowing users to utilize an OpenAI-compatible API without requiring an API key. Update the model creation and update processes to accommodate Ollama's specifications, and enhance the user interface to reflect the new provider. Documentation includes setup instructions and considerations for using Ollama in various environments.

Fixes #249