### PR TITLE
Always the right scroll bar appears

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,6 +11,14 @@
     <link rel="apple-touch-icon" href="/icons/icon-512.png" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <title>PH Agent Hub</title>
+    <style>
+      html, body, #root {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+      }
+    </style>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
The changes ensure that the right scroll bar does not appear unnecessarily by adjusting the CSS for the HTML and body elements.

Fixes #266