### PR TITLE
## Description

### DIFF
--- a/backend/src/agents/runner.py
+++ b/backend/src/agents/runner.py
@@ -2027,12 +2027,14 @@ async def _build_tool_callables(
         return await build_calendar_tools(
             tool.config or {},
             user_credentials=user_credentials,
+            db=db,
         )
     elif tool.type == "tasks":
         from ..tools.tasks import build_tasks_tools
         return build_tasks_tools(
             tool.config or {},
             user_credentials=user_credentials,
+            db=db,
         )
     elif tool.type == "image_generation":
         from ..tools.image_generation import build_image_generation_tools
@@ -2047,6 +2049,7 @@ async def _build_tool_callables(
         return build_email_tools(
             tool.config or {},
             user_credentials=user_credentials,
+            db=db,
         )
     elif tool.type == "mcp":
         from ..tools.mcp import build_mcp_tool_callables

--- a/backend/src/core/oauth.py
+++ b/backend/src/core/oauth.py
@@ -160,11 +160,22 @@ async def refresh_microsoft_token(
     client_id: str,
     client_secret: str,
 ) -> dict[str, Any] | None:
-    """Refresh an expired Microsoft access token using msal.
+    """Refresh an expired Microsoft access token.
+
+    Uses MSAL first with the ``.default`` scope so the refreshed token
+    retains all statically configured permissions.  Falls back to a
+    direct HTTP POST to the Microsoft token endpoint if MSAL fails.
+
+    Also captures a new ``refresh_token`` if Microsoft rotates it
+    (common with certain tenant configurations).
 
     Returns:
-        Dict with new access_token, expires_at, or None on failure.
+        Dict with new access_token, expires_at, and optionally
+        refresh_token (if Microsoft issued a new one), or None on failure.
     """
+    MICROSOFT_SCOPE = "https://graph.microsoft.com/.default"
+
+    # --- Attempt 1: MSAL ---
     try:
         from msal import ConfidentialClientApplication
 
@@ -173,18 +184,61 @@ async def refresh_microsoft_token(
             client_credential=client_secret,
         )
 
-        result = app.acquire_token_by_refresh_token(refresh_token, scopes=[])
+        result = app.acquire_token_by_refresh_token(
+            refresh_token,
+            scopes=[MICROSOFT_SCOPE],
+        )
 
-        if "access_token" not in result:
-            logger.warning("Microsoft token refresh failed: %s", result.get("error_description", "unknown"))
-            return None
+        if "access_token" in result:
+            tokens: dict[str, Any] = {
+                "access_token": result["access_token"],
+                "expires_at": int(time.time()) + result.get("expires_in", 3600),
+            }
+            # Microsoft may rotate the refresh token — capture if present
+            new_rt = result.get("refresh_token")
+            if new_rt:
+                tokens["refresh_token"] = new_rt
+            return tokens
 
-        return {
-            "access_token": result["access_token"],
-            "expires_at": int(time.time()) + result.get("expires_in", 3600),
-        }
+        logger.warning(
+            "MSAL refresh failed (%s); trying HTTP fallback",
+            result.get("error_description", "unknown"),
+        )
     except Exception as exc:
-        logger.error("Microsoft token refresh error: %s", exc)
+        logger.warning("MSAL refresh error (%s); trying HTTP fallback", exc)
+
+    # --- Attempt 2: Direct HTTP POST fallback ---
+    try:
+        async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
+            response = await client.post(
+                MICROSOFT_TOKEN_URL,
+                data={
+                    "refresh_token": refresh_token,
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                    "grant_type": "refresh_token",
+                    "scope": MICROSOFT_SCOPE,
+                },
+            )
+            if response.status_code != 200:
+                logger.warning(
+                    "Microsoft token refresh (HTTP) failed: HTTP %d",
+                    response.status_code,
+                )
+                return None
+
+            data = response.json()
+
+        tokens: dict[str, Any] = {
+            "access_token": data.get("access_token", ""),
+            "expires_at": int(time.time()) + data.get("expires_in", 3600),
+        }
+        new_rt = data.get("refresh_token")
+        if new_rt:
+            tokens["refresh_token"] = new_rt
+        return tokens
+    except Exception as exc:
+        logger.error("Microsoft token refresh (HTTP) error: %s", exc)
         return None
 
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -108,7 +108,7 @@ async def lifespan(app: FastAPI):
     demo_cleanup_task.cancel()
 
 
-app = FastAPI(title="PH Agent Hub", version="1.18.2", lifespan=lifespan)
+app = FastAPI(title="PH Agent Hub", version="1.18.3", lifespan=lifespan)
 
 # ---------------------------------------------------------------------------
 # Middleware

--- a/backend/src/services/credential_service.py
+++ b/backend/src/services/credential_service.py
@@ -303,8 +303,16 @@ async def _do_test_connection(
     elif provider in ("gmail", "outlook", "google", "microsoft"):
         result = await _test_oauth_connection(provider, tool_type, tokens)
 
-        # If expired and we have a refresh_token, try refreshing
-        if result.get("ok") is False and "expired" in result.get("message", "").lower():
+        # If expired or permissions error, try refreshing the token
+        should_retry = (
+            result.get("ok") is False
+            and (
+                "expired" in result.get("message", "").lower()
+                or "permissions" in result.get("message", "").lower()
+                or "403" in result.get("message", "")
+            )
+        )
+        if should_retry:
             refresh_token = tokens.get("refresh_token", "")
             if refresh_token:
                 # Get client credentials from settings
@@ -317,10 +325,14 @@ async def _do_test_connection(
 
                 new_tokens = await refresh_oauth_token(tokens, provider, client_id, client_secret)
                 if new_tokens:
-                    # Update stored tokens with new access_token and expires_at
+                    # Update stored tokens
                     tokens["access_token"] = new_tokens.get("access_token", tokens.get("access_token", ""))
                     if "expires_at" in new_tokens:
                         tokens["expires_at"] = new_tokens["expires_at"]
+                    # Persist rotated refresh_token if Microsoft issued one
+                    new_rt = new_tokens.get("refresh_token")
+                    if new_rt:
+                        tokens["refresh_token"] = new_rt
                     credential.oauth_tokens = json.dumps(tokens)
                     if db:
                         await db.commit()
@@ -423,18 +435,41 @@ async def _test_oauth_connection(provider: str, tool_type: str, tokens: dict) ->
         elif provider in ("outlook", "microsoft"):
             import httpx
 
+            # Pick the right test endpoint based on tool type
+            if tool_type == "calendar":
+                test_url = "https://graph.microsoft.com/v1.0/me/events?$top=1"
+                api_label = "Calendar"
+            elif tool_type == "tasks":
+                test_url = "https://graph.microsoft.com/v1.0/me/todo/lists"
+                api_label = "Tasks"
+            else:
+                test_url = "https://graph.microsoft.com/v1.0/me/messages?$top=1"
+                api_label = "Email"
+
             async with httpx.AsyncClient(timeout=10) as client:
                 resp = await client.get(
-                    "https://graph.microsoft.com/v1.0/me",
+                    test_url,
                     headers={"Authorization": f"Bearer {access_token}"},
                 )
                 if resp.status_code == 200:
                     data = resp.json()
-                    return {"ok": True, "message": f"Connected as {data.get('mail', data.get('userPrincipalName', 'unknown'))}"}
+                    if tool_type == "calendar":
+                        items = data.get("value", [])
+                        return {"ok": True, "message": f"Connected — {len(items)} upcoming event(s) found"}
+                    elif tool_type == "tasks":
+                        items = data.get("value", [])
+                        return {"ok": True, "message": f"Connected — {len(items)} task list(s) found"}
+                    else:
+                        items = data.get("value", [])
+                        user = data.get("from", {})
+                        sender = data.get("from", {}).get("emailAddress", {}).get("address", "") if data.get("from") else ""
+                        return {"ok": True, "message": f"Connected. Found {len(items)} email(s)."}
                 elif resp.status_code == 401:
                     return {"ok": False, "message": "Token expired. Reconnect the account."}
+                elif resp.status_code == 403:
+                    return {"ok": False, "message": f"Token lacks {api_label} permissions (HTTP 403). Try reconnecting the account."}
                 else:
-                    return {"ok": False, "message": f"Microsoft Graph error: HTTP {resp.status_code}"}
+                    return {"ok": False, "message": f"Microsoft Graph ({api_label}) error: HTTP {resp.status_code}"}
 
     except Exception as exc:
         return {"ok": False, "message": f"Connection test failed: {exc}"}

--- a/backend/src/tools/_oauth_refresh.py
+++ b/backend/src/tools/_oauth_refresh.py
@@ -8,8 +8,53 @@
 
 import json
 import logging
+from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+async def ensure_fresh_token(
+    tokens: dict,
+    provider: str,
+    tool_name: str = "Tool",
+    credential_orm: object | None = None,
+    tokens_dict: dict | None = None,
+    db: object | None = None,
+) -> bool:
+    """Check token expiry and refresh proactively before an API call.
+
+    Uses ``is_token_expired`` (5-minute buffer) to decide whether to
+    refresh.  This avoids making a doomed API call just to get a 401.
+
+    Args:
+        tokens: Dict with refresh_token, access_token, expires_at.
+        provider: "gmail", "google", "outlook", or "microsoft".
+        tool_name: Human-readable label for log messages.
+        credential_orm: Optional ``UserToolCredential`` ORM object to
+            persist the refreshed token to the database.
+        tokens_dict: The original tokens dict to persist.
+        db: Optional async DB session for persisting refreshed tokens.
+
+    Returns:
+        True if the token is fresh (already valid or successfully
+        refreshed), False otherwise.
+    """
+    from ..core.oauth import is_token_expired
+
+    if not is_token_expired(tokens):
+        return True
+
+    refresh_token = tokens.get("refresh_token", "")
+    if not refresh_token:
+        return False
+
+    result = await refresh_token_if_expired(
+        tokens, provider, tool_name,
+        credential_orm=credential_orm,
+        tokens_dict=tokens_dict,
+        db=db,
+    )
+    return result is not None
 
 
 async def refresh_token_if_expired(
@@ -18,12 +63,13 @@ async def refresh_token_if_expired(
     tool_name: str = "Tool",
     credential_orm: object | None = None,
     tokens_dict: dict | None = None,
+    db: object | None = None,
 ) -> dict | None:
     """Try to refresh an OAuth token.  Modifies ``tokens`` in-place.
 
-    When ``credential_orm`` and ``tokens_dict`` are provided, persists the
-    refreshed tokens back to the database so subsequent sessions don't
-    need to re-refresh.
+    When ``credential_orm``, ``tokens_dict``, and ``db`` are provided,
+    persists the refreshed tokens back to the database so subsequent
+    sessions don't need to re-refresh.
 
     Args:
         tokens: Dict with refresh_token, access_token, expires_at.
@@ -33,6 +79,7 @@ async def refresh_token_if_expired(
             persist the refreshed token to the database.
         tokens_dict: The original tokens dict (from ``_parse_credential``)
             to persist. Usually the same as ``tokens``.
+        db: Optional async DB session for persisting refreshed tokens.
 
     Returns:
         The updated tokens dict on success, or None on failure.
@@ -56,6 +103,12 @@ async def refresh_token_if_expired(
         if result:
             tokens["access_token"] = result.get("access_token", tokens.get("access_token", ""))
             tokens["expires_at"] = result.get("expires_at", tokens.get("expires_at", 0))
+
+            # Handle refresh token rotation — Microsoft may issue a new one
+            new_rt = result.get("refresh_token")
+            if new_rt:
+                tokens["refresh_token"] = new_rt
+
             logger.info("%s token refreshed successfully", tool_name)
 
             # Sync refreshed values to tokens_dict when it's a different dict
@@ -64,11 +117,28 @@ async def refresh_token_if_expired(
             if tokens_dict is not None and tokens_dict is not tokens:
                 tokens_dict["access_token"] = tokens["access_token"]
                 tokens_dict["expires_at"] = tokens["expires_at"]
+                if new_rt:
+                    tokens_dict["refresh_token"] = new_rt
 
-            # Persist refreshed tokens to the ORM object if available
+            # Persist refreshed tokens to the ORM object + commit
             if credential_orm is not None and tokens_dict is not None:
                 credential_orm.oauth_tokens = json.dumps(tokens_dict)
-                logger.info("%s token persisted to database", tool_name)
+                if db is not None:
+                    try:
+                        db.add(credential_orm)
+                        await db.commit()
+                        logger.info("%s token persisted to database (committed)", tool_name)
+                    except Exception:
+                        logger.warning(
+                            "%s token DB commit failed (tokens still fresh in-memory)",
+                            tool_name,
+                            exc_info=True,
+                        )
+                else:
+                    logger.info(
+                        "%s token set on ORM object but no db session to commit",
+                        tool_name,
+                    )
 
             return tokens
     except Exception:

--- a/backend/src/tools/calendar.py
+++ b/backend/src/tools/calendar.py
@@ -16,7 +16,7 @@ from urllib.parse import quote
 import httpx
 from agent_framework import tool
 
-from ._oauth_refresh import refresh_token_if_expired
+from ._oauth_refresh import ensure_fresh_token, refresh_token_if_expired
 
 logger = logging.getLogger(__name__)
 
@@ -196,6 +196,7 @@ async def _detect_timezone(provider: str, access_token: str) -> str | None:
 async def build_calendar_tools(
     tool_config: dict | None = None,
     user_credentials: list | None = None,
+    db: object | None = None,
 ) -> list:
     """Return a list of MAF @tool-decorated async functions for calendar.
 
@@ -210,6 +211,7 @@ async def build_calendar_tools(
             - ``calendar_id`` (str): Calendar ID (default "primary")
             - ``timezone`` (str): Timezone for events (default "UTC")
         user_credentials: List of ``UserToolCredential`` ORM rows.
+        db: Optional async DB session for persisting refreshed tokens.
 
     Returns:
         A list of callables ready to pass to ``Agent(tools=...)``.
@@ -329,7 +331,7 @@ async def build_calendar_tools(
                         if user_creds_map and user_creds_map.get("refresh_token"):
                             refreshed = await refresh_token_if_expired(
                                 user_creds_map, user_creds_map["provider"], "Calendar",
-                                credential_orm=_credential_orm, tokens_dict=_tokens_dict,
+                                credential_orm=_credential_orm, tokens_dict=_tokens_dict, db=db,
                             )
                             if refreshed:
                                 active_token = user_creds_map["access_token"]
@@ -427,7 +429,7 @@ async def build_calendar_tools(
                         if user_creds_map and user_creds_map.get("refresh_token"):
                             refreshed = await refresh_token_if_expired(
                                 user_creds_map, user_creds_map["provider"], "Calendar",
-                                credential_orm=_credential_orm, tokens_dict=_tokens_dict,
+                                credential_orm=_credential_orm, tokens_dict=_tokens_dict, db=db,
                             )
                             if refreshed:
                                 active_token = user_creds_map["access_token"]
@@ -603,7 +605,7 @@ async def build_calendar_tools(
                         if user_creds_map and user_creds_map.get("refresh_token"):
                             refreshed = await refresh_token_if_expired(
                                 user_creds_map, user_creds_map["provider"], "Calendar",
-                                credential_orm=_credential_orm, tokens_dict=_tokens_dict,
+                                credential_orm=_credential_orm, tokens_dict=_tokens_dict, db=db,
                             )
                             if refreshed:
                                 active_token = user_creds_map["access_token"]
@@ -687,7 +689,7 @@ async def build_calendar_tools(
                         if user_creds_map and user_creds_map.get("refresh_token"):
                             refreshed = await refresh_token_if_expired(
                                 user_creds_map, user_creds_map["provider"], "Calendar",
-                                credential_orm=_credential_orm, tokens_dict=_tokens_dict,
+                                credential_orm=_credential_orm, tokens_dict=_tokens_dict, db=db,
                             )
                             if refreshed:
                                 active_token = user_creds_map["access_token"]
@@ -880,7 +882,7 @@ async def build_calendar_tools(
                         if user_creds_map and user_creds_map.get("refresh_token"):
                             refreshed = await refresh_token_if_expired(
                                 user_creds_map, user_creds_map["provider"], "Calendar",
-                                credential_orm=_credential_orm, tokens_dict=_tokens_dict,
+                                credential_orm=_credential_orm, tokens_dict=_tokens_dict, db=db,
                             )
                             if refreshed:
                                 active_token = user_creds_map["access_token"]
@@ -919,7 +921,7 @@ async def build_calendar_tools(
                         if user_creds_map and user_creds_map.get("refresh_token"):
                             refreshed = await refresh_token_if_expired(
                                 user_creds_map, user_creds_map["provider"], "Calendar",
-                                credential_orm=_credential_orm, tokens_dict=_tokens_dict,
+                                credential_orm=_credential_orm, tokens_dict=_tokens_dict, db=db,
                             )
                             if refreshed:
                                 active_token = user_creds_map["access_token"]
@@ -1023,7 +1025,7 @@ async def build_calendar_tools(
                         if user_creds_map and user_creds_map.get("refresh_token"):
                             refreshed = await refresh_token_if_expired(
                                 user_creds_map, user_creds_map["provider"], "Calendar",
-                                credential_orm=_credential_orm, tokens_dict=_tokens_dict,
+                                credential_orm=_credential_orm, tokens_dict=_tokens_dict, db=db,
                             )
                             if refreshed:
                                 active_token = user_creds_map["access_token"]
@@ -1075,7 +1077,7 @@ async def build_calendar_tools(
                         if user_creds_map and user_creds_map.get("refresh_token"):
                             refreshed = await refresh_token_if_expired(
                                 user_creds_map, user_creds_map["provider"], "Calendar",
-                                credential_orm=_credential_orm, tokens_dict=_tokens_dict,
+                                credential_orm=_credential_orm, tokens_dict=_tokens_dict, db=db,
                             )
                             if refreshed:
                                 active_token = user_creds_map["access_token"]

--- a/backend/src/tools/email.py
+++ b/backend/src/tools/email.py
@@ -22,6 +22,7 @@ from typing import Any
 import httpx
 from agent_framework import tool
 
+from ._oauth_refresh import ensure_fresh_token as _ensure_fresh_token
 from ._oauth_refresh import refresh_token_if_expired as _refresh_token_if_expired
 
 logger = logging.getLogger(__name__)
@@ -147,6 +148,7 @@ def _parse_credential(cred: Any) -> tuple[str, dict, dict, str | None]:
 def build_email_tools(
     tool_config: dict | None = None,
     user_credentials: list | None = None,
+    db: object | None = None,
 ) -> list:
     """Return a list of MAF @tool-decorated async functions for email.
 
@@ -156,6 +158,7 @@ def build_email_tools(
         tool_config: ``Tool.config`` JSON dict (tenant-level).
         user_credentials: List of ``UserToolCredential`` ORM rows for
             per-user email accounts.
+        db: Optional async DB session for persisting refreshed tokens.
 
     Returns:
         A list of MAF tool callables.
@@ -166,6 +169,13 @@ def build_email_tools(
     from_email: str = creds.get("from_email", "")
     from_name: str = creds.get("from_name", "")
     allowed_recipients: list[str] = config.get("allowed_recipients", [])
+
+    async def _maybe_refresh(tk, cp, active_cred):
+        """Refresh token if expired; persist if db is available."""
+        return await _refresh_token_if_expired(
+            tk, cp, "Email",
+            credential_orm=active_cred, tokens_dict=tk, db=db,
+        )
 
     # ------------------------------------------------------------------
     @tool
@@ -196,16 +206,18 @@ def build_email_tools(
         if active_cred:
             cp, cd, tk, ce = _parse_credential(active_cred)
             if cp in ("gmail", "google") and tk.get("access_token"):
-                result = await _send_via_gmail_api(to, subject, body, cc, is_html, tk["access_token"])
+                await _ensure_fresh_token(tk, cp, "Email", credential_orm=active_cred, tokens_dict=tk, db=db)
+                result = await _send_via_gmail_api(to, subject, body, cc, is_html, tk.get("access_token", ""))
                 if "expired" in result.get("error", "").lower():
-                    refreshed = await _refresh_token_if_expired(tk, cp, "Gmail")
+                    refreshed = await _maybe_refresh(tk, cp, active_cred)
                     if refreshed:
                         result = await _send_via_gmail_api(to, subject, body, cc, is_html, tk["access_token"])
                 return result
             elif cp in ("outlook", "microsoft") and tk.get("access_token"):
-                result = await _send_via_graph_api(to, subject, body, cc, is_html, tk["access_token"])
+                await _ensure_fresh_token(tk, cp, "Email", credential_orm=active_cred, tokens_dict=tk, db=db)
+                result = await _send_via_graph_api(to, subject, body, cc, is_html, tk.get("access_token", ""))
                 if "expired" in result.get("error", "").lower():
-                    refreshed = await _refresh_token_if_expired(tk, cp, "Outlook")
+                    refreshed = await _maybe_refresh(tk, cp, active_cred)
                     if refreshed:
                         result = await _send_via_graph_api(to, subject, body, cc, is_html, tk["access_token"])
                 return result
@@ -288,16 +300,18 @@ def build_email_tools(
         cp, cd, tk, _ = _parse_credential(active_cred)
 
         if cp in ("gmail", "google") and tk.get("access_token"):
-            result = await _read_gmail_api(tk["access_token"], limit, "is:unread " if unread_only else "")
+            await _ensure_fresh_token(tk, cp, "Email", credential_orm=active_cred, tokens_dict=tk, db=db)
+            result = await _read_gmail_api(tk.get("access_token", ""), limit, "is:unread " if unread_only else "")
             if "expired" in result.get("error", "").lower():
-                refreshed = await _refresh_token_if_expired(tk, cp, "Gmail")
+                refreshed = await _maybe_refresh(tk, cp, active_cred)
                 if refreshed:
                     result = await _read_gmail_api(tk["access_token"], limit, "is:unread " if unread_only else "")
             return result
         elif cp in ("outlook", "microsoft") and tk.get("access_token"):
-            result = await _read_outlook_api(tk["access_token"], limit, unread_only)
+            await _ensure_fresh_token(tk, cp, "Email", credential_orm=active_cred, tokens_dict=tk, db=db)
+            result = await _read_outlook_api(tk.get("access_token", ""), limit, unread_only)
             if "expired" in result.get("error", "").lower():
-                refreshed = await _refresh_token_if_expired(tk, cp, "Outlook")
+                refreshed = await _maybe_refresh(tk, cp, active_cred)
                 if refreshed:
                     result = await _read_outlook_api(tk["access_token"], limit, unread_only)
             return result
@@ -337,16 +351,18 @@ def build_email_tools(
         cp, cd, tk, _ = _parse_credential(active_cred)
 
         if cp in ("gmail", "google") and tk.get("access_token"):
-            result = await _read_gmail_api(tk["access_token"], limit, query)
+            await _ensure_fresh_token(tk, cp, "Email", credential_orm=active_cred, tokens_dict=tk, db=db)
+            result = await _read_gmail_api(tk.get("access_token", ""), limit, query)
             if "expired" in result.get("error", "").lower():
-                refreshed = await _refresh_token_if_expired(tk, cp, "Gmail")
+                refreshed = await _maybe_refresh(tk, cp, active_cred)
                 if refreshed:
                     result = await _read_gmail_api(tk["access_token"], limit, query)
             return result
         elif cp in ("outlook", "microsoft") and tk.get("access_token"):
-            result = await _search_outlook_api(tk["access_token"], query, limit)
+            await _ensure_fresh_token(tk, cp, "Email", credential_orm=active_cred, tokens_dict=tk, db=db)
+            result = await _search_outlook_api(tk.get("access_token", ""), query, limit)
             if "expired" in result.get("error", "").lower():
-                refreshed = await _refresh_token_if_expired(tk, cp, "Outlook")
+                refreshed = await _maybe_refresh(tk, cp, active_cred)
                 if refreshed:
                     result = await _search_outlook_api(tk["access_token"], query, limit)
             return result

--- a/backend/src/tools/tasks.py
+++ b/backend/src/tools/tasks.py
@@ -14,7 +14,7 @@ from typing import Any
 import httpx
 from agent_framework import tool
 
-from ._oauth_refresh import refresh_token_if_expired
+from ._oauth_refresh import ensure_fresh_token, refresh_token_if_expired
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +61,7 @@ def _parse_credential(cred) -> tuple[str, dict, dict, str | None]:
 def build_tasks_tools(
     tool_config: dict | None = None,
     user_credentials: list | None = None,
+    db: object | None = None,
 ) -> list:
     """Return a list of MAF @tool-decorated async functions for tasks.
 
@@ -69,11 +70,19 @@ def build_tasks_tools(
     Args:
         tool_config: ``Tool.config`` JSON dict (reserved for future use).
         user_credentials: List of ``UserToolCredential`` ORM rows.
+        db: Optional async DB session for persisting refreshed tokens.
 
     Returns:
         A list of MAF tool callables.
     """
     config = tool_config or {}
+
+    async def _maybe_refresh(tokens, provider, cred):
+        """Refresh token if expired; persist if db is available."""
+        return await refresh_token_if_expired(
+            tokens, provider, "Tasks",
+            credential_orm=cred, tokens_dict=tokens, db=db,
+        )
 
     # ------------------------------------------------------------------
     @tool
@@ -99,17 +108,20 @@ def build_tasks_tools(
         if not access_token:
             return {"error": "Access token not available. Reconnect account.", "task_lists": [], "total": 0}
 
+        # Proactive refresh if token is about to expire
+        await ensure_fresh_token(tokens, provider, "Tasks", credential_orm=cred, tokens_dict=tokens, db=db)
+
         if provider in ("gmail", "google"):
-            result = await _list_google_task_lists(access_token)
+            result = await _list_google_task_lists(tokens.get("access_token", ""))
             if "Token expired" in result.get("error", ""):
-                refreshed = await refresh_token_if_expired(tokens, provider, "Tasks", credential_orm=cred, tokens_dict=tokens)
+                refreshed = await _maybe_refresh(tokens, provider, cred)
                 if refreshed:
                     result = await _list_google_task_lists(tokens["access_token"])
             return result
         elif provider in ("outlook", "microsoft"):
-            result = await _list_microsoft_task_lists(access_token)
+            result = await _list_microsoft_task_lists(tokens.get("access_token", ""))
             if "Token expired" in result.get("error", ""):
-                refreshed = await refresh_token_if_expired(tokens, provider, "Tasks", credential_orm=cred, tokens_dict=tokens)
+                refreshed = await _maybe_refresh(tokens, provider, cred)
                 if refreshed:
                     result = await _list_microsoft_task_lists(tokens["access_token"])
             return result
@@ -149,17 +161,20 @@ def build_tasks_tools(
         if not access_token:
             return {"error": "Access token not available.", "tasks": [], "total": 0}
 
+        # Proactive refresh if token is about to expire
+        await ensure_fresh_token(tokens, provider, "Tasks", credential_orm=cred, tokens_dict=tokens, db=db)
+
         if provider in ("gmail", "google"):
-            result = await _list_google_tasks(access_token, list_name, include_completed, limit)
+            result = await _list_google_tasks(tokens.get("access_token", ""), list_name, include_completed, limit)
             if "Token expired" in result.get("error", ""):
-                refreshed = await refresh_token_if_expired(tokens, provider, "Tasks", credential_orm=cred, tokens_dict=tokens)
+                refreshed = await _maybe_refresh(tokens, provider, cred)
                 if refreshed:
                     result = await _list_google_tasks(tokens["access_token"], list_name, include_completed, limit)
             return result
         elif provider in ("outlook", "microsoft"):
-            result = await _list_microsoft_tasks(access_token, list_name, include_completed, limit)
+            result = await _list_microsoft_tasks(tokens.get("access_token", ""), list_name, include_completed, limit)
             if "Token expired" in result.get("error", ""):
-                refreshed = await refresh_token_if_expired(tokens, provider, "Tasks", credential_orm=cred, tokens_dict=tokens)
+                refreshed = await _maybe_refresh(tokens, provider, cred)
                 if refreshed:
                     result = await _list_microsoft_tasks(tokens["access_token"], list_name, include_completed, limit)
             return result
@@ -201,17 +216,20 @@ def build_tasks_tools(
         if not access_token:
             return {"error": "Access token not available.", "status": "error"}
 
+        # Proactive refresh if token is about to expire
+        await ensure_fresh_token(tokens, provider, "Tasks", credential_orm=cred, tokens_dict=tokens, db=db)
+
         if provider in ("gmail", "google"):
-            result = await _create_google_task(access_token, title.strip(), list_name, due_date, notes)
+            result = await _create_google_task(tokens.get("access_token", ""), title.strip(), list_name, due_date, notes)
             if "Token expired" in result.get("error", ""):
-                refreshed = await refresh_token_if_expired(tokens, provider, "Tasks", credential_orm=cred, tokens_dict=tokens)
+                refreshed = await _maybe_refresh(tokens, provider, cred)
                 if refreshed:
                     result = await _create_google_task(tokens["access_token"], title.strip(), list_name, due_date, notes)
             return result
         elif provider in ("outlook", "microsoft"):
-            result = await _create_microsoft_task(access_token, title.strip(), list_name, due_date, notes)
+            result = await _create_microsoft_task(tokens.get("access_token", ""), title.strip(), list_name, due_date, notes)
             if "Token expired" in result.get("error", ""):
-                refreshed = await refresh_token_if_expired(tokens, provider, "Tasks", credential_orm=cred, tokens_dict=tokens)
+                refreshed = await _maybe_refresh(tokens, provider, cred)
                 if refreshed:
                     result = await _create_microsoft_task(tokens["access_token"], title.strip(), list_name, due_date, notes)
             return result
@@ -256,22 +274,23 @@ def build_tasks_tools(
         if not access_token:
             return {"error": "Access token not available.", "status": "error"}
 
+        # Proactive refresh if token is about to expire
+        await ensure_fresh_token(tokens, provider, "Tasks", credential_orm=cred, tokens_dict=tokens, db=db)
+
         if provider in ("gmail", "google"):
-            result = await _update_google_task(access_token, task_id, title, completed, due_date, notes, list_name)
+            result = await _update_google_task(tokens.get("access_token", ""), task_id, title, completed, due_date, notes, list_name)
             if "Token expired" in result.get("error", ""):
-                refreshed = await refresh_token_if_expired(tokens, provider, "Tasks", credential_orm=cred, tokens_dict=tokens)
+                refreshed = await _maybe_refresh(tokens, provider, cred)
                 if refreshed:
                     result = await _update_google_task(tokens["access_token"], task_id, title, completed, due_date, notes, list_name)
             return result
         elif provider in ("outlook", "microsoft"):
-            result = await _update_microsoft_task(access_token, task_id, title, completed, due_date, notes, list_name)
+            result = await _update_microsoft_task(tokens.get("access_token", ""), task_id, title, completed, due_date, notes, list_name)
             if "Token expired" in result.get("error", ""):
-                refreshed = await refresh_token_if_expired(tokens, provider, "Tasks", credential_orm=cred, tokens_dict=tokens)
+                refreshed = await _maybe_refresh(tokens, provider, cred)
                 if refreshed:
                     result = await _update_microsoft_task(tokens["access_token"], task_id, title, completed, due_date, notes, list_name)
             return result
-        else:
-            return {"error": f"Provider '{provider}' not supported."}
 
     # ------------------------------------------------------------------
     @tool
@@ -321,17 +340,20 @@ def build_tasks_tools(
         if not access_token:
             return {"error": "Access token not available.", "status": "error"}
 
+        # Proactive refresh if token is about to expire
+        await ensure_fresh_token(tokens, provider, "Tasks", credential_orm=cred, tokens_dict=tokens, db=db)
+
         if provider in ("gmail", "google"):
-            result = await _delete_google_task(access_token, task_id, list_name)
+            result = await _delete_google_task(tokens.get("access_token", ""), task_id, list_name)
             if "Token expired" in result.get("error", ""):
-                refreshed = await refresh_token_if_expired(tokens, provider, "Tasks", credential_orm=cred, tokens_dict=tokens)
+                refreshed = await _maybe_refresh(tokens, provider, cred)
                 if refreshed:
                     result = await _delete_google_task(tokens["access_token"], task_id, list_name)
             return result
         elif provider in ("outlook", "microsoft"):
-            result = await _delete_microsoft_task(access_token, task_id, list_name)
+            result = await _delete_microsoft_task(tokens.get("access_token", ""), task_id, list_name)
             if "Token expired" in result.get("error", ""):
-                refreshed = await refresh_token_if_expired(tokens, provider, "Tasks", credential_orm=cred, tokens_dict=tokens)
+                refreshed = await _maybe_refresh(tokens, provider, cred)
                 if refreshed:
                     result = await _delete_microsoft_task(tokens["access_token"], task_id, list_name)
             return result

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ph-agent-hub-frontend",
   "private": true,
-  "version": "1.18.2",
+  "version": "1.18.3",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000 --host",


### PR DESCRIPTION


The changes address the issue of expired Outlook account tokens by enhancing the token refresh mechanism. The implementation now attempts to refresh the token using MSAL and falls back to a direct HTTP POST if necessary. Additionally, the connection test for Outlook accounts has been improved to handle permissions errors and provide clearer messages.



## Related Issue



Fixes #323



## Type of Change



- [x] Bug fix (non-breaking change that fixes an issue)



## Testing



- [x] Tested locally with Docker Compose (dev)

- [x] Backend tests pass (`pytest backend/tests/`)

- [x] Manual testing completed (tested token refresh and connection for Outlook accounts)



## Checklist



- [x] My code follows the coding conventions of this project

- [x] I have self-reviewed my own code

- [x] I have commented complex code sections, particularly in hard-to-understand areas

- [x] I have updated the documentation (`docs/`) if my change affects user-facing behaviour or configuration

- [x] My changes generate no new warnings or errors

- [x] New and existing tests pass locally



## Screenshots (if applicable)



## Additional Notes



None

