### PR TITLE
New line in mobile chat input

### DIFF
--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -688,7 +688,7 @@ export function ChatWindow({
   }, []);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (e.key === "Enter" && !e.shiftKey && !isMobile) {
       e.preventDefault();
       handleSend();
     }


### PR DESCRIPTION
The chat input on mobile now allows users to insert a new line when pressing Enter, instead of submitting the message. This change enhances the user experience for mobile users by enabling multiline messages.

Fixes #285

