### PR TITLE
## Description

### DIFF
--- a/backend/src/services/group_service.py
+++ b/backend/src/services/group_service.py
@@ -127,9 +127,10 @@ async def add_member(
             UserGroupMember.user_id == user_id,
         )
     )
-    if existing.scalar_one_or_none() is not None:
+    member = existing.scalar_one_or_none()
+    if member is not None:
         # Already a member — return existing
-        return existing.scalar_one()
+        return member
 
     member = UserGroupMember(user_id=user_id, group_id=group_id)
     db.add(member)
@@ -208,8 +209,9 @@ async def assign_model_to_group(
             ModelGroup.model_id == model_id,
         )
     )
-    if existing.scalar_one_or_none() is not None:
-        return existing.scalar_one()
+    assignment = existing.scalar_one_or_none()
+    if assignment is not None:
+        return assignment
 
     mg = ModelGroup(model_id=model_id, group_id=group_id)
     db.add(mg)
@@ -288,8 +290,9 @@ async def assign_tool_to_group(
             ToolGroup.tool_id == tool_id,
         )
     )
-    if existing.scalar_one_or_none() is not None:
-        return existing.scalar_one()
+    assignment = existing.scalar_one_or_none()
+    if assignment is not None:
+        return assignment
 
     tg = ToolGroup(tool_id=tool_id, group_id=group_id)
     db.add(tg)

--- a/backend/tests/test_group_service.py
+++ b/backend/tests/test_group_service.py
@@ -1,0 +1,111 @@
+# =============================================================================
+# PH Agent Hub — Group Service Tests (Idempotent Operations)
+# =============================================================================
+# Tests that duplicate operations (adding the same member/model/tool to a
+# group twice) return the existing row instead of crashing with a
+# cursor-consumption error (Issue #348).
+# =============================================================================
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.db.orm.models import Model
+from src.db.orm.tools import Tool
+from src.services.group_service import (
+    add_member,
+    assign_model_to_group,
+    assign_tool_to_group,
+    create_group,
+)
+
+pytestmark = [
+    pytest.mark.regression,
+    pytest.mark.integration,
+]
+
+
+class TestGroupIdempotentOperations:
+    """Verify duplicate adds return existing rows without error."""
+
+    async def test_add_member_idempotent(
+        self, db_session: AsyncSession, test_tenant, test_user
+    ):
+        """Call add_member twice with same args — second call returns existing."""
+        group = await create_group(
+            db_session, tenant_id=test_tenant.id, name="Idempotent Group"
+        )
+        # First call — create
+        first = await add_member(db_session, group.id, test_user.id)
+        assert first.user_id == test_user.id
+        assert first.group_id == group.id
+
+        # Second call — should return existing, not raise
+        second = await add_member(db_session, group.id, test_user.id)
+        assert second.user_id == test_user.id
+        assert second.group_id == group.id
+        assert second.user_id == first.user_id
+        assert second.group_id == first.group_id  # same composite-PK row
+
+    async def test_assign_model_to_group_idempotent(
+        self, db_session: AsyncSession, test_tenant
+    ):
+        """Call assign_model_to_group twice — second call returns existing."""
+        group = await create_group(
+            db_session, tenant_id=test_tenant.id, name="Model Group"
+        )
+        model = Model(
+            id=str(uuid.uuid4()),
+            tenant_id=test_tenant.id,
+            name="Idempotent Test Model",
+            model_id="test-model",
+            provider="openai",
+            api_key="test-key",
+            max_tokens=4096,
+            temperature=0.7,
+        )
+        db_session.add(model)
+        await db_session.flush()
+
+        # First call — create
+        first = await assign_model_to_group(db_session, group.id, model.id)
+        assert first.model_id == model.id
+        assert first.group_id == group.id
+
+        # Second call — should return existing, not raise
+        second = await assign_model_to_group(db_session, group.id, model.id)
+        assert second.model_id == model.id
+        assert second.group_id == group.id
+        assert second.model_id == first.model_id
+        assert second.group_id == first.group_id  # same composite-PK row
+
+    async def test_assign_tool_to_group_idempotent(
+        self, db_session: AsyncSession, test_tenant
+    ):
+        """Call assign_tool_to_group twice — second call returns existing."""
+        group = await create_group(
+            db_session, tenant_id=test_tenant.id, name="Tool Group"
+        )
+        tool = Tool(
+            id=str(uuid.uuid4()),
+            tenant_id=test_tenant.id,
+            name="Idempotent Test Tool",
+            type="datetime",
+            category="general",
+            config={},
+        )
+        db_session.add(tool)
+        await db_session.flush()
+
+        # First call — create
+        first = await assign_tool_to_group(db_session, group.id, tool.id)
+        assert first.tool_id == tool.id
+        assert first.group_id == group.id
+
+        # Second call — should return existing, not raise
+        second = await assign_tool_to_group(db_session, group.id, tool.id)
+        assert second.tool_id == tool.id
+        assert second.group_id == group.id
+        assert second.tool_id == first.tool_id
+        assert second.group_id == first.group_id  # same composite-PK row

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -51,6 +51,7 @@ The project uses **pytest** for backend testing. Tests are organized by marker a
 | `test_upload_flow.py` | 4 | File type/size validation, temp session guard, DeepSeek+image rejection |
 | `test_concurrency.py` | 8 | Stream cancellation, temp session TTL/races, rate limiter concurrency |
 | `test_regression.py` | 10 | Prompt/credential/chat/memory tenant isolation, temp upload guard |
+| `test_group_service.py` | 3 | Group CRUD idempotency (Issue #348) |
 
 ### Security & Isolation Tests
 


### PR DESCRIPTION


Duplicate-check branches in the group service re-read consumed SQLAlchemy results, leading to potential failures in idempotent operations. This update ensures that existing entities are read once and reused, preventing cursor-consumption errors.



## Related Issue



Closes #348



## Type of Change



- [x] Bug fix (non-breaking change that fixes an issue)



## Testing



- [x] Tested locally with Docker Compose (dev)

- [x] Backend tests pass (`pytest backend/tests/ -m "not e2e and not slow"`)



## Checklist



- [x] My code follows the coding conventions of this project

- [x] I have self-reviewed my own code

- [x] I have commented complex code sections, particularly in hard-to-understand areas

- [x] My changes generate no new warnings or errors

- [x] New and existing tests pass locally



## Additional Notes



New tests have been added to verify that duplicate operations return existing rows without errors.

