### PR TITLE
Update MCP tools visibility to public by default

### DIFF
--- a/backend/src/services/mcp_service.py
+++ b/backend/src/services/mcp_service.py
@@ -312,6 +312,7 @@ async def sync_mcp_tools(
             tool.name = f"{server.name}: {tool_name}"
             tool.config = config
             tool.enabled = True
+            tool.is_public = True
             updated += 1
             existing_tools.pop(tool_name)
         else:
@@ -323,7 +324,7 @@ async def sync_mcp_tools(
                 config=config,
                 category="mcp",
                 enabled=True,
-                is_public=False,
+                is_public=True,
             )
             db.add(tool)
             created += 1

--- a/backend/src/tools/mcp.py
+++ b/backend/src/tools/mcp.py
@@ -90,9 +90,20 @@ async def build_mcp_tool_callables(
     }
 
     if server.transport == "streamable_http":
+        # Create an httpx client with headers baked in, so auth is sent
+        # during the initial connect() handshake (not just call_tool).
+        import httpx
+        http_client = httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=httpx.Timeout(30.0, read=300.0),
+            headers=headers,
+        )
+        if cleanup_clients is not None:
+            cleanup_clients.append(http_client)
         mcp_tool = MCPStreamableHTTPTool(
             **common_kwargs,
             url=server.url,
+            http_client=http_client,
             header_provider=lambda _ctx: headers,
         )
     elif server.transport == "websocket":

--- a/frontend/src/features/admin/resources/tools/ToolList.tsx
+++ b/frontend/src/features/admin/resources/tools/ToolList.tsx
@@ -21,7 +21,7 @@ import {
   Select,
   Input,
 } from "antd";
-import { EditOutlined, DeleteOutlined, CopyOutlined, SearchOutlined } from "@ant-design/icons";
+import { EditOutlined, DeleteOutlined, CopyOutlined, SearchOutlined, EyeOutlined, EyeInvisibleOutlined } from "@ant-design/icons";
 import { useSearchParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
@@ -170,6 +170,27 @@ export function ToolList() {
       ),
     },
     {
+      title: "Public",
+      dataIndex: "is_public",
+      key: "is_public",
+      width: 90,
+      filters: [
+        { text: "Public", value: true },
+        { text: "Private", value: false },
+      ],
+      onFilter: (value, record) => record.is_public === value,
+      render: (v: boolean) =>
+        v ? (
+          <Tag icon={<EyeOutlined />} color="blue">
+            Public
+          </Tag>
+        ) : (
+          <Tag icon={<EyeInvisibleOutlined />}>
+            Private
+          </Tag>
+        ),
+    },
+    {
       title: "Actions",
       key: "actions",
       render: (_: unknown, record: ToolData) => (
@@ -288,6 +309,11 @@ export function ToolList() {
                       <Tag color="purple">{tool.type}</Tag>
                       {tool.type === "custom" && tool.code && (
                         <Tag color="green" style={{ fontSize: 11 }}>code</Tag>
+                      )}
+                      {tool.is_public ? (
+                        <Tag icon={<EyeOutlined />} color="blue" style={{ fontSize: 11 }}>Public</Tag>
+                      ) : (
+                        <Tag icon={<EyeInvisibleOutlined />} style={{ fontSize: 11 }}>Private</Tag>
                       )}
                     </Space>
                     <Switch


### PR DESCRIPTION
The changes ensure that MCP tools are set as public by default, allowing admin users to view them. Additionally, visibility tags for public and private status have been added to the ToolList for better clarity and filtering options.
Fixes #291

