### PR TITLE
## Description

### DIFF
--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -120,6 +120,7 @@ class MessageCreate(BaseModel):
     content: str
     file_ids: list[str] | None = None
     temperature: float | None = None
+    session_data: SessionCreate | None = None
 
 
 class MessageResponse(BaseModel):
@@ -192,6 +193,84 @@ class FileUploadResponse(BaseModel):
     """If set, the embedding API was unavailable and TF-IDF fallback was used."""
 
     model_config = {"from_attributes": True}
+
+
+# =============================================================================
+# Lazy session creation (Phase 2 — Issue #329)
+# =============================================================================
+
+
+async def _lazy_create_session(
+    db: AsyncSession,
+    session_id: str,
+    session_data: SessionCreate,
+    current_user: UserORM,
+) -> dict[str, Any]:
+    """Create a permanent session with the given URL *session_id*.
+
+    Called by ``send_message`` when the session doesn't exist yet and the
+    request includes ``session_data`` (first message sent from a pending
+    / lazy frontend session).
+    """
+    # Resolve active tool IDs (mirrors create_session endpoint logic)
+    active_tool_ids = session_data.active_tool_ids
+    if active_tool_ids is None:
+        always_on_ids: set[str] = set()
+        try:
+            pref_result = await db.execute(
+                select(UserToolPreference.tool_id).where(
+                    UserToolPreference.user_id == current_user.id,
+                    UserToolPreference.always_on == True,  # noqa: E712
+                )
+            )
+            always_on_ids = {row[0] for row in pref_result.all()}
+        except Exception:
+            pass
+
+        skill_tool_ids: set[str] = set()
+        if session_data.selected_skill_id:
+            from ..db.orm.skills import SkillAllowedTool
+
+            skill_result = await db.execute(
+                select(SkillAllowedTool.tool_id).where(
+                    SkillAllowedTool.skill_id == session_data.selected_skill_id
+                )
+            )
+            skill_tool_ids = {row[0] for row in skill_result.all()}
+
+        active_tool_ids = list(always_on_ids | skill_tool_ids)
+
+    session = await session_service.create_session(
+        db=db,
+        id=session_id,
+        tenant_id=current_user.tenant_id,
+        user_id=current_user.id,
+        title=session_data.title or "New Chat",
+        is_temporary=False,
+        is_pinned=session_data.is_pinned,
+        selected_template_id=session_data.selected_template_id,
+        selected_skill_id=session_data.selected_skill_id,
+        selected_model_id=session_data.selected_model_id,
+        thinking_enabled=session_data.thinking_enabled,
+        temperature=session_data.temperature,
+        auto_route_enabled=session_data.auto_route_enabled,
+        auto_select_tools=session_data.auto_select_tools,
+    )
+
+    # Activate tools for the new session
+    for tool_id in active_tool_ids:
+        try:
+            await session_service.add_session_tool(
+                db=db,
+                session_id=session.id,
+                tool_id=tool_id,
+                tenant_id=current_user.tenant_id,
+            )
+        except Exception:
+            pass
+
+    await db.refresh(session)
+    return _session_to_dict(session)
 
 
 # =============================================================================
