### PR TITLE
Ability to edit agent responses

### DIFF
--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -155,6 +155,11 @@ class ToolResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class AssistantMessageUpdate(BaseModel):
+    """Payload for PATCH editing an assistant message in-place."""
+    content: str
+
+
 class FeedbackCreate(BaseModel):
     rating: str
     comment: str | None = None
@@ -235,6 +240,43 @@ async def _require_session_owner(
         raise ForbiddenError("You do not own this session")
     if session_data.get("tenant_id") != current_user.tenant_id:
         raise ForbiddenError("Session belongs to a different tenant")
+
+
+async def _truncate_after_message(
+    db: AsyncSession,
+    session_id: str,
+    message: Message,
+) -> int:
+    """Hard-delete all messages in the session after *message*.
+
+    Deletes feedback rows, file uploads, and the messages themselves.
+    Returns the count of messages deleted (excludes the target).
+    Does NOT commit — the caller is responsible for committing.
+    """
+    result = await db.execute(
+        select(Message)
+        .where(
+            Message.session_id == session_id,
+            Message.is_deleted == False,  # noqa: E712
+            Message.created_at > message.created_at,
+        )
+        .order_by(Message.created_at)
+    )
+    subsequent = list(result.scalars().all())
+
+    for msg in subsequent:
+        # Delete feedback rows (FK constraint)
+        await db.execute(
+            delete(MessageFeedback).where(
+                MessageFeedback.message_id == msg.id
+            )
+        )
+        # Delete file uploads (MinIO + DB rows)
+        await upload_service.delete_uploads_for_message(db, msg.id)
+        # Hard-delete the message
+        await db.delete(msg)
+
+    return len(subsequent)
 
 
 async def _inject_file_content(
@@ -950,31 +992,9 @@ async def edit_user_message(
     if original_msg.sender != "user":
         raise ValidationError("Only user messages can be edited")
 
-    # Find and hard-delete the assistant response that follows this user message
-    child_result = await db.execute(
-        select(Message).where(
-            Message.session_id == session_id,
-            Message.is_deleted == False,  # noqa: E712
-        )
-        .order_by(Message.created_at)
-    )
-    all_msgs = list(child_result.scalars().all())
-
-    # Find the assistant message immediately after this user message
-    original_idx = None
-    for i, m in enumerate(all_msgs):
-        if m.id == message_id:
-            original_idx = i
-            break
-
-    # Hard-delete the assistant response that belongs to this user message
-    if original_idx is not None and original_idx + 1 < len(all_msgs):
-        next_msg = all_msgs[original_idx + 1]
-        if next_msg.sender == "assistant":
-            await db.delete(next_msg)
-            await upload_service.delete_uploads_for_message(db, next_msg.id)
-
-    # Hard-delete the original user message
+    # Truncate all messages after this user message, then hard-delete
+    # the original user message itself.
+    await _truncate_after_message(db, session_id, original_msg)
     await upload_service.delete_uploads_for_message(db, message_id)
     await db.delete(original_msg)
     await db.commit()
@@ -1043,6 +1063,9 @@ async def delete_message(
     if msg is None:
         raise NotFoundError("Message not found")
 
+    # Truncate all messages after this one
+    await _truncate_after_message(db, session_id, msg)
+
     # Delete feedback rows first (FK constraint)
     await db.execute(
         delete(MessageFeedback).where(
@@ -1058,6 +1081,62 @@ async def delete_message(
 
     await db.commit()
     return Response(status_code=204)
+
+
+@router.patch(
+    "/session/{session_id}/message/{message_id}",
+    response_model=MessageResponse,
+)
+async def update_assistant_message(
+    session_id: str,
+    message_id: str,
+    body: AssistantMessageUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserORM = Depends(get_current_user),
+):
+    """Edit an assistant message in-place (no agent re-run).
+
+    Updates the message content and truncates all subsequent messages.
+    Unlike PUT (which edits a user message and re-runs the agent),
+    this endpoint only modifies the stored text — no regeneration.
+    """
+    data = await _load_session(db, session_id)
+    await _require_session_owner(data, current_user)
+
+    if data.get("is_temporary", False):
+        raise ValidationError(
+            "Message editing is not supported for temporary sessions"
+        )
+
+    # Load the assistant message
+    msg_result = await db.execute(
+        select(Message).where(
+            Message.id == message_id,
+            Message.session_id == session_id,
+        )
+    )
+    msg = msg_result.scalar_one_or_none()
+    if msg is None:
+        raise NotFoundError("Message not found")
+    if msg.sender != "assistant":
+        raise ValidationError("Only assistant messages can be edited with PATCH")
+
+    # Truncate all subsequent messages
+    deleted_count = await _truncate_after_message(db, session_id, msg)
+
+    # Update content in-place
+    msg.content = [{"type": "text", "text": body.content}]
+    await db.commit()
+    await db.refresh(msg)
+
+    logger.info(
+        "Assistant message %s edited in session %s — truncated %d subsequent message(s)",
+        message_id,
+        session_id,
+        deleted_count,
+    )
+
+    return MessageResponse.model_validate(msg)
 
 
 @router.post(
@@ -1099,6 +1178,23 @@ async def regenerate_assistant_message(
         raise NotFoundError("Message not found")
     if assistant_msg.sender != "assistant":
         raise ValidationError("Only assistant messages can be regenerated")
+
+    # Restrict regeneration to the last assistant message in the session.
+    last_msg_result = await db.execute(
+        select(Message)
+        .where(
+            Message.session_id == session_id,
+            Message.is_deleted == False,  # noqa: E712
+        )
+        .order_by(Message.created_at.desc())
+        .limit(1)
+    )
+    last_msg = last_msg_result.scalar_one_or_none()
+    if last_msg is None or last_msg.id != message_id:
+        raise ValidationError(
+            "Only the most recent assistant message can be regenerated. "
+            "Use edit (PATCH) to modify earlier responses."
+        )
 
     # Find the user message immediately before this assistant message
     all_msgs_result = await db.execute(

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ph-agent-hub-frontend",
   "private": true,
-  "version": "1.12.2",
+  "version": "1.13.0",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000 --host",

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -30,6 +30,7 @@ import {
   deleteMessage,
   summarizeSession,
   finalizeSession,
+  updateAssistantMessage,
 } from "../services/chat";
 import { getDemoMessages } from "../services/demo";
 import api, { getToken } from "../../../services/api";
@@ -504,6 +505,11 @@ export function ChatWindow({
     setEditingMsgId(null);
     setInputValue("");
   }, []);
+
+  const handleEditAssistant = useCallback(async (messageId: string, newContent: string) => {
+    await updateAssistantMessage(sessionId, messageId, newContent);
+    queryClient.invalidateQueries({ queryKey: ["messages", sessionId] });
+  }, [sessionId, queryClient]);
 
   const handleDelete = useCallback(async (messageId: string) => {
     await deleteMessage(sessionId, messageId);
@@ -989,14 +995,31 @@ export function ChatWindow({
                 message={msg}
                 sessionId={sessionId}
                 onEdit={msg.sender === "user" ? handleEdit : undefined}
+                onEditAssistant={
+                  msg.sender === "assistant" && !isTemporary
+                    ? handleEditAssistant
+                    : undefined
+                }
+                hasSubsequentMessages={
+                  messages
+                    ? messages.some(
+                        (m: any) =>
+                          m.created_at > msg.created_at &&
+                          m.id !== regeneratingMsgId &&
+                          m.id !== editingMsgId,
+                      )
+                    : false
+                }
                 onDelete={
                   !isTemporary
                     ? handleDelete
                     : undefined
                 }
                 onRegenerate={
-                  msg.sender === "assistant" && !isTemporary
-                    ? handleRegenerate
+                  msg.sender === "assistant" && !isTemporary && messages
+                    ? messages.filter((m: any) => m.sender === "assistant" && !m.is_deleted).at(-1)?.id === msg.id
+                      ? handleRegenerate
+                      : undefined
                     : undefined
                 }
                 disabled={streaming}

--- a/frontend/src/features/chat/components/MessageBubble.tsx
+++ b/frontend/src/features/chat/components/MessageBubble.tsx
@@ -6,8 +6,8 @@
 // tool activity display for tool_start/tool_result events.
 // =============================================================================
 
-import React from "react";
-import { Typography, Space, Collapse, Tag, Button, Popconfirm, App, Spin, Tooltip } from "antd";
+import React, { useState } from "react";
+import { Typography, Space, Collapse, Tag, Button, Popconfirm, App, Spin, Tooltip, Input, Modal } from "antd";
 import {
   UserOutlined,
   RobotOutlined,
@@ -20,6 +20,8 @@ import {
   CopyOutlined,
   CompressOutlined,
   DollarOutlined,
+  CheckOutlined,
+  CloseOutlined,
 } from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
 import ReactMarkdown from "react-markdown";
@@ -71,6 +73,8 @@ interface MessageBubbleProps {
   onEdit?: (messageId: string) => void;
   onDelete?: (messageId: string) => void;
   onRegenerate?: (messageId: string) => void;
+  onEditAssistant?: (messageId: string, newContent: string) => Promise<void>;
+  hasSubsequentMessages?: boolean;
   disabled?: boolean;
   regenerating?: boolean;
   streaming?: boolean;
@@ -82,6 +86,8 @@ function MessageBubbleInner({
   onEdit,
   onDelete,
   onRegenerate,
+  onEditAssistant,
+  hasSubsequentMessages,
   disabled,
   regenerating,
   streaming,
@@ -89,6 +95,11 @@ function MessageBubbleInner({
   const isUser = message.sender === "user";
   const isSystem = message.sender === "system";
   const contentItems = parseContent(message.content);
+
+  // Inline editing state for assistant messages
+  const [isEditingAssistant, setIsEditingAssistant] = useState(false);
+  const [editContent, setEditContent] = useState("");
+  const [savingEdit, setSavingEdit] = useState(false);
 
   // Separate text, reasoning, and tool events
   const textItems = contentItems.filter((c) => c.type === "text");
@@ -207,53 +218,96 @@ function MessageBubbleInner({
           />
         )}
 
-        {textItems.map((item, i) => (
-          <div key={i} style={isUser ? undefined : { maxWidth: 750 }}>
-            {isUser ? (
-              <Text style={{ color: "#fff", whiteSpace: "pre-wrap" }}>
-                {item.text}
-              </Text>
-            ) : (
-              <div className="markdown-body" style={{ fontSize: 14 }}>
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm]}
-                  components={{
-                    code({ className, children, ...props }) {
-                      const match = /language-(\w+)/.exec(
-                        className || "",
-                      );
-                      const codeStr = String(children).replace(
-                        /\n$/,
-                        "",
-                      );
-                      if (match) {
-                        return (
-                          <SyntaxHighlighter
-                            style={oneDark}
-                            language={match[1]}
-                            PreTag="div"
-                          >
-                            {codeStr}
-                          </SyntaxHighlighter>
-                        );
-                      }
-                      return (
-                        <code
-                          className={className}
-                          {...(props as Record<string, unknown>)}
-                        >
-                          {children}
-                        </code>
-                      );
-                    },
-                  }}
-                >
-                  {item.text || ""}
-                </ReactMarkdown>
-              </div>
-            )}
+        {/* Inline edit mode for assistant messages */}
+        {isEditingAssistant && !isUser ? (
+          <div style={{ maxWidth: 750 }}>
+            <Input.TextArea
+              value={editContent}
+              onChange={(e) => setEditContent(e.target.value)}
+              autoSize={{ minRows: 4, maxRows: 20 }}
+              style={{ marginBottom: 8 }}
+              disabled={savingEdit}
+            />
+            <Space>
+              <Button
+                type="primary"
+                size="small"
+                icon={<CheckOutlined />}
+                loading={savingEdit}
+                onClick={async () => {
+                  if (!onEditAssistant) return;
+                  setSavingEdit(true);
+                  try {
+                    await onEditAssistant(message.id, editContent);
+                    setIsEditingAssistant(false);
+                  } catch {
+                    messageApi.error("Failed to save edit");
+                  } finally {
+                    setSavingEdit(false);
+                  }
+                }}
+              >
+                Save
+              </Button>
+              <Button
+                size="small"
+                icon={<CloseOutlined />}
+                onClick={() => setIsEditingAssistant(false)}
+                disabled={savingEdit}
+              >
+                Cancel
+              </Button>
+            </Space>
           </div>
-        ))}
+        ) : (
+          textItems.map((item, i) => (
+            <div key={i} style={isUser ? undefined : { maxWidth: 750 }}>
+              {isUser ? (
+                <Text style={{ color: "#fff", whiteSpace: "pre-wrap" }}>
+                  {item.text}
+                </Text>
+              ) : (
+                <div className="markdown-body" style={{ fontSize: 14 }}>
+                  <ReactMarkdown
+                    remarkPlugins={[remarkGfm]}
+                    components={{
+                      code({ className, children, ...props }) {
+                        const match = /language-(\w+)/.exec(
+                          className || "",
+                        );
+                        const codeStr = String(children).replace(
+                          /\n$/,
+                          "",
+                        );
+                        if (match) {
+                          return (
+                            <SyntaxHighlighter
+                              style={oneDark}
+                              language={match[1]}
+                              PreTag="div"
+                            >
+                              {codeStr}
+                            </SyntaxHighlighter>
+                          );
+                        }
+                        return (
+                          <code
+                            className={className}
+                            {...(props as Record<string, unknown>)}
+                          >
+                            {children}
+                          </code>
+                        );
+                      },
+                    }}
+                  >
+                    {item.text || ""}
+                  </ReactMarkdown>
+                </div>
+              )}
+            </div>
+          ))
+        )}
 
         {/* Tool calls / results */}
         {toolItems.length > 0 && (
@@ -412,6 +466,31 @@ function MessageBubbleInner({
               </Button>
             </Tooltip>
           )}
+          {onEditAssistant && (
+            <Button
+              type="text"
+              size="small"
+              icon={<EditOutlined />}
+              onClick={() => {
+                const text = textItems.map((t) => t.text || "").join("\n");
+                if (hasSubsequentMessages) {
+                  Modal.confirm({
+                    title: "Edit this response?",
+                    content:
+                      "Editing this response will remove the messages that follow it. Continue?",
+                    onOk: () => {
+                      setEditContent(text);
+                      setIsEditingAssistant(true);
+                    },
+                  });
+                } else {
+                  setEditContent(text);
+                  setIsEditingAssistant(true);
+                }
+              }}
+              disabled={disabled || isEditingAssistant}
+            />
+          )}
           {onRegenerate && (
             <Button
               type="text"
@@ -423,7 +502,8 @@ function MessageBubbleInner({
           )}
           {onDelete && (
             <Popconfirm
-              title="Delete this message?"
+              title={hasSubsequentMessages ? "Delete this message and all that follow?" : "Delete this message?"}
+              description={hasSubsequentMessages ? "This will also remove all messages after this one." : undefined}
               onConfirm={() => onDelete(message.id)}
             >
               <Button
@@ -498,6 +578,8 @@ export const MessageBubble = React.memo(MessageBubbleInner, (prev, next) =>
   prev.onEdit === next.onEdit &&
   prev.onDelete === next.onDelete &&
   prev.onRegenerate === next.onRegenerate &&
+  prev.onEditAssistant === next.onEditAssistant &&
+  prev.hasSubsequentMessages === next.hasSubsequentMessages &&
   prev.sessionId === next.sessionId
 );
 

--- a/frontend/src/features/chat/services/chat.ts
+++ b/frontend/src/features/chat/services/chat.ts
@@ -202,6 +202,18 @@ export function regenerateMessage(
   });
 }
 
+/** Update an assistant message in-place (PATCH — no agent re-run). */
+export function updateAssistantMessage(
+  sessionId: string,
+  messageId: string,
+  content: string,
+): Promise<MessageData> {
+  return api<MessageData>(`/chat/session/${sessionId}/message/${messageId}`, {
+    method: "PATCH",
+    body: { content },
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Message Feedback
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
This feature allows users to edit agent responses directly in the chat interface. An edit button is added to the agent's messages, enabling users to modify the content as needed. The updated response will be saved and used in subsequent messages, providing greater flexibility and control over the conversation flow.
Closes #274

