### PR TITLE
Enhance model selection clarity in Edit Embed Config

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -107,7 +107,7 @@ async def lifespan(app: FastAPI):
     demo_cleanup_task.cancel()
 
 
-app = FastAPI(title="PH Agent Hub", version="1.14.1", lifespan=lifespan)
+app = FastAPI(title="PH Agent Hub", version="1.14.2", lifespan=lifespan)
 
 # ---------------------------------------------------------------------------
 # Middleware

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ph-agent-hub-frontend",
   "private": true,
-  "version": "1.14.1",
+  "version": "1.14.2",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000 --host",

--- a/frontend/src/features/admin/resources/embed/EmbedConfigForm.tsx
+++ b/frontend/src/features/admin/resources/embed/EmbedConfigForm.tsx
@@ -26,6 +26,7 @@ import {
   listModels,
   listSkills,
   listTemplates,
+  listTenants,
 } from "../../services/admin";
 
 const { Text } = Typography;
@@ -58,6 +59,14 @@ export function EmbedConfigForm({ open, config, onClose, onSuccess }: EmbedConfi
     queryFn: () => listTemplates({ page_size: 200 }),
     enabled: open,
   });
+
+  const { data: tenants } = useQuery({
+    queryKey: ["admin-tenants-embed-selector"],
+    queryFn: () => listTenants(),
+    enabled: open,
+  });
+
+  const tenantNameById = new Map((tenants?.items || []).map((t: { id: string; name: string }) => [t.id, t.name]));
 
   // Reset form when opening/closing
   useEffect(() => {
@@ -201,10 +210,13 @@ export function EmbedConfigForm({ open, config, onClose, onSuccess }: EmbedConfi
 
         <Space size="large" wrap>
           <Form.Item name="default_model_id" label="Default Model">
-            <Select allowClear style={{ width: 200 }} placeholder="Tenant default">
+            <Select allowClear style={{ width: 240 }} placeholder="Tenant default">
               {(models?.items || []).map((m) => (
                 <Select.Option key={m.id} value={m.id}>
                   {m.name}
+                  {tenantNameById.has(m.tenant_id)
+                    ? ` (${tenantNameById.get(m.tenant_id)})`
+                    : ""}
                 </Select.Option>
               ))}
             </Select>


### PR DESCRIPTION
The model selection dropdown in the Edit Embed Config now displays the tenant name alongside the model name. This change helps administrators differentiate between models with the same name across different tenants, improving the user experience and reducing selection errors.
Closes #278

