### PR TITLE
## Description

### DIFF
--- a/backend/src/agents/runner.py
+++ b/backend/src/agents/runner.py
@@ -1733,6 +1733,32 @@ async def _auto_select_tools(
             seen_names.add(key)
             deduped.append((tool, score))
 
+    # ── Step 4b: Cap instance-type tools (keep only highest-scored per type) ──
+    # Tool types that produce identically-named internal functions (e.g.,
+    # ERPNext tools all produce get_doc, get_list, ...).  Including more
+    # than one instance of these types causes tool name collisions that
+    # confuse the model and can produce empty response streams.
+    _INSTANCE_TOOL_TYPES = {"erpnext"}
+    capped_types: dict[str, int] = {}
+    type_capped: list[tuple[Tool, float]] = []
+    for tool, score in deduped:
+        tt = tool.type or ""
+        if tt in _INSTANCE_TOOL_TYPES:
+            if tt not in capped_types:
+                capped_types[tt] = 1
+                type_capped.append((tool, score))
+            else:
+                capped_types[tt] += 1
+        else:
+            type_capped.append((tool, score))
+    for tt, dropped in capped_types.items():
+        if dropped > 1:
+            logger.info(
+                "Auto-select: capped %s tools from %d to 1",
+                tt, dropped,
+            )
+    deduped = type_capped
+
     # ── Step 5: Deterministic filter (Top-K) ───────────────────────────
     top_k = getattr(settings, "AUTO_SELECT_TOOLS_TOP_K", 5)
     shortlisted_tools = [t for t, _ in deduped[:top_k]]
@@ -2106,6 +2132,7 @@ async def _build_erpnext_callables(
         api_secret=api_secret,
         httpx_client=erpnext_client,
         file_infos=file_infos,
+        tool_name=tool.name,
     )
 
 
@@ -3115,6 +3142,22 @@ async def _run_agent_stream(
                     "step_index": step_index,
                     "total_steps_so_far": step_index,
                 }, session_id=session_id, message_id=message_id)
+
+                # ── Step limit guard ────────────────────────────────────
+                # Prevent runaway agents that loop indefinitely on tool
+                # results (see agent_memory_crash_analysis.md).
+                if step_index >= settings.AGENT_MAX_STEPS:
+                    logger.warning(
+                        "Agent step limit reached (%d) for session %s — terminating stream",
+                        settings.AGENT_MAX_STEPS, session_id,
+                    )
+                    yield _sse_event("step_limit_reached", {
+                        "step_index": step_index,
+                        "max_steps": settings.AGENT_MAX_STEPS,
+                    }, session_id=session_id, message_id=message_id)
+                    # Drain any remaining partial tool calls from pending
+                    pending_calls.clear()
+                    break
 
     # ---- Token extraction -------------------------------------------------
     # After the stream is exhausted, attempt to collect usage metadata.

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -77,6 +77,11 @@ class Settings(BaseSettings):
     # --- Auto tool selection (Issue #287) ---
     AUTO_SELECT_TOOLS_TOP_K: int = 3
 
+    # --- Agent execution (Issue #317) ---
+    AGENT_MAX_STEPS: int = 15
+    """Maximum number of tool-call steps before the agent loop terminates.
+    Prevents runaway agents that loop indefinitely on tool results."""
+
     # --- OAuth (Issue #312) ---
     GOOGLE_CLIENT_ID: str = ""
     """Google OAuth client ID for Gmail/Calendar/Tasks access."""

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -108,7 +108,7 @@ async def lifespan(app: FastAPI):
     demo_cleanup_task.cancel()
 
 
-app = FastAPI(title="PH Agent Hub", version="1.18.0", lifespan=lifespan)
+app = FastAPI(title="PH Agent Hub", version="1.18.1", lifespan=lifespan)
 
 # ---------------------------------------------------------------------------
 # Middleware

--- a/backend/src/tools/erpnext.py
+++ b/backend/src/tools/erpnext.py
@@ -7,12 +7,38 @@
 
 import json
 import logging
+import re
 from typing import Any
 
 import httpx
 from agent_framework import tool
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tool_slug(tool_name: str) -> str:
+    """Derive a safe, readable slug from a tool's display name.
+
+    Example: ``"kainotomo.com"`` → ``"kainotomo_com"``
+    """
+    return re.sub(r'[^a-zA-Z0-9]', '_', tool_name.lower()).strip('_')
+
+
+def _make_tool_name(tool_name: str | None, func_name: str) -> str:
+    """Build a globally unique tool name by prefixing with the instance slug.
+
+    When ``tool_name`` is provided, returns ``"erpnext_{slug}__{func_name}"``.
+    Otherwise returns ``func_name`` unchanged (backward compatibility).
+    """
+    if tool_name:
+        slug = _make_tool_slug(tool_name)
+        return f"erpnext_{slug}__{func_name}"
+    return func_name
+
 
 # ---------------------------------------------------------------------------
 # HTTP helpers
