### PR TITLE
Fix display of selected tools from skills

### DIFF
--- a/frontend/src/features/chat/components/SessionToolActivation.tsx
+++ b/frontend/src/features/chat/components/SessionToolActivation.tsx
@@ -10,6 +10,7 @@ import {
   Drawer,
   List,
   Switch,
+  Tag,
   Typography,
   Empty,
   Space,
@@ -224,9 +225,9 @@ export function SessionToolActivation({
                       <Space size={4}>
                         {tool.name}
                         {skillToolIds.has(tool.id) && (
-                          <Text type="secondary" style={{ fontSize: 11, fontStyle: "italic" }}>
+                          <Tag color="blue" style={{ fontSize: 11, lineHeight: "18px", margin: 0 }}>
                             from skill
-                          </Text>
+                          </Tag>
                         )}
                       </Space>
                     }

--- a/frontend/src/features/chat/components/SkillSelector.tsx
+++ b/frontend/src/features/chat/components/SkillSelector.tsx
@@ -6,7 +6,7 @@
 // =============================================================================
 
 import React, { useState } from "react";
-import { Select, Space, Typography, Button } from "antd";
+import { Select, Space, Tag, Typography, Button } from "antd";
 import { SettingOutlined } from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
 import api from "../../../services/api";
@@ -65,7 +65,16 @@ export function SkillSelector({
             style={{ minWidth: 160 }}
             allowClear
             options={(skills || []).map((s) => ({
-              label: s.title,
+              label: (
+                <Space size={4}>
+                  {s.title}
+                  {s.tool_ids && s.tool_ids.length > 0 && (
+                    <Tag color="blue" style={{ fontSize: 11, lineHeight: "18px", margin: 0 }}>
+                      {s.tool_ids.length} tool{s.tool_ids.length !== 1 ? "s" : ""}
+                    </Tag>
+                  )}
+                </Space>
+              ),
               value: s.id,
             }))}
             notFoundContent={isLoading ? "Loading..." : "No skills available"}


### PR DESCRIPTION
The update ensures that when a user selects a skill, the corresponding tools are displayed correctly. This resolves the issue where selected tools were not shown, enhancing user experience and clarity in the interface.
Fixes #301

