### PR TITLE
Fix temporary message editing error

### DIFF
--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -1051,7 +1051,11 @@ export function ChatWindow({
                 message={msg}
                 sessionId={sessionId}
                 showFeedback={!embedded && !demo}
-                onEdit={msg.sender === "user" ? handleEdit : undefined}
+                onEdit={
+                  msg.sender === "user" && !isTemporary
+                    ? handleEdit
+                    : undefined
+                }
                 onEditAssistant={
                   msg.sender === "assistant" && !isTemporary
                     ? handleEditAssistant


### PR DESCRIPTION
Editing a temporary message no longer triggers an error when sending. This change ensures that the edit functionality is only available for non-temporary messages, addressing the issue reported in #294.

Closes #294

