### PR TITLE
Fix file attachment issue in new conversations

### DIFF
--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -939,6 +939,25 @@ async def send_message(
             db, session_id, body.session_data, current_user,
         )
 
+    # ---- Temp → permanent promotion (Issue #336) -----------------------
+    # If the user uploaded files to a temp session (created by upload_file
+    # when the session didn't exist yet) and then sends a message with
+    # session_data, promote the session to permanent.
+    if data.get("is_temporary") and body.session_data is not None:
+        logger.info(
+            "Promoting temp session %s to permanent on first message",
+            session_id,
+        )
+        data = await _lazy_create_session(
+            db, session_id, body.session_data, current_user,
+        )
+        # Re-link any files uploaded during the pending phase
+        await upload_service.link_pending_uploads_to_session(
+            db, session_id, current_user.id,
+        )
+        # Clean up the stale Redis temp entry
+        await delete_temp_session(session_id)
+
     # ---- Auto-title: if session still has the default title, use the
     #      first user message as the title.  Set a raw truncated title
     #      immediately, then fire a background task that calls a cheap
@@ -2167,9 +2186,40 @@ async def upload_file(
     db: AsyncSession = Depends(get_db),
     current_user: UserORM = Depends(get_current_user),
 ):
-    """Upload a file to a session (stored in MinIO)."""
-    data = await _load_session(db, session_id)
-    await _require_session_owner(data, current_user)
+    """Upload a file to a session (stored in MinIO).
+
+    Supports lazy (pending) sessions: if the session doesn't exist yet
+    (e.g. "New Chat" before the first message), a minimal temporary Redis
+    session is created on-the-fly.  The session will be promoted to
+    permanent when the first message is sent (see ``send_message``).
+    """
+    try:
+        data = await _load_session(db, session_id)
+        await _require_session_owner(data, current_user)
+    except NotFoundError:
+        logger.info(
+            "Lazy-creating temp session %s on file upload", session_id,
+        )
+        now = datetime.now(timezone.utc).isoformat()
+        data = {
+            "id": session_id,
+            "tenant_id": current_user.tenant_id,
+            "user_id": current_user.id,
+            "title": "New Chat",
+            "is_temporary": True,
+            "is_pinned": False,
+            "selected_template_id": None,
+            "selected_skill_id": None,
+            "selected_model_id": None,
+            "auto_route_enabled": False,
+            "auto_select_tools": True,
+            "thinking_enabled": None,
+            "temperature": None,
+            "active_tool_ids": [],
+            "created_at": now,
+            "updated_at": now,
+        }
+        await store_temp_session(session_id, data)
 
     if not file.filename:
         raise ValidationError("File must have a filename")

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -108,7 +108,7 @@ async def lifespan(app: FastAPI):
     demo_cleanup_task.cancel()
 
 
-app = FastAPI(title="PH Agent Hub", version="1.19.1", lifespan=lifespan)
+app = FastAPI(title="PH Agent Hub", version="1.19.2", lifespan=lifespan)
 
 # ---------------------------------------------------------------------------
 # Middleware

--- a/backend/src/services/upload_service.py
+++ b/backend/src/services/upload_service.py
@@ -434,6 +434,50 @@ async def list_uploads_for_message(
 
 
 # ---------------------------------------------------------------------------
+# Pending upload re-linking (Issue #336)
+# ---------------------------------------------------------------------------
+
+
+async def link_pending_uploads_to_session(
+    db: AsyncSession,
+    session_id: str,
+    user_id: str,
+) -> int:
+    """Re-associate temporary uploads with a now-permanent session.
+
+    When a user uploads files to a pending (lazy) session before sending
+    the first message, the uploads are stored with ``session_id = NULL``
+    and ``is_temporary = True``.  This function links them to the permanent
+    session created by ``_lazy_create_session`` so they remain accessible
+    after promotion.
+
+    Returns the number of uploads re-linked.
+    """
+    result = await db.execute(
+        select(FileUpload).where(
+            FileUpload.user_id == user_id,
+            FileUpload.session_id.is_(None),
+            FileUpload.is_temporary == True,  # noqa: E712
+            FileUpload.storage_key.like(f"%/{session_id}/%"),
+        )
+    )
+    uploads = list(result.scalars().all())
+
+    for upload in uploads:
+        upload.session_id = session_id
+        upload.is_temporary = False
+
+    if uploads:
+        await db.flush()
+        logger.info(
+            "Re-linked %d pending upload(s) to session %s",
+            len(uploads), session_id,
+        )
+
+    return len(uploads)
+
+
+# ---------------------------------------------------------------------------
 # Temporary session cleanup
 # ---------------------------------------------------------------------------
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ph-agent-hub-frontend",
   "private": true,
-  "version": "1.19.1",
+  "version": "1.19.2",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000 --host",


### PR DESCRIPTION
## Description

The changes address the inability to attach files when starting a new conversation. A temporary session is created during file uploads, which is then promoted to a permanent session upon sending the first message. This ensures that uploaded files remain accessible.

## Related Issue

Fixes #336

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Tested locally with Docker Compose (dev)
- [x] Backend tests pass (`pytest backend/tests/`)
- [x] Frontend builds without errors (`npm run build`)
- [x] Manual testing completed (uploaded files in new conversations)

## Checklist

- [x] My code follows the coding conventions of this project
- [x] I have self-reviewed my own code
- [x] I have commented complex code sections, particularly in hard-to-understand areas
- [x] I have updated the documentation (`docs/`) if my change affects user-facing behaviour or configuration
- [x] My changes generate no new warnings or errors
- [x] New and existing tests pass locally

## Screenshots (if applicable)

## Additional Notes

No additional notes.