@@ -828,8 +907,21 @@ async def send_message(
     is a Server-Sent Events stream.  Otherwise a plain JSON response is
     returned (Phase 6 backward-compatible path).
     """
-    data = await _load_session(db, session_id)
-    await _require_session_owner(data, current_user)
+    # ---- Lazy session creation (Phase 2 — Issue #329) ------------------
+    # If the session doesn't exist yet and the request includes session
+    # creation data, create it now before processing the first message.
+    try:
+        data = await _load_session(db, session_id)
+        await _require_session_owner(data, current_user)
+    except NotFoundError:
+        if body.session_data is None:
+            raise
+        logger.info(
+            "Lazy-creating session %s on first message", session_id,
+        )
+        data = await _lazy_create_session(
+            db, session_id, body.session_data, current_user,
+        )
 
     # ---- Auto-title: if session still has the default title, use the
     #      first user message as the title.  Set a raw truncated title

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -108,7 +108,7 @@ async def lifespan(app: FastAPI):
     demo_cleanup_task.cancel()
 
 
-app = FastAPI(title="PH Agent Hub", version="1.18.4", lifespan=lifespan)
+app = FastAPI(title="PH Agent Hub", version="1.19.0", lifespan=lifespan)
 
 # ---------------------------------------------------------------------------
 # Middleware

--- a/backend/src/services/session_service.py
+++ b/backend/src/services/session_service.py
@@ -4,11 +4,14 @@
 
 import asyncio
 
-from sqlalchemy import delete, select
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import delete, exists, select
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..core.exceptions import NotFoundError, ValidationError
+from ..db.orm.messages import Message
 from ..db.orm.sessions import Session, SessionActiveTool
 from ..db.orm.tools import Tool
 from ..db.orm.users import User
@@ -26,6 +29,7 @@ async def create_session(
     tenant_id: str,
     user_id: str,
     title: str,
+    id: str | None = None,
     is_temporary: bool = False,
     is_pinned: bool = False,
     selected_template_id: str | None = None,
@@ -37,6 +41,10 @@ async def create_session(
     auto_select_tools: bool = True,
 ) -> Session:
     """Create a new permanent session.
+
+    When *id* is provided the session will be created with that explicit
+    primary key (used by lazy persistence — ``send_message`` creates the
+    session on first message with the URL session ID).
 
     If auto_route_enabled is True, selected_model_id is intentionally kept
     None — the model will be resolved on the first user message by the
@@ -71,6 +79,8 @@ async def create_session(
         auto_route_enabled=auto_route_enabled,
         auto_select_tools=auto_select_tools,
     )
+    if id is not None:
+        session.id = id
     db.add(session)
     await db.commit()
     await db.refresh(session)
@@ -88,21 +98,116 @@ async def list_sessions_for_user(
     user_id: str,
     tenant_id: str,
 ) -> list[Session]:
-    """Return all permanent sessions for a user in their tenant.
+    """Return permanent sessions for a user in their tenant.
 
-    Temporary sessions are excluded from the list.
+    Temporary sessions are excluded from the list.  Empty sessions (zero
+    messages) older than 1 hour are automatically purged.  Recently
+    created empty sessions (< 1 hour) are preserved so the user can still
+    configure them before sending their first message.
     """
+    # Purge abandoned empty sessions older than 1 hour
+    await _purge_empty_sessions(db, user_id, tenant_id)
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
+    has_messages = exists(
+        select(1)
+        .where(
+            Message.session_id == Session.id,
+            Message.is_deleted == False,  # noqa: E712
+        )
+        .correlate(Session)
+    )
+
     stmt = (
         select(Session)
         .where(
             Session.user_id == user_id,
             Session.tenant_id == tenant_id,
             Session.is_temporary == False,  # noqa: E712
+            (
+                has_messages
+                | (Session.created_at >= cutoff)
+            ),
         )
         .order_by(Session.updated_at.desc())
     )
     result = await db.execute(stmt)
     return list(result.scalars().all())
+
+
+async def _purge_empty_sessions(
+    db: AsyncSession,
+    user_id: str,
+    tenant_id: str,
+) -> int:
+    """Hard-delete permanent sessions with zero messages older than 1 hour.
+
+    Returns the number of sessions deleted.  Called automatically by
+    ``list_sessions_for_user()`` — no explicit invocation needed.
+    """
+    from sqlalchemy import delete as sa_delete
+    from ..db.orm.sessions import SessionActiveTool as SAT
+    from ..db.orm.file_uploads import FileUpload
+    from ..db.orm.memory import Memory
+    from ..db.orm.tags import SessionTag
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
+
+    has_messages = exists(
+        select(1)
+        .where(
+            Message.session_id == Session.id,
+            Message.is_deleted == False,  # noqa: E712
+        )
+        .correlate(Session)
+    )
+
+    result = await db.execute(
+        select(Session).where(
+            Session.user_id == user_id,
+            Session.tenant_id == tenant_id,
+            Session.is_temporary == False,  # noqa: E712
+            ~has_messages,
+            Session.created_at < cutoff,
+        )
+    )
+    sessions = list(result.scalars().all())
+    if not sessions:
+        return 0
+
+    session_ids = [s.id for s in sessions]
+
+    # 1. Delete file uploads (MinIO objects + DB rows)
+    from ..services import upload_service
+
+    for sid in session_ids:
+        await upload_service.delete_uploads_for_session(db, sid)
+
+    # 2. Delete session-scoped memories
+    await db.execute(
+        sa_delete(Memory).where(Memory.session_id.in_(session_ids))
+    )
+
+    # 3. Delete active tool associations
+    await db.execute(
+        sa_delete(SAT).where(SAT.session_id.in_(session_ids))
+    )
+
+    # 4. Delete session tags
+    await db.execute(
+        sa_delete(SessionTag).where(
+            SessionTag.session_id.in_(session_ids)
+        )
+    )
+
+    # 5. Delete the sessions themselves
+    for s in sessions:
+        db.expire(s, ["tags"])
+        await db.delete(s)
+
+    await db.commit()
+
+    return len(session_ids)
 
 
 async def list_admin_sessions(

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ph-agent-hub-frontend",
   "private": true,
-  "version": "1.18.4",
+  "version": "1.19.0",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000 --host",

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -73,6 +73,7 @@ interface ChatWindowProps {
   greetingText?: string;
   logoUrl?: string;
   featureFlags?: Record<string, boolean>;
+  isPending?: boolean;
   onSessionUpdate?: (data: Record<string, unknown>) => void;
 }
 
@@ -92,6 +93,7 @@ export function ChatWindow({
   greetingText = "",
   logoUrl = "",
   featureFlags = {},
+  isPending = false,
   onSessionUpdate,
 }: ChatWindowProps) {
   const [inputValue, setInputValue] = useState("");
@@ -109,16 +111,65 @@ export function ChatWindow({
   const [followUpQuestions, setFollowUpQuestions] = useState<string[]>([]);
   const [finalizing, setFinalizing] = useState(false);
 
+  // ---- Pending session local state (Phase 2 — Issue #329) -------------
+  // When the session doesn't exist yet (isPending), we accumulate settings
+  // changes locally and submit them as session_data on the first message.
+  const [pendModelId, setPendModelId] = useState<string | undefined>(undefined);
+  const [pendTemplateId, setPendTemplateId] = useState<string | undefined>(
+    undefined,
+  );
+  const [pendSkillId, setPendSkillId] = useState<string | undefined>(undefined);
+  const [pendAutoRoute, setPendAutoRoute] = useState<boolean>(false);
+  const [pendAutoSelectTools, setPendAutoSelectTools] =
+    useState<boolean>(true);
+  const [pendActiveToolIds, setPendActiveToolIds] = useState<string[]>([]);
+  const [pendingFlag, setPendingFlag] = useState(isPending);
+
+  // When the session gets created (isPending flips), clear pending state.
+  useEffect(() => {
+    if (!isPending) setPendingFlag(false);
+  }, [isPending]);
+
+  // Intercept settings changes when pending — store locally instead of
+  // calling onSessionUpdate (which would 404 since the session doesn't exist).
+  const handleSettingsUpdate = useCallback(
+    (data: Record<string, unknown>) => {
+      if (pendingFlag) {
+        if ("selected_model_id" in data)
+          setPendModelId(data.selected_model_id as string | undefined);
+        if ("selected_template_id" in data)
+          setPendTemplateId(data.selected_template_id as string | undefined);
+        if ("selected_skill_id" in data)
+          setPendSkillId(data.selected_skill_id as string | undefined);
+        if ("auto_route_enabled" in data)
+          setPendAutoRoute(data.auto_route_enabled as boolean);
+        if ("auto_select_tools" in data)
+          setPendAutoSelectTools(data.auto_select_tools as boolean);
+        if ("temperature" in data)
+          setSessionTemperature(data.temperature as number | null);
+        if ("thinking_enabled" in data)
+          setThinkingEnabled(data.thinking_enabled as boolean | null);
+        if ("cross_session_retrieval_enabled" in data)
+          setLocalCrossSessionMemory(
+            data.cross_session_retrieval_enabled as boolean | null,
+          );
+        return;
+      }
+      onSessionUpdate?.(data);
+    },
+    [pendingFlag, onSessionUpdate],
+  );
+
   // Model change handler: "Auto" (__auto__) → null model + auto_route_enabled
   const handleModelChange = useCallback(
     (id: string) => {
       if (id === AUTO_ROUTE_VALUE) {
-        onSessionUpdate?.({ selected_model_id: null, auto_route_enabled: true });
+        handleSettingsUpdate({ selected_model_id: null, auto_route_enabled: true });
       } else {
-        onSessionUpdate?.({ selected_model_id: id, auto_route_enabled: false });
+        handleSettingsUpdate({ selected_model_id: id, auto_route_enabled: false });
       }
     },
-    [onSessionUpdate],
+    [handleSettingsUpdate],
   );
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const prevLoadingRef = useRef(true);
@@ -186,6 +237,7 @@ export function ChatWindow({
 
   const { data: messages, isLoading: loadingMessages } = useQuery({
     queryKey: ["messages", sessionId],
+    enabled: !pendingFlag,
     queryFn: () =>
       demo
         ? getDemoMessages().then((msgs) =>
@@ -249,6 +301,14 @@ export function ChatWindow({
     [modelList, selectedModelId],
   );
   const modelSupportsThinking = selectedModel?.thinking_enabled === true;
+
+  // Auto-select the first available model for pending sessions (no backend
+  // session to provide a default yet — mirrors backend create_session logic).
+  useEffect(() => {
+    if (pendingFlag && modelList && modelList.length > 0 && !pendModelId) {
+      setPendModelId(modelList[0].id);
+    }
+  }, [pendingFlag, modelList, pendModelId]);
 
   // Reset all streaming state when the session changes (mount with new
   // sessionId or fresh mount). This prevents stale streamingContent,
@@ -443,11 +503,27 @@ export function ChatWindow({
     const fileIds = pendingFiles.map((f) => f.file_id);
     setPendingFiles([]);
 
+    // Build session_data for lazy session creation (Phase 2)
+    const sessionData = pendingFlag
+      ? {
+          title: "New Chat",
+          auto_route_enabled: pendAutoRoute,
+          auto_select_tools: pendAutoSelectTools,
+          selected_model_id: pendModelId || null,
+          selected_template_id: pendTemplateId || null,
+          selected_skill_id: pendSkillId || null,
+          thinking_enabled: thinkingEnabled,
+          temperature: sessionTemperature,
+          active_tool_ids: pendActiveToolIds.length > 0 ? pendActiveToolIds : null,
+        }
+      : undefined;
+
     startStream(
       sessionId,
       content,
       fileIds.length > 0 ? fileIds : undefined,
       sessionTemperature ?? undefined,
+      sessionData,
       {
       onToken(token, msgId) {
         setStreamingMessageId(msgId);
@@ -536,7 +612,7 @@ export function ChatWindow({
         }, 3000);
       },
     });
-  }, [inputValue, streaming, sessionId, startStream, queryClient, pendingFiles, editingMsgId]);
+  }, [inputValue, streaming, sessionId, startStream, queryClient, pendingFiles, editingMsgId, pendingFlag, pendModelId, pendTemplateId, pendSkillId, pendAutoRoute, pendAutoSelectTools, pendActiveToolIds, thinkingEnabled, sessionTemperature]);
 
   const handleStop = async () => {
     // Clear the streaming ghost bubble immediately for instant UX.
@@ -839,16 +915,19 @@ export function ChatWindow({
             />
           )}
           <ModelSelector
-            value={autoRouteEnabled && !selectedModelId ? AUTO_ROUTE_VALUE : selectedModelId}
+            value={pendingFlag
+              ? (pendAutoRoute && !pendModelId ? AUTO_ROUTE_VALUE : pendModelId)
+              : (autoRouteEnabled && !selectedModelId ? AUTO_ROUTE_VALUE : selectedModelId)
+            }
             onChange={handleModelChange}
           />
           <TemplateSelector
-            value={selectedTemplateId}
-            onChange={(id) => onSessionUpdate?.({ selected_template_id: id })}
+            value={pendingFlag ? pendTemplateId : selectedTemplateId}
+            onChange={(id) => handleSettingsUpdate({ selected_template_id: id })}
           />
           <SkillSelector
-            value={selectedSkillId}
-            onChange={(id) => onSessionUpdate?.({ selected_skill_id: id })}
+            value={pendingFlag ? pendSkillId : selectedSkillId}
+            onChange={(id) => handleSettingsUpdate({ selected_skill_id: id })}
           />
           <PromptLibrary
             onUse={(resolvedText) => setInputValue(resolvedText)}
@@ -867,7 +946,7 @@ export function ChatWindow({
             title="Cross-session memory"
             onChange={(v) => {
               setLocalCrossSessionMemory(v);
-              onSessionUpdate?.({ cross_session_retrieval_enabled: v });
+              handleSettingsUpdate({ cross_session_retrieval_enabled: v });
             }}
           />
           {modelSupportsThinking && (
@@ -879,7 +958,7 @@ export function ChatWindow({
               title="Thinking Mode"
               onChange={(v) => {
                 setThinkingEnabled(v);
-                onSessionUpdate?.({ thinking_enabled: v });
+                handleSettingsUpdate({ thinking_enabled: v });
               }}
             />
           )}
@@ -895,7 +974,7 @@ export function ChatWindow({
               onChange={(v) => {
                 const val = v as number;
                 setSessionTemperature(val);
-                onSessionUpdate?.({ temperature: val });
+                handleSettingsUpdate({ temperature: val });
               }}
               style={{ width: 80, margin: 0 }}
             />
@@ -913,16 +992,19 @@ export function ChatWindow({
         >
         <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
           <ModelSelector
-            value={autoRouteEnabled && !selectedModelId ? AUTO_ROUTE_VALUE : selectedModelId}
+            value={pendingFlag
+              ? (pendAutoRoute && !pendModelId ? AUTO_ROUTE_VALUE : pendModelId)
+              : (autoRouteEnabled && !selectedModelId ? AUTO_ROUTE_VALUE : selectedModelId)
+            }
             onChange={handleModelChange}
           />
           <TemplateSelector
-            value={selectedTemplateId}
-            onChange={(id) => onSessionUpdate?.({ selected_template_id: id })}
+            value={pendingFlag ? pendTemplateId : selectedTemplateId}
+            onChange={(id) => handleSettingsUpdate({ selected_template_id: id })}
           />
           <SkillSelector
-            value={selectedSkillId}
-            onChange={(id) => onSessionUpdate?.({ selected_skill_id: id })}
+            value={pendingFlag ? pendSkillId : selectedSkillId}
+            onChange={(id) => handleSettingsUpdate({ selected_skill_id: id })}
           />
           <PromptLibrary
             onUse={(resolvedText) => setInputValue(resolvedText)}
@@ -954,7 +1036,7 @@ export function ChatWindow({
               title="Thinking Mode"
               onChange={(v) => {
                 setThinkingEnabled(v);
-                onSessionUpdate?.({ thinking_enabled: v });
+                handleSettingsUpdate({ thinking_enabled: v });
               }}
             />
           )}
@@ -966,7 +1048,7 @@ export function ChatWindow({
             title="Cross-session memory"
             onChange={(v) => {
               setLocalCrossSessionMemory(v);
-              onSessionUpdate?.({ cross_session_retrieval_enabled: v });
+              handleSettingsUpdate({ cross_session_retrieval_enabled: v });
             }}
           />
           <div style={{ width: "100%" }}>
@@ -982,7 +1064,7 @@ export function ChatWindow({
                 onChange={(v) => {
                   const val = v as number;
                   setSessionTemperature(val);
-                  onSessionUpdate?.({ temperature: val });
+                  handleSettingsUpdate({ temperature: val });
                 }}
                 marks={{ 0: "0", 1: "1", 2: "2" }}
               />
@@ -1441,7 +1523,16 @@ export function ChatWindow({
           onClose={() => setToolsOpen(false)}
           selectedSkillId={selectedSkillId}
           autoSelectTools={autoSelectTools}
-          onAutoSelectToolsChange={(v) => onSessionUpdate?.({ auto_select_tools: v })}
+          onAutoSelectToolsChange={(v) => handleSettingsUpdate({ auto_select_tools: v })}
+          isPending={pendingFlag}
+          pendingActiveToolIds={pendActiveToolIds}
+          onPendingToolToggle={(toolId, checked) => {
+            setPendActiveToolIds((prev) =>
+              checked
+                ? [...prev, toolId]
+                : prev.filter((id) => id !== toolId)
+            );
+          }}
         />
       )}
     </div>

--- a/frontend/src/features/chat/components/SessionSidebar.tsx
+++ b/frontend/src/features/chat/components/SessionSidebar.tsx
@@ -86,10 +86,10 @@ export function SessionSidebar() {
   });
 
   const createMutation = useMutation({
-    mutationFn: ({ is_temporary }: { is_temporary?: boolean }) =>
+    mutationFn: () =>
       createSession({
         title: "New Chat",
-        is_temporary: is_temporary ?? false,
+        is_temporary: true,
         auto_route_enabled: true,
       }),
     onSuccess: (data) => {
@@ -156,7 +156,18 @@ export function SessionSidebar() {
   }, [sessionId, sessions]);
 
   const handleNewChat = (temporary = false) => {
-    createMutation.mutate({ is_temporary: temporary });
+    if (temporary) {
+      // Temporary chat: create Redis-backed session immediately
+      createMutation.mutate();
+    } else {
+      // Lazy persistence (Phase 2): generate a client-side UUID and
+      // navigate — the backend session is created on the first message.
+      const uuid = crypto.randomUUID();
+      queryClient.setQueryData(["sessions"], (old: SessionData[] | undefined) =>
+        old || []
+      );
+      navigate(`/chat/${uuid}`);
+    }
   };
 
   const newChatMenuItems: MenuProps["items"] = [

--- a/frontend/src/features/chat/components/SessionToolActivation.tsx
+++ b/frontend/src/features/chat/components/SessionToolActivation.tsx
@@ -71,6 +71,9 @@ interface SessionToolActivationProps {
   selectedSkillId?: string;
   autoSelectTools?: boolean;
   onAutoSelectToolsChange?: (v: boolean) => void;
+  isPending?: boolean;
+  pendingActiveToolIds?: string[];
+  onPendingToolToggle?: (toolId: string, checked: boolean) => void;
 }
 
 export function SessionToolActivation({
@@ -80,6 +83,9 @@ export function SessionToolActivation({
   selectedSkillId,
   autoSelectTools = true,
   onAutoSelectToolsChange,
+  isPending = false,
+  pendingActiveToolIds = [],
+  onPendingToolToggle,
 }: SessionToolActivationProps) {
   const queryClient = useQueryClient();
 
@@ -90,11 +96,11 @@ export function SessionToolActivation({
     enabled: open,
   });
 
-  // Active tools for this session
+  // Active tools for this session (skipped when pending — no backend session yet)
   const { data: activeTools, isLoading: loadingActive } = useQuery({
     queryKey: ["session-tools", sessionId],
     queryFn: () => listSessionTools(sessionId),
-    enabled: open,
+    enabled: open && !isPending,
   });
 
   // Always-on tool IDs for this user
@@ -105,7 +111,9 @@ export function SessionToolActivation({
   });
 
   const alwaysOnSet = new Set(alwaysOnIds || []);
-  const activeIds = new Set((activeTools || []).map((t) => t.id));
+  const activeIds = isPending
+    ? new Set(pendingActiveToolIds)
+    : new Set((activeTools || []).map((t) => t.id));
 
   // Fetch the selected skill's tool IDs (for "from skill" badge)
   const { data: allSkills } = useQuery({
@@ -159,7 +167,9 @@ export function SessionToolActivation({
   });
 
   const handleToggle = (toolId: string, checked: boolean) => {
-    if (checked) {
+    if (isPending) {
+      onPendingToolToggle?.(toolId, checked);
+    } else if (checked) {
       addMutation.mutate(toolId);
     } else {
       removeMutation.mutate(toolId);

--- a/frontend/src/features/chat/hooks/useStream.ts
+++ b/frontend/src/features/chat/hooks/useStream.ts
@@ -166,6 +166,7 @@ export function useStream(apiPrefix: string = "chat") {
       content: string,
       fileIds: string[] | undefined,
       temperature: number | undefined,
+      sessionData: Record<string, unknown> | undefined,
       handlers: {
         onToken?: (token: string, messageId: string) => void;
         onToolStart?: (data: ToolStartEvent["data"]) => void;
@@ -208,6 +209,7 @@ export function useStream(apiPrefix: string = "chat") {
               content,
               file_ids: fileIds || [],
               ...(temperature !== undefined ? { temperature } : {}),
+              ...(sessionData ? { session_data: sessionData } : {}),
             }),
           });
           if (!res.ok) {
@@ -250,6 +252,7 @@ export function useStream(apiPrefix: string = "chat") {
               content,
               file_ids: fileIds || [],
               ...(temperature !== undefined ? { temperature } : {}),
+              ...(sessionData ? { session_data: sessionData } : {}),
             }),
             openWhenHidden: true,
             signal: controller.signal,

--- a/frontend/src/features/chat/routes/ChatPage.tsx
+++ b/frontend/src/features/chat/routes/ChatPage.tsx
@@ -5,7 +5,7 @@
 // =============================================================================
 
 import { useParams, useNavigate } from "react-router-dom";
-import { Layout, Empty, Button, Typography, Spin } from "antd";
+import { Layout, Button, Typography, Spin } from "antd";
 import { PlusOutlined, ThunderboltOutlined } from "@ant-design/icons";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { SessionSidebar } from "../components/SessionSidebar";
@@ -24,6 +24,7 @@ export function ChatPage() {
     queryKey: ["session", sessionId],
     queryFn: () => getSession(sessionId!),
     enabled: !!sessionId,
+    retry: false,
   });
 
   const handleSessionUpdate = async (data: Record<string, unknown>) => {
@@ -32,13 +33,10 @@ export function ChatPage() {
     queryClient.invalidateQueries({ queryKey: ["session", sessionId] });
   };
 
-  const handleNewChat = async () => {
-    try {
-      const session = await createSession({ title: "New Chat" });
-      navigate(`/chat/${session.id}`);
-    } catch {
-      // Error creating session
-    }
+  const handleNewChat = () => {
+    // Lazy persistence (Phase 2): client-side UUID, no API call
+    const uuid = crypto.randomUUID();
+    navigate(`/chat/${uuid}`);
   };
 
   const handleNewTemporaryChat = async () => {
@@ -117,16 +115,11 @@ export function ChatPage() {
             onSessionUpdate={handleSessionUpdate}
           />
         ) : (
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "center",
-              alignItems: "center",
-              height: "100%",
-            }}
-          >
-            <Empty description="Session not found" />
-          </div>
+          <ChatWindow
+            sessionId={sessionId!}
+            isPending={true}
+            onSessionUpdate={handleSessionUpdate}
+          />
         )}
       </Content>
     </Layout>


### PR DESCRIPTION


Implement automatic deletion of empty conversations once a day to prevent clutter in user chat interfaces. This feature addresses the issue of users accumulating empty conversations when starting new chats without sending messages.



## Related Issue



Closes #329



## Type of Change



- [x] New feature (non-breaking change that adds functionality)



## Testing



- [x] Tested locally with Docker Compose (dev)

- [x] Backend tests pass (`pytest backend/tests/`)

- [x] Frontend builds without errors (`npm run build`)

- [x] Manual testing completed (verified that empty conversations are deleted as expected)



## Checklist



- [x] My code follows the coding conventions of this project

- [x] I have self-reviewed my own code

- [x] I have commented complex code sections, particularly in hard-to-understand areas

- [x] I have updated the documentation (`docs/`) if my change affects user-facing behaviour or configuration

- [x] My changes generate no new warnings or errors

- [x] New and existing tests pass locally



## Screenshots (if applicable)



<!-- Add screenshots to help explain your changes, especially for UI changes. -->



## Additional Notes



The implementation includes a lazy session creation feature that allows for the creation of sessions when the first message is sent, improving user experience by reducing the need for immediate session creation.

