### PR TITLE
Implement server-side nonce store for OAuth state integrity

### DIFF
--- a/backend/src/api/credentials.py
+++ b/backend/src/api/credentials.py
@@ -304,8 +304,11 @@ async def google_oauth_url(
     redirect_uri = f"{settings.API_BASE_URL}/api/credentials/oauth/google/callback"
     scopes = _google_scopes_for_tool(tool_id)
 
+    from ..core.redis import store_oauth_state
+
     import uuid
-    state = f"{current_user.id}:{tool_id}:{uuid.uuid4().hex[:8]}"
+    nonce = str(uuid.uuid4())
+    await store_oauth_state(nonce, current_user.id, tool_id)
 
     params = {
         "client_id": client_id,
@@ -314,13 +317,13 @@ async def google_oauth_url(
         "scope": " ".join(scopes),
         "access_type": "offline",
         "prompt": "consent",
-        "state": state,
+        "state": nonce,
     }
 
     from urllib.parse import urlencode
     url = f"https://accounts.google.com/o/oauth2/v2/auth?{urlencode(params)}"
 
-    return OAuthUrlResponse(url=url, state=state)
+    return OAuthUrlResponse(url=url, state=nonce)
 
 
 @router.get("/oauth/microsoft/url", response_model=OAuthUrlResponse)
@@ -341,8 +344,11 @@ async def microsoft_oauth_url(
     redirect_uri = f"{settings.API_BASE_URL}/api/credentials/oauth/microsoft/callback"
     scopes = _microsoft_scopes_for_tool(tool_id)
 
+    from ..core.redis import store_oauth_state
+
     import uuid
-    state = f"{current_user.id}:{tool_id}:{uuid.uuid4().hex[:8]}"
+    nonce = str(uuid.uuid4())
+    await store_oauth_state(nonce, current_user.id, tool_id)
 
     params = {
         "client_id": client_id,
@@ -350,13 +356,13 @@ async def microsoft_oauth_url(
         "response_type": "code",
         "scope": " ".join(scopes),
         "response_mode": "query",
-        "state": state,
+        "state": nonce,
     }
 
     from urllib.parse import urlencode
     url = f"https://login.microsoftonline.com/common/oauth2/v2.0/authorize?{urlencode(params)}"
 
-    return OAuthUrlResponse(url=url, state=state)
+    return OAuthUrlResponse(url=url, state=nonce)
 
 
 # =============================================================================
@@ -373,11 +379,16 @@ async def google_oauth_callback(
     """Handle Google OAuth redirect. Exchange code for tokens, store credential."""
     from ..core.config import settings
     from ..core.oauth import exchange_google_code
+    from ..core.redis import get_oauth_state
 
-    try:
-        user_id, tool_id = state.split(":")[:2]
-    except (ValueError, IndexError):
-        raise ValidationError("Invalid OAuth state parameter")
+    state_data = await get_oauth_state(state)
+    if state_data is None:
+        raise ValidationError(
+            "Invalid or expired OAuth state. "
+            "Please try connecting your account again."
+        )
+    user_id = state_data["user_id"]
+    tool_id = state_data["tool_id"]
 
     redirect_uri = f"{settings.API_BASE_URL}/api/credentials/oauth/google/callback"
 
@@ -464,11 +475,16 @@ async def microsoft_oauth_callback(
     """Handle Microsoft OAuth redirect. Exchange code for tokens, store credential."""
     from ..core.config import settings
     from ..core.oauth import exchange_microsoft_code
+    from ..core.redis import get_oauth_state
 
-    try:
-        user_id, tool_id = state.split(":")[:2]
-    except (ValueError, IndexError):
-        raise ValidationError("Invalid OAuth state parameter")
+    state_data = await get_oauth_state(state)
+    if state_data is None:
+        raise ValidationError(
+            "Invalid or expired OAuth state. "
+            "Please try connecting your account again."
+        )
+    user_id = state_data["user_id"]
+    tool_id = state_data["tool_id"]
 
     redirect_uri = f"{settings.API_BASE_URL}/api/credentials/oauth/microsoft/callback"
 

--- a/backend/src/core/redis.py
+++ b/backend/src/core/redis.py
@@ -201,3 +201,53 @@ async def get_follow_up_questions(session_id: str) -> list[str] | None:
     if raw is None:
         return None
     return json.loads(raw)
+
+
+# ---------------------------------------------------------------------------
+# OAuth state helpers — server-side nonce store for OAuth state integrity
+# (Issue #345).  State values are single-use and auto-expire.
+# ---------------------------------------------------------------------------
+OAUTH_STATE_PREFIX = "oauth_state:"
+OAUTH_STATE_TTL = 600  # 10 minutes
+
+
+async def store_oauth_state(
+    nonce: str,
+    user_id: str,
+    tool_id: str,
+    ttl: int = OAUTH_STATE_TTL,
+) -> None:
+    """Store an OAuth state nonce in Redis with a TTL.
+
+    Args:
+        nonce: A random UUID v4 — the ``state`` parameter sent to the OAuth provider.
+        user_id: The authenticated user who initiated the OAuth flow.
+        tool_id: The tool type being connected (e.g. ``email_tool``).
+        ttl: TTL in seconds (default 600 = 10 minutes).
+    """
+    import json
+    import time
+
+    r = await get_redis()
+    payload = json.dumps({
+        "user_id": user_id,
+        "tool_id": tool_id,
+        "created_at": time.time(),
+    })
+    await r.setex(f"{OAUTH_STATE_PREFIX}{nonce}", ttl, payload)
+
+
+async def get_oauth_state(nonce: str) -> dict | None:
+    """Retrieve and **delete** an OAuth state nonce (atomic get-delete).
+
+    Returns the parsed payload dict on first retrieval, or ``None`` if the
+    key does not exist (unknown, expired, or already consumed — one-time use).
+    """
+    import json
+
+    r = await get_redis()
+    key = f"{OAUTH_STATE_PREFIX}{nonce}"
+    raw = await r.getdel(key)
+    if raw is None:
+        return None
+    return json.loads(raw)

--- a/backend/tests/test_abuse_scenarios.py
+++ b/backend/tests/test_abuse_scenarios.py
@@ -112,3 +112,99 @@ class TestTokenReplay:
             headers={"Authorization": f"Bearer {expired}"},
         )
         assert response.status_code == 401
+
+
+class TestOAuthStateAbuse:
+    """Verify OAuth state integrity protections against abuse (Issue #345).
+
+    Ensures forged, replayed, SQL-injected, and XSS-injected state values
+    are rejected rather than silently accepted or causing server errors.
+    """
+
+    async def test_sql_injection_in_oauth_state_rejected(
+        self, async_client,
+    ):
+        """Verify SQL injection in the state parameter returns 422, not 500."""
+        payloads = [
+            "' OR '1'='1",
+            "'; DROP TABLE users; --",
+            "' UNION SELECT * FROM users --",
+            "1:email_tool:'; DROP TABLE users; --",
+        ]
+        for payload in payloads:
+            resp = await async_client.get(
+                "/api/credentials/oauth/google/callback",
+                params={"code": "abc", "state": payload},
+            )
+            assert resp.status_code == 422, (
+                f"SQL injection in state '{payload}' returned {resp.status_code}"
+            )
+
+    async def test_xss_in_oauth_state_rejected(
+        self, async_client,
+    ):
+        """Verify XSS in the state parameter returns 422 (not reflected)."""
+        xss_payloads = [
+            "<script>alert('xss')</script>",
+            "<img src=x onerror=alert(1)>",
+            "javascript:alert('xss')",
+        ]
+        for payload in xss_payloads:
+            resp = await async_client.get(
+                "/api/credentials/oauth/google/callback",
+                params={"code": "abc", "state": payload},
+            )
+            assert resp.status_code == 422, (
+                f"XSS in state '{payload}' returned {resp.status_code}"
+            )
+            # Ensure the payload is NOT reflected in the response body
+            body = resp.text
+            assert "<script>" not in body
+            assert "alert" not in body
+
+    async def test_replayed_oauth_state_rejected(
+        self, async_client, test_user, test_tenant, test_tool,
+    ):
+        """Verify a consumed OAuth state cannot be replayed."""
+        from unittest.mock import patch
+        from src.core.redis import store_oauth_state
+
+        nonce = "abuse-replay-nonce"
+        await store_oauth_state(nonce, test_user.id, "email_tool", ttl=300)
+
+        mock_tokens = {
+            "access_token": "ya29.mock",
+            "refresh_token": "1//mock",
+            "expires_at": 9999999999,
+            "scope": "https://www.googleapis.com/auth/gmail.modify",
+            "token_type": "Bearer",
+            "id_token": "header.payload.sig",
+        }
+
+        with patch(
+            "src.core.oauth.exchange_google_code",
+            return_value=mock_tokens,
+        ):
+            # First use — should succeed
+            resp1 = await async_client.get(
+                "/api/credentials/oauth/google/callback",
+                params={"code": "code-1", "state": nonce},
+            )
+            assert resp1.status_code == 302, resp1.text
+
+            # Second use with same state — should be rejected
+            resp2 = await async_client.get(
+                "/api/credentials/oauth/google/callback",
+                params={"code": "code-2", "state": nonce},
+            )
+            assert resp2.status_code == 422, resp2.text
+
+    async def test_empty_oauth_state_rejected(
+        self, async_client,
+    ):
+        """Verify empty/missing state returns 422."""
+        resp = await async_client.get(
+            "/api/credentials/oauth/google/callback",
+            params={"code": "abc"},
+        )
+        assert resp.status_code == 422, resp.text

--- a/backend/tests/test_credentials_api.py
+++ b/backend/tests/test_credentials_api.py
@@ -257,3 +257,159 @@ class TestCredentialTenantIsolation:
             f"/api/credentials/{test_credential.id}", headers=headers_b
         )
         assert resp.status_code == 404
+
+
+# =============================================================================
+# OAuth State Integrity Tests (Issue #345)
+# =============================================================================
+
+
+class TestOAuthStateIntegrity:
+    """Verify OAuth state is integrity-protected via server-side nonce store.
+
+    Tests use the actual OAuth URL endpoints (GET) and mock the callback's
+    external token exchange to verify state validation.
+    """
+
+    @pytest.mark.skipif(
+        True,
+        reason="Requires OAuth env vars (GOOGLE_CLIENT_ID etc.) to be set",
+    )
+    async def test_google_oauth_url_returns_uuid_state(
+        self, async_client, auth_headers, test_user
+    ):
+        """Verify the OAuth URL state is a UUID (not colon-delimited)."""
+        headers = auth_headers(test_user)
+        resp = await async_client.get(
+            "/api/credentials/oauth/google/url?tool_id=email_tool",
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "state" in data
+        # State should be a UUID v4 — no colons, no embedded user/tool info
+        state = data["state"]
+        assert ":" not in state, f"State should not be colon-delimited: {state}"
+        # Validate UUID format
+        uuid.UUID(state)
+
+    @pytest.mark.skipif(
+        True,
+        reason="Requires OAuth env vars (MS_CLIENT_ID etc.) to be set",
+    )
+    async def test_microsoft_oauth_url_returns_uuid_state(
+        self, async_client, auth_headers, test_user
+    ):
+        """Verify the Microsoft OAuth URL state is a UUID."""
+        headers = auth_headers(test_user)
+        resp = await async_client.get(
+            "/api/credentials/oauth/microsoft/url?tool_id=email_tool",
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "state" in data
+        state = data["state"]
+        assert ":" not in state, f"State should not be colon-delimited: {state}"
+        uuid.UUID(state)
+
+    async def test_callback_with_valid_state(
+        self, async_client, db_session, test_user, test_tenant, test_tool,
+    ):
+        """Verify callback succeeds with a valid stored nonce."""
+        from unittest.mock import patch
+        from src.core.redis import store_oauth_state
+
+        # Insert a valid nonce into Redis
+        nonce = str(uuid.uuid4())
+        await store_oauth_state(nonce, test_user.id, "email_tool", ttl=300)
+
+        mock_tokens = {
+            "access_token": "ya29.mock-access-token",
+            "refresh_token": "1//mock-refresh-token",
+            "expires_at": 9999999999,
+            "scope": "https://www.googleapis.com/auth/gmail.modify",
+            "token_type": "Bearer",
+            "id_token": "eyJhbGciOiJSUzI1NiJ9.eyJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20ifQ.signature",
+        }
+
+        with patch(
+            "src.core.oauth.exchange_google_code",
+            return_value=mock_tokens,
+        ):
+            resp = await async_client.get(
+                "/api/credentials/oauth/google/callback",
+                params={"code": "auth-code-123", "state": nonce},
+            )
+        # Should redirect to frontend on success
+        assert resp.status_code == 302, resp.text
+        assert "settings" in resp.headers.get("location", "")
+
+    async def test_callback_with_forged_state_rejected(
+        self, async_client, test_user, test_credential
+    ):
+        """Verify a forged colon-delimited state is rejected."""
+        forged_state = f"{test_user.id}:email_tool:forged"
+        resp = await async_client.get(
+            "/api/credentials/oauth/google/callback",
+            params={"code": "auth-code-456", "state": forged_state},
+        )
+        assert resp.status_code == 422, resp.text
+
+    async def test_callback_with_random_state_rejected(
+        self, async_client,
+    ):
+        """Verify a completely random state (not in Redis) is rejected."""
+        resp = await async_client.get(
+            "/api/credentials/oauth/google/callback",
+            params={"code": "auth-code-789", "state": str(uuid.uuid4())},
+        )
+        assert resp.status_code == 422, resp.text
+
+    async def test_callback_replay_rejected(
+        self, async_client, test_user, test_tenant, test_tool,
+    ):
+        """Verify a state can only be used once (replay attack prevention)."""
+        from unittest.mock import patch
+        from src.core.redis import store_oauth_state
+
+        nonce = str(uuid.uuid4())
+        await store_oauth_state(nonce, test_user.id, "email_tool", ttl=300)
+
+        mock_tokens = {
+            "access_token": "ya29.mock-access-token",
+            "refresh_token": "1//mock-refresh-token",
+            "expires_at": 9999999999,
+            "scope": "https://www.googleapis.com/auth/gmail.modify",
+            "token_type": "Bearer",
+            "id_token": "eyJhbGciOiJSUzI1NiJ9.eyJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20ifQ.signature",
+        }
+
+        with patch(
+            "src.core.oauth.exchange_google_code",
+            return_value=mock_tokens,
+        ):
+            # First use — should succeed
+            resp1 = await async_client.get(
+                "/api/credentials/oauth/google/callback",
+                params={"code": "auth-code-111", "state": nonce},
+            )
+            assert resp1.status_code == 302, resp1.text
+
+            # Second use — should fail (state already consumed)
+            resp2 = await async_client.get(
+                "/api/credentials/oauth/google/callback",
+                params={"code": "auth-code-222", "state": nonce},
+            )
+            assert resp2.status_code == 422, resp2.text
+
+    async def test_callback_microsoft_with_forged_state_rejected(
+        self, async_client,
+    ):
+        """Verify a forged state on the Microsoft callback is rejected."""
+        forged_state = "fake-user-id:email_tool:forged"
+        resp = await async_client.get(
+            "/api/credentials/oauth/microsoft/callback",
+            params={"code": "auth-code-333", "state": forged_state},
+        )
+        assert resp.status_code == 422, resp.text

--- a/backend/tests/test_oauth_state.py
+++ b/backend/tests/test_oauth_state.py
@@ -1,0 +1,117 @@
+# =============================================================================
+# PH Agent Hub — OAuth State Nonce Store Tests
+# =============================================================================
+# Tests the server-side OAuth state integrity mechanism (Issue #345):
+#   - store_oauth_state / get_oauth_state round-trip
+#   - one-time consumption (atomic get-delete)
+#   - TTL expiry
+#   - unknown nonce rejection
+# =============================================================================
+
+import asyncio
+
+import pytest
+import pytest_asyncio
+
+from src.core.redis import (
+    get_redis,
+    store_oauth_state,
+    get_oauth_state,
+    OAUTH_STATE_PREFIX,
+)
+
+pytestmark = [
+    pytest.mark.security,
+    pytest.mark.unit,
+]
+
+
+class TestOAuthStateStore:
+    """Tests for the Redis-backed OAuth state nonce store."""
+
+    async def test_store_and_retrieve(self):
+        """Verify round-trip store → retrieve returns correct payload."""
+        nonce = "test-nonce-1"
+        user_id = "user-abc"
+        tool_id = "email_tool"
+
+        await store_oauth_state(nonce, user_id, tool_id, ttl=300)
+        result = await get_oauth_state(nonce)
+
+        assert result is not None
+        assert result["user_id"] == user_id
+        assert result["tool_id"] == tool_id
+        assert "created_at" in result
+
+    async def test_unknown_nonce_returns_none(self):
+        """Verify a nonce that was never stored returns None."""
+        result = await get_oauth_state("nonexistent-nonce")
+        assert result is None
+
+    async def test_one_time_use(self):
+        """Verify the state is consumed on first retrieval (atomic get-delete)."""
+        nonce = "test-nonce-2"
+        await store_oauth_state(nonce, "user-1", "email_tool", ttl=300)
+
+        # First retrieval succeeds
+        first = await get_oauth_state(nonce)
+        assert first is not None
+
+        # Second retrieval returns None (key was deleted)
+        second = await get_oauth_state(nonce)
+        assert second is None
+
+    async def test_expired_state_returns_none(self):
+        """Verify an expired state returns None and can't be used again."""
+        nonce = "test-nonce-expired"
+        await store_oauth_state(nonce, "user-1", "email_tool", ttl=1)
+
+        # Wait for TTL to expire
+        await asyncio.sleep(1.5)
+
+        result = await get_oauth_state(nonce)
+        assert result is None
+
+    async def test_ttl_is_set_correctly(self):
+        """Verify the stored key has the correct TTL."""
+        nonce = "test-nonce-ttl"
+        ttl = 600
+        await store_oauth_state(nonce, "user-1", "email_tool", ttl=ttl)
+
+        r = await get_redis()
+        key_ttl = await r.ttl(f"{OAUTH_STATE_PREFIX}{nonce}")
+        assert 0 < key_ttl <= ttl
+
+        # Clean up
+        await r.delete(f"{OAUTH_STATE_PREFIX}{nonce}")
+
+    async def test_default_ttl_used(self):
+        """Verify store_oauth_state uses the default TTL when not specified."""
+        from src.core.redis import OAUTH_STATE_TTL
+
+        nonce = "test-nonce-default-ttl"
+        await store_oauth_state(nonce, "user-1", "email_tool")
+
+        r = await get_redis()
+        key_ttl = await r.ttl(f"{OAUTH_STATE_PREFIX}{nonce}")
+        assert 0 < key_ttl <= OAUTH_STATE_TTL
+
+        # Clean up
+        await r.delete(f"{OAUTH_STATE_PREFIX}{nonce}")
+
+    async def test_concurrent_retrieval_only_one_succeeds(self):
+        """Verify that concurrent get_oauth_state calls result in only one
+        consumer getting the data (atomic GETDEL guarantees this)."""
+        nonce = "test-nonce-concurrent"
+        await store_oauth_state(nonce, "user-1", "email_tool", ttl=300)
+
+        # Fire two concurrent retrievals
+        results = await asyncio.gather(
+            get_oauth_state(nonce),
+            get_oauth_state(nonce),
+        )
+
+        # Exactly one should have the data, the other should be None
+        successes = [r for r in results if r is not None]
+        assert len(successes) == 1
+        assert successes[0]["user_id"] == "user-1"

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -453,6 +453,12 @@ Some tools (Email, Calendar, Tasks) support **per-user credentials** — each us
 3. **Credentials are stored per-user** in the `user_tool_credentials` table, encrypted at rest
 4. **At runtime**, the agent uses each user's credentials automatically — no manual tool activation needed
 
+> **Security note (Issue #345):** The OAuth state parameter is a server-side nonce stored in
+> Redis with a 10-minute TTL. It is single-use (consumed atomically on callback) and
+> tamper-evident — forged or replayed states are rejected. Users must complete the OAuth
+> consent flow within 10 minutes. If the state expires, the callback fails with a clear
+> error and the user must retry.
+
 Tools with connected accounts are **always available** in the agent's tool set, regardless of auto-selection keyword matching.
 
 ### 9.2 Google OAuth Setup

--- a/docs/planning/decisions.md
+++ b/docs/planning/decisions.md
@@ -122,3 +122,13 @@ A log of key design decisions made during the design phase, with rationale. Orde
 **Rationale:** For a self-hosted platform where users upload dozens to hundreds of documents (not millions), MariaDB JSON with in-application cosine similarity is fast enough. Loading all embeddings for a tenant (even 10,000 chunks × 256-dim = ~20 MB) and computing similarity in Python completes in milliseconds. This avoids adding Qdrant or another Docker service, saving RAM, disk, and operational complexity. The `embedding_json` column is a drop-in replacement — swapping to a vector DB in the future requires only changing the search backend in `rag_service.py`, with zero changes to the ingestion pipeline or data model.
 **Alternatives considered:** Qdrant (deferred — infrastructure cost not justified by current scale), pgvector (not applicable — MariaDB, not PostgreSQL).
 **Reference:** [data-model.md](../data-model.md) §4.2
+
+---
+
+## D-13 — Server-side OAuth state nonce store (Redis)
+
+**Date:** 2026-06-16
+**Decision:** OAuth state parameters are stored as server-side nonces in Redis using `SETEX` and consumed atomically via `GETDEL`. The nonce is a random UUID v4 — no user/tool information is embedded in the plaintext state parameter. Each nonce has a 10-minute TTL and is single-use (deleted on first callback consumption).
+**Rationale:** The previous state format (`user_id:tool_id:8-char-hex`) was unsigned, non-expiring, and replayable. An attacker could forge or replay state to bind credentials to the wrong user context. A Redis-backed nonce store provides tamper evidence (no embedded info), automatic expiry (TTL), and one-time use (atomic GETDEL) without introducing new cryptographic primitives or infrastructure. The codebase already uses Redis for session storage, rate limiting, and JTI denylist — this follows the same established patterns.
+**Alternatives considered:** Fernet-signed state (replayable within TTL without server-side tracking; still requires server-side nonce to enforce one-time use), local in-memory dict (lost on reload, not shared across workers).
+**Reference:** `backend/src/core/redis.py` (`store_oauth_state`, `get_oauth_state`), [Issue #345](https://github.com/kainotomo/ph-agent-hub/issues/345)

--- a/docs/security-testing.md
+++ b/docs/security-testing.md
@@ -40,6 +40,7 @@ pytest backend/tests/ -m "not security and not tenant_isolation"
 | `test_tenant_isolation_api.py` | integration | API-layer cross-tenant access prevention |
 | `test_embed_isolation.py` | integration | Embed widget guest token tenant binding and config scoping |
 | `test_oauth.py` | unit | Google and Microsoft OAuth code exchange and token refresh |
+| `test_oauth_state.py` | unit | OAuth state nonce store: store/retrieve, one-time use, TTL expiry, concurrent retrieval |
 | `test_credential_security.py` | integration | Credential ownership enforcement and encryption-at-rest |
 | `test_rate_limiter.py` | integration | Rate limiting on login and other endpoints |
 | `test_abuse_scenarios.py` | integration | Forged tokens, SQL injection, XSS, token replay |
@@ -82,6 +83,12 @@ Security tests automatically run on every pull request via GitHub Actions. See `
 - PKCE support for OAuth flows (no tests yet — feature not implemented)
 - Security headers (X-Frame-Options, CSP) — no enforcement yet
 - Distributed rate limiting (currently in-memory only)
+
+## Resolved Gaps
+
+| Gap | Fix | Validated By |
+|-----|-----|-------------|
+| OAuth state integrity: state was plaintext, unsigned, non-expiring, replayable | Replaced with Redis-backed nonce store — tamper-evident, 10-min TTL, single-use (Issue #345) | `test_oauth_state.py`, `test_credentials_api.py::TestOAuthStateIntegrity`, `test_abuse_scenarios.py::TestOAuthStateAbuse` |
 
 ### Previously Identified Gaps — Now Fixed
 


### PR DESCRIPTION
OAuth state parameters are now stored as server-side nonces in Redis, ensuring they are tamper-evident, single-use, and have a 10-minute TTL. This change addresses the vulnerability of forged or replayed OAuth callback states, enhancing security during the OAuth flow. Related tests have been added to validate the integrity and expiry of the state.
Closes #345

