### PR TITLE
Fix failing to view MCP Servers on admin

### DIFF
--- a/backend/src/api/admin.py
+++ b/backend/src/api/admin.py
@@ -1340,10 +1340,12 @@ async def list_mcp_servers(
     total_pages = max(1, -(-total // page_size))
     items = []
     for s in servers:
-        data = McpServerResponse.model_validate(s)
-        # Mask secrets
-        data.env_vars = mask_dict(decrypt_env_vars(s))
-        data.headers = mask_dict(decrypt_headers(s))
+        decrypted_env = decrypt_env_vars(s)
+        decrypted_headers = decrypt_headers(s)
+        server_dict = {c.name: getattr(s, c.name) for c in s.__table__.columns}
+        server_dict["env_vars"] = mask_dict(decrypted_env)
+        server_dict["headers"] = mask_dict(decrypted_headers)
+        data = McpServerResponse.model_validate(server_dict)
         items.append(data)
 
     return PaginatedResponse(
@@ -1386,9 +1388,12 @@ async def create_mcp_server(
         tenant_id=current_user.tenant_id,
         ip_address=_get_client_ip(request),
     )
-    data = McpServerResponse.model_validate(server)
-    data.env_vars = mask_dict(decrypt_env_vars(server))
-    data.headers = mask_dict(decrypt_headers(server))
+    decrypted_env = decrypt_env_vars(server)
+    decrypted_headers = decrypt_headers(server)
+    server_dict = {c.name: getattr(server, c.name) for c in server.__table__.columns}
+    server_dict["env_vars"] = mask_dict(decrypted_env)
+    server_dict["headers"] = mask_dict(decrypted_headers)
+    data = McpServerResponse.model_validate(server_dict)
     return data
 
 
@@ -1405,9 +1410,12 @@ async def get_mcp_server(
     if current_user.role == "manager" and server.tenant_id != current_user.tenant_id:
         raise ForbiddenError("Managers can only view MCP servers in their own tenant")
 
-    data = McpServerResponse.model_validate(server)
-    data.env_vars = mask_dict(decrypt_env_vars(server))
-    data.headers = mask_dict(decrypt_headers(server))
+    decrypted_env = decrypt_env_vars(server)
+    decrypted_headers = decrypt_headers(server)
+    server_dict = {c.name: getattr(server, c.name) for c in server.__table__.columns}
+    server_dict["env_vars"] = mask_dict(decrypted_env)
+    server_dict["headers"] = mask_dict(decrypted_headers)
+    data = McpServerResponse.model_validate(server_dict)
     return data
 
 
@@ -1445,9 +1453,12 @@ async def update_mcp_server(
         tenant_id=current_user.tenant_id,
         ip_address=_get_client_ip(request),
     )
-    data = McpServerResponse.model_validate(server)
-    data.env_vars = mask_dict(decrypt_env_vars(server))
-    data.headers = mask_dict(decrypt_headers(server))
+    decrypted_env = decrypt_env_vars(server)
+    decrypted_headers = decrypt_headers(server)
+    server_dict = {c.name: getattr(server, c.name) for c in server.__table__.columns}
+    server_dict["env_vars"] = mask_dict(decrypted_env)
+    server_dict["headers"] = mask_dict(decrypted_headers)
+    data = McpServerResponse.model_validate(server_dict)
     return data
 
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -107,7 +107,7 @@ async def lifespan(app: FastAPI):
     demo_cleanup_task.cancel()
 
 
-app = FastAPI(title="PH Agent Hub", version="1.15.2", lifespan=lifespan)
+app = FastAPI(title="PH Agent Hub", version="1.15.3", lifespan=lifespan)
 
 # ---------------------------------------------------------------------------
 # Middleware

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ph-agent-hub-frontend",
   "private": true,
-  "version": "1.15.2",
+  "version": "1.15.3",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000 --host",


### PR DESCRIPTION
The changes address the issue of not being able to view newly created MCP servers in the admin interface. The implementation ensures that environment variables and headers are properly decrypted and included in the server response. Additionally, the version of the application has been updated to reflect these changes.
Closes #286

## Description

The changes address the issue of not being able to view newly created MCP servers in the admin interface. The implementation ensures that environment variables and headers are properly decrypted and included in the server response. Additionally, the version of the application has been updated to reflect these changes.

## Related Issue

Closes #286

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Tested locally with Docker Compose (dev)
- [x] Backend tests pass (`pytest backend/tests/`)
- [x] Frontend builds without errors (`npm run build`)
- [x] Manual testing completed (describe what you tested)

## Checklist

- [x] My code follows the coding conventions of this project
- [x] I have self-reviewed my own code
- [x] I have commented complex code sections, particularly in hard-to-understand areas
- [x] I have updated the documentation (`docs/`) if my change affects user-facing behaviour or configuration
- [x] My changes generate no new warnings or errors
- [x] New and existing tests pass locally

## Screenshots (if applicable)

## Additional Notes

<!-- Any other information reviewers should know? -->