@@ -61,6 +87,7 @@ def build_erpnext_tools(
     api_secret: str,
     httpx_client: httpx.AsyncClient,
     file_infos: list[dict] | None = None,
+    tool_name: str | None = None,
 ) -> list:
     """Return a list of MAF @tool-decorated async functions bound to an
     ERPNext instance.
@@ -74,6 +101,9 @@ def build_erpnext_tools(
             ``Authorization`` headers set.
         file_infos: Optional list of FileUpload dicts (storage_key, bucket,
             original_filename, content_type, id) for the ``upload_file`` tool.
+        tool_name: Optional display name of the Tool ORM record. When provided,
+            each tool function is prefixed (e.g. ``erpnext_kainotomo_com__get_doc``)
+            to prevent name collisions when multiple ERPNext instances are active.
 
     Returns:
         A list of callables ready to pass to ``Agent(tools=...)``.
@@ -81,7 +111,7 @@ def build_erpnext_tools(
     auth_header = _build_auth_header(api_key, api_secret)
 
     # ------------------------------------------------------------------
-    @tool
+    @tool(name=_make_tool_name(tool_name, "get_doc"))
     async def get_doc(doctype: str, name: str) -> dict:
         """Retrieve a single ERPNext document by doctype and name.
 
@@ -96,7 +126,7 @@ def build_erpnext_tools(
         return data
 
     # ------------------------------------------------------------------
-    @tool
+    @tool(name=_make_tool_name(tool_name, "get_list"))
     async def get_list(
         doctype: str,
         filters: list | dict | None = None,
@@ -144,7 +174,7 @@ def build_erpnext_tools(
         return results
 
     # ------------------------------------------------------------------
-    @tool
+    @tool(name=_make_tool_name(tool_name, "create_doc"))
     async def create_doc(doctype: str, data: dict) -> dict:
         """Create a new ERPNext document.
 
@@ -159,7 +189,7 @@ def build_erpnext_tools(
         return result
 
     # ------------------------------------------------------------------
-    @tool
+    @tool(name=_make_tool_name(tool_name, "update_doc"))
     async def update_doc(doctype: str, name: str, data: dict) -> dict:
         """Update an existing ERPNext document.
 
@@ -175,7 +205,7 @@ def build_erpnext_tools(
         return result
 
     # ------------------------------------------------------------------
-    @tool
+    @tool(name=_make_tool_name(tool_name, "delete_doc"))
     async def delete_doc(doctype: str, name: str) -> dict:
         """Delete an ERPNext document.
 
@@ -190,7 +220,7 @@ def build_erpnext_tools(
         return {"message": f"Deleted {doctype} {name}"}
 
     # ------------------------------------------------------------------
-    @tool
+    @tool(name=_make_tool_name(tool_name, "submit_doc"))
     async def submit_doc(doctype: str, name: str) -> dict:
         """Submit an ERPNext document (sets docstatus to 1, triggers submit hooks).
 
@@ -205,7 +235,7 @@ def build_erpnext_tools(
         return result
 
     # ------------------------------------------------------------------
-    @tool
+    @tool(name=_make_tool_name(tool_name, "cancel_doc"))
     async def cancel_doc(doctype: str, name: str) -> dict:
         """Cancel an ERPNext document (sets docstatus to 2).
 
@@ -220,7 +250,7 @@ def build_erpnext_tools(
         return result
 
     # ------------------------------------------------------------------
-    @tool
+    @tool(name=_make_tool_name(tool_name, "amend_doc"))
     async def amend_doc(doctype: str, name: str) -> dict:
         """Amend a submitted/cancelled ERPNext document, creating a new draft.
 
@@ -238,7 +268,7 @@ def build_erpnext_tools(
         return result
 
     # ------------------------------------------------------------------
-    @tool
+    @tool(name=_make_tool_name(tool_name, "get_doctype_meta"))
     async def get_doctype_meta(doctype: str) -> list[dict]:
         """Get field definitions for a DocType so the agent knows which
         fields are mandatory, valid Link/Select options, etc.
@@ -264,7 +294,7 @@ def build_erpnext_tools(
         return results
 
     # ------------------------------------------------------------------
-    @tool
+    @tool(name=_make_tool_name(tool_name, "call_method"))
     async def call_method(
         method: str,
         args: dict | None = None,
@@ -307,7 +337,7 @@ def build_erpnext_tools(
         for fi in file_infos:
             _file_lookup[fi["original_filename"].lower()] = fi
 
-        @tool
+        @tool(name=_make_tool_name(tool_name, "upload_file"))
         async def upload_file(
             filename: str,
             doctype: str | None = None,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ph-agent-hub-frontend",
   "private": true,
-  "version": "1.18.0",
+  "version": "1.18.1",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000 --host",


### PR DESCRIPTION


The changes address the issue where the DeepSeek API occasionally returns an empty response stream after tool auto-selection. This is primarily due to multiple ERPNext tools from different tenants causing context overload. The auto-selection logic has been updated to cap instance-type tools, ensuring only the highest-scored tool per type is selected. Additionally, a step limit guard has been implemented to prevent runaway agents that loop indefinitely on tool results.



## Related Issue



Closes #317



## Type of Change



- [x] Bug fix (non-breaking change that fixes an issue)



## Testing



- [x] Tested locally with Docker Compose (dev)

- [x] Backend tests pass (`pytest backend/tests/`)

- [x] Frontend builds without errors (`npm run build`)

- [x] Manual testing completed (verified tool selection and response handling)



## Checklist



- [x] My code follows the coding conventions of this project

- [x] I have self-reviewed my own code

- [x] I have commented complex code sections, particularly in hard-to-understand areas

- [x] I have updated the documentation (`docs/`) if my change affects user-facing behaviour or configuration

- [x] My changes generate no new warnings or errors

- [x] New and existing tests pass locally



## Screenshots (if applicable)



## Additional Notes



```

