### PR TITLE
Fix pull-to-refresh functionality for PWA on mobile (Microsoft Edge)

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -107,7 +107,7 @@ async def lifespan(app: FastAPI):
     demo_cleanup_task.cancel()
 
 
-app = FastAPI(title="PH Agent Hub", version="1.16.3", lifespan=lifespan)
+app = FastAPI(title="PH Agent Hub", version="1.16.4", lifespan=lifespan)
 
 # ---------------------------------------------------------------------------
 # Middleware

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ph-agent-hub-frontend",
   "private": true,
-  "version": "1.16.3",
+  "version": "1.16.4",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000 --host",

--- a/frontend/src/features/chat/components/SessionSidebar.tsx
+++ b/frontend/src/features/chat/components/SessionSidebar.tsx
@@ -38,6 +38,7 @@ import {
   MenuOutlined,
   MenuFoldOutlined,
   MenuUnfoldOutlined,
+  ReloadOutlined,
 } from "@ant-design/icons";
 import { Logo } from "../../../shared/components/Logo";
 import { useNavigate, useParams } from "react-router-dom";
@@ -209,6 +210,14 @@ export function SessionSidebar() {
                   icon={<DatabaseOutlined />}
                   size="small"
                   onClick={() => setMemoryOpen(true)}
+                />
+              </Tooltip>
+              <Tooltip title="Refresh">
+                <Button
+                  type="text"
+                  icon={<ReloadOutlined />}
+                  size="small"
+                  onClick={() => window.location.reload()}
                 />
               </Tooltip>
               <Tooltip title="Collapse sidebar">


### PR DESCRIPTION
Updated the version of the PH Agent Hub to 1.16.4 and added a refresh button to the toolbar for easier access to refresh the app when installed as a PWA. This addresses the issue where the pull-to-refresh gesture was not functioning on mobile devices.
Fixes #307

