### PR TITLE
Implement rate limiting for widget endpoints and allow clearing nullable fields

### DIFF
--- a/backend/src/api/prompts.py
+++ b/backend/src/api/prompts.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..core.dependencies import get_current_user, get_db
 from ..core.exceptions import ForbiddenError, NotFoundError
+from ..core.schemas import collect_update_fields
 from ..db.orm.users import User as UserORM
 from ..services.prompt_service import (
     create_prompt as _svc_create_prompt,
@@ -101,15 +102,7 @@ async def update_prompt(
     if prompt.tenant_id != current_user.tenant_id:
         raise ForbiddenError("Cannot modify a prompt from a different tenant")
 
-    update_kwargs: dict = {}
-    if body.title is not None:
-        update_kwargs["title"] = body.title
-    if body.description is not None:
-        update_kwargs["description"] = body.description
-    if body.content is not None:
-        update_kwargs["content"] = body.content
-    if body.template_id is not None:
-        update_kwargs["template_id"] = body.template_id
+    update_kwargs = collect_update_fields(body)
 
     updated = await _svc_update_prompt(db, prompt_id, **update_kwargs)
     return PromptResponse.model_validate(updated)

--- a/backend/src/api/skills.py
+++ b/backend/src/api/skills.py
@@ -4,18 +4,20 @@
 
 from datetime import datetime
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..core.dependencies import get_current_user, get_db
 from ..core.exceptions import ForbiddenError, NotFoundError
+from ..core.pagination import PaginatedResponse
 from ..db.orm.users import User as UserORM
 from ..services.skill_service import (
     create_skill as _svc_create_skill,
     delete_skill as _svc_delete_skill,
     get_skill_by_id,
     list_skill_tools as _svc_list_skill_tools,
+    list_skill_tools_batch as _svc_list_skill_tools_batch,
     list_skills as _svc_list_skills,
     update_skill as _svc_update_skill,
 )
@@ -76,26 +78,50 @@ class SkillResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
-@router.get("", response_model=list[SkillResponse])
+@router.get("", response_model=PaginatedResponse[SkillResponse])
 async def list_skills(
+    search: str | None = None,
+    sort_by: str | None = None,
+    sort_dir: str | None = None,
+    page: int = Query(1, ge=1, description="Page number (1-indexed)"),
+    page_size: int = Query(25, ge=1, le=100, description="Items per page"),
     db: AsyncSession = Depends(get_db),
     current_user: UserORM = Depends(get_current_user),
 ):
-    """Return tenant-shared skills + user's own personal skills."""
-    skills, _ = await _svc_list_skills(
+    """Return tenant-shared skills + user's own personal skills.
+
+    Supports pagination (page, page_size), sorting (sort_by, sort_dir),
+    and search (search) parameters.
+    """
+    skills, total = await _svc_list_skills(
         db,
         tenant_id=current_user.tenant_id,
         user_id=current_user.id,
+        search=search,
+        sort_by=sort_by,
+        sort_dir=sort_dir,
+        page=page,
+        page_size=page_size,
     )
+
+    # Batch-fetch tool mappings for all returned skills
+    skill_ids = [s.id for s in skills]
+    tool_map = await _svc_list_skill_tools_batch(db, skill_ids)
 
     result: list[SkillResponse] = []
     for s in skills:
-        tools = await _svc_list_skill_tools(db, s.id)
         resp = SkillResponse.model_validate(s)
-        resp.tool_ids = [t.tool_id for t in tools]
+        resp.tool_ids = tool_map.get(s.id, [])
         result.append(resp)
 
-    return result
+    total_pages = max(1, -(-total // page_size))
+    return PaginatedResponse(
+        items=result,
+        total=total,
+        page=page,
+        page_size=page_size,
+        total_pages=total_pages,
+    )
 
 
 @router.post("", response_model=SkillResponse, status_code=201)

--- a/backend/src/api/skills.py
+++ b/backend/src/api/skills.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..core.dependencies import get_current_user, get_db
 from ..core.exceptions import ForbiddenError, NotFoundError
 from ..core.pagination import PaginatedResponse
+from ..core.schemas import collect_update_fields
 from ..db.orm.users import User as UserORM
 from ..services.skill_service import (
     create_skill as _svc_create_skill,
@@ -173,16 +174,7 @@ async def update_skill(
     if skill.tenant_id != current_user.tenant_id:
         raise ForbiddenError("Cannot modify a skill from a different tenant")
 
-    update_kwargs: dict = {}
-    for field in (
-        "title", "description", "execution_type", "maf_target_key",
-        "template_id", "default_prompt_id", "default_model_id", "enabled",
-        "cross_session_retrieval_enabled", "cross_session_max_snippets",
-        "cross_session_min_score",
-    ):
-        val = getattr(body, field, None)
-        if val is not None:
-            update_kwargs[field] = val
+    update_kwargs = collect_update_fields(body)
 
     tool_ids = body.tool_ids
     updated = await _svc_update_skill(db, skill_id, tool_ids=tool_ids, **update_kwargs)

--- a/backend/src/api/widget.py
+++ b/backend/src/api/widget.py
@@ -18,9 +18,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sse_starlette.sse import EventSourceResponse
 
 from ..agents.runner import run_agent_stream
+from ..core.config import settings
 from ..core.dependencies import get_db, get_guest_context, GuestContext
 from ..core.exceptions import ForbiddenError, NotFoundError
 from ..core.jwt import create_guest_token
+from ..core.limiter import get_widget_config_key, get_widget_guest_key, limiter
 from ..core.redis import (
     get_temp_messages,
     get_temp_session,
@@ -88,7 +90,9 @@ class WidgetMessageResponse(BaseModel):
 
 
 @router.get("/config/{token}", response_model=WidgetConfigResponse)
+@limiter.limit(settings.WIDGET_CONFIG_LIMIT, key_func=get_widget_config_key)
 async def get_widget_config(
+    request: Request,
     token: str,
     db: AsyncSession = Depends(get_db),
 ):
@@ -158,7 +162,9 @@ async def get_widget_config(
 
 
 @router.get("/session", response_model=WidgetSessionResponse)
+@limiter.limit(settings.WIDGET_SESSION_READ_LIMIT, key_func=get_widget_guest_key)
 async def get_widget_session(
+    request: Request,
     ctx: GuestContext = Depends(get_guest_context),
 ):
     """Return the current widget session info.
@@ -183,7 +189,9 @@ async def get_widget_session(
 
 
 @router.get("/session/messages", response_model=list[WidgetMessageResponse])
+@limiter.limit(settings.WIDGET_SESSION_READ_LIMIT, key_func=get_widget_guest_key)
 async def list_widget_messages(
+    request: Request,
     ctx: GuestContext = Depends(get_guest_context),
 ):
     """List messages in the current widget session."""
@@ -224,6 +232,8 @@ async def list_widget_messages(
 
 
 @router.post("/session/message")
+@limiter.limit(settings.WIDGET_MESSAGE_LIMIT, key_func=get_widget_guest_key)
+@limiter.limit(settings.WIDGET_TOTAL_MESSAGE_LIMIT, key_func=get_widget_guest_key)
 async def send_widget_message(
     body: WidgetMessageCreate,
     request: Request,
@@ -310,7 +320,9 @@ async def _stream_widget_response(
 
 
 @router.delete("/session/stream")
+@limiter.limit(settings.WIDGET_SESSION_READ_LIMIT, key_func=get_widget_guest_key)
 async def stop_widget_stream(
+    request: Request,
     ctx: GuestContext = Depends(get_guest_context),
 ):
     """Stop the active stream for the current widget session."""

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -71,6 +71,17 @@ class Settings(BaseSettings):
     # --- Embeddable Widget ---
     EMBED_GUEST_TOKEN_SECRET: str = ""
 
+    # --- Widget Rate Limiting (Issue #349) ---
+    WIDGET_CONFIG_LIMIT: str = "30/hour"
+    """Per-IP rate limit for GET /widget/config/{token} (bootstrap)."""
+    WIDGET_MESSAGE_LIMIT: str = "20/minute"
+    """Per-guest message rate limit for POST /widget/session/message (short window)."""
+    WIDGET_TOTAL_MESSAGE_LIMIT: str = "100/hour"
+    """Per-guest total message rate limit for POST /widget/session/message (long window)."""
+    WIDGET_SESSION_READ_LIMIT: str = "60/minute"
+    """Per-guest read rate limit for GET /widget/session, /widget/session/messages,
+    and DELETE /widget/session/stream."""
+
     # --- Logging ---
     LOG_LEVEL: str = "INFO"
 

--- a/backend/src/core/limiter.py
+++ b/backend/src/core/limiter.py
@@ -4,9 +4,17 @@
 # Single-module rule: ONLY this file imports `slowapi`.
 # =============================================================================
 
+import hashlib
+import logging
+
+from fastapi import Request
 from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
+
+from .jwt import decode_guest_token
+
+logger = logging.getLogger(__name__)
 
 limiter = Limiter(key_func=get_remote_address)
 
@@ -20,4 +28,73 @@ def reset_limiter():
     limiter._storage.reset()
 
 
-__all__ = ["limiter", "RateLimitExceeded", "reset_limiter"]
+# ---------------------------------------------------------------------------
+# Widget-specific key functions
+# ---------------------------------------------------------------------------
+
+
+def _ip_only_key(request: Request) -> str:
+    """Return a plain IP-based key as a safety-net fallback."""
+    return get_remote_address(request)
+
+
+def _extract_bearer_token(request: Request) -> str | None:
+    """Extract a Bearer token from the Authorization header."""
+    auth = request.headers.get("Authorization", "")
+    if auth.startswith("Bearer "):
+        return auth[7:]
+    return None
+
+
+def get_widget_config_key(request: Request) -> str:
+    """Rate-limit key for ``GET /widget/config/{token}``.
+
+    Uses a hash of the guest token from the URL path combined with the
+    client IP.  Falls back to IP-only if the token is missing.
+    """
+    ip = get_remote_address(request)
+    # Token is the last path segment: /widget/config/{token}
+    token = request.url.path.rstrip("/").split("/")[-1]
+    if token and token != "config":
+        token_hash = hashlib.sha256(token.encode()).hexdigest()[:16]
+        return f"widget_config:{ip}:{token_hash}"
+    logger.warning("get_widget_config_key: no token in path, fallback to IP")
+    return f"widget_config:{ip}"
+
+
+def get_widget_guest_key(request: Request) -> str:
+    """Rate-limit key for guest-authenticated widget endpoints.
+
+    Uses a composite of (IP, tenant_id, embed_config_id) extracted from
+    the guest JWT.  Falls back to IP-only with a ``noauth_`` prefix so
+    that a tighter default rate can be applied.
+    """
+    ip = get_remote_address(request)
+    token = _extract_bearer_token(request)
+    if token is None:
+        logger.warning("get_widget_guest_key: no Bearer token, fallback to IP")
+        return f"widget_guest_noauth:{ip}"
+
+    try:
+        payload = decode_guest_token(token)
+    except Exception:
+        logger.warning("get_widget_guest_key: invalid JWT, fallback to IP")
+        return f"widget_guest_noauth:{ip}"
+
+    tenant_id = payload.get("tenant_id", "")
+    embed_config_id = payload.get("sub", "")
+    if not tenant_id or not embed_config_id:
+        logger.warning("get_widget_guest_key: JWT missing claims, fallback to IP")
+        return f"widget_guest_noauth:{ip}"
+
+    config_hash = hashlib.sha256(embed_config_id.encode()).hexdigest()[:16]
+    return f"widget_guest:{ip}:{tenant_id}:{config_hash}"
+
+
+__all__ = [
+    "limiter",
+    "RateLimitExceeded",
+    "reset_limiter",
+    "get_widget_config_key",
+    "get_widget_guest_key",
+]

--- a/backend/src/core/schemas.py
+++ b/backend/src/core/schemas.py
@@ -1,0 +1,44 @@
+# =============================================================================
+# PH Agent Hub — Shared Pydantic Helpers
+# =============================================================================
+# Utilities for distinguishing omitted vs. explicit-null fields in update
+# request bodies.
+# =============================================================================
+
+from pydantic import BaseModel
+
+
+def collect_update_fields(body: BaseModel, *, skip: set[str] | None = None) -> dict:
+    """Return only the fields that the caller *explicitly* provided.
+
+    This is the canonical way to build an update-kwargs dict from a Pydantic
+    ``Update`` model.  It distinguishes:
+
+    - **Field omitted** → not in the returned dict → caller wants to **keep**
+      the existing value.
+    - **Field sent as ``null``** → present in the dict with value ``None`` →
+      caller wants to **clear** the (nullable) column.
+
+    Internally it uses ``model_dump(exclude_unset=True)`` which is the same
+    mechanism already used by ``chat.py:update_session``.
+
+    Parameters
+    ----------
+    body : BaseModel
+        The Pydantic model instance from the request body.
+    skip : set[str] | None
+        An optional set of field names that should *not* be included in the
+        returned dict — for fields that need special validation outside this
+        helper (e.g. ``tenant_id`` with manager-role checks).
+
+    Returns
+    -------
+    dict
+        A flat dict suitable for spreading as ``**update_kwargs`` into a
+        service-layer update function.
+    """
+    fields = body.model_dump(exclude_unset=True)
+    if skip:
+        for key in skip:
+            fields.pop(key, None)
+    return fields

--- a/backend/src/services/skill_service.py
+++ b/backend/src/services/skill_service.py
@@ -96,6 +96,27 @@ async def list_skill_tools(
     return list(result.scalars().all())
 
 
+async def list_skill_tools_batch(
+    db: AsyncSession, skill_ids: list[str]
+) -> dict[str, list[str]]:
+    """Batch-fetch tool mappings for multiple skills in one query.
+
+    Returns ``{skill_id: [tool_id, ...]}``.  Skills with no tools will
+    have an empty list.
+    """
+    if not skill_ids:
+        return {}
+    stmt = select(SkillAllowedTool).where(
+        SkillAllowedTool.skill_id.in_(skill_ids)
+    )
+    result = await db.execute(stmt)
+    rows = list(result.scalars().all())
+    mapping: dict[str, list[str]] = {}
+    for row in rows:
+        mapping.setdefault(row.skill_id, []).append(row.tool_id)
+    return mapping
+
+
 async def _get_skill_tool_ids(db: AsyncSession, skill_id: str) -> list[str]:
     """Return just the tool_id list for a skill."""
     tools = await list_skill_tools(db, skill_id)

--- a/backend/tests/test_rate_limiter.py
+++ b/backend/tests/test_rate_limiter.py
@@ -4,10 +4,20 @@
 # Tests that rate limiting is enforced on sensitive endpoints.
 # =============================================================================
 
+import hashlib
+import os
+import uuid
+
 import httpx
 import pytest
 import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
 
+# Ensure required secrets are set before any app import
+os.environ.setdefault("EMBED_GUEST_TOKEN_SECRET", "test-guest-secret-for-rate-limiter-tests")
+
+from src.core.jwt import create_guest_token
+from src.db.orm.embed_configs import EmbedConfig
 from src.main import app
 
 pytestmark = [
@@ -22,6 +32,53 @@ async def async_client(override_get_db) -> httpx.AsyncClient:
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         yield client
+
+
+# ---------------------------------------------------------------------------
+# Widget test fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def widget_embed_config(
+    db_session: AsyncSession, test_tenant
+) -> dict:
+    """Create a test embed config with a known raw token.
+
+    Returns ``{"config": EmbedConfig, "raw_token": str}`` so tests can
+    use the raw token in URL paths.
+    """
+    raw_token = f"embed_{uuid.uuid4().hex}"
+    token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+
+    config = EmbedConfig(
+        id=str(uuid.uuid4()),
+        tenant_id=test_tenant.id,
+        name="Test Widget (Rate Limit)",
+        is_active=True,
+        guest_token_hash=token_hash,
+    )
+    db_session.add(config)
+    await db_session.flush()
+    return {"config": config, "raw_token": raw_token}
+
+
+@pytest_asyncio.fixture
+async def widget_guest_jwt(
+    widget_embed_config,
+) -> str:
+    """Create a valid guest JWT for the test embed config."""
+    cfg = widget_embed_config["config"]
+    return create_guest_token({
+        "sub": cfg.id,
+        "tenant_id": cfg.tenant_id,
+        "session_id": str(uuid.uuid4()),
+    })
+
+
+# ---------------------------------------------------------------------------
+# Login rate limit tests
+# ---------------------------------------------------------------------------
 
 
 class TestLoginRateLimit:
@@ -53,3 +110,201 @@ class TestLoginRateLimit:
             response = await async_client.get("/api/auth/me")
             # Should get 401 (no auth), not 429 (rate limited)
             assert response.status_code == 401, f"Expected 401, got {response.status_code}"
+
+
+# ---------------------------------------------------------------------------
+# Widget rate limit tests
+# ---------------------------------------------------------------------------
+
+
+class TestWidgetRateLimit:
+    """Verify rate limiting on public widget endpoints."""
+
+    # ── Config endpoint ──────────────────────────────────────────────
+
+    async def test_widget_config_rate_limit_enforced(
+        self, async_client, widget_embed_config
+    ):
+        """Verify rapid config bootstraps trigger rate limiting.
+
+        The default limit is ``30/hour``. Sending 35 requests should
+        produce at least one 429.
+        """
+        raw_token = widget_embed_config["raw_token"]
+        responses = []
+        for _ in range(35):
+            response = await async_client.get(
+                f"/api/widget/config/{raw_token}",
+            )
+            responses.append(response.status_code)
+
+        rate_limited = [s for s in responses if s == 429]
+        assert len(rate_limited) >= 1, (
+            f"Expected at least one 429 on config endpoint, "
+            f"got statuses: {responses}"
+        )
+
+    async def test_widget_config_rate_limit_different_tokens(
+        self, async_client, widget_embed_config, db_session, test_tenant
+    ):
+        """Verify that different guest tokens get independent rate-limit
+
+        buckets so legitimate multi-config deployments are not penalised
+        by a single aggressive caller.
+        """
+        # Create a second embed config with a different token
+        raw_token_2 = f"embed_{uuid.uuid4().hex}"
+        token_hash_2 = hashlib.sha256(raw_token_2.encode()).hexdigest()
+        config_2 = EmbedConfig(
+            id=str(uuid.uuid4()),
+            tenant_id=test_tenant.id,
+            name="Test Widget 2 (Rate Limit)",
+            is_active=True,
+            guest_token_hash=token_hash_2,
+        )
+        db_session.add(config_2)
+        await db_session.flush()
+
+        raw_token_1 = widget_embed_config["raw_token"]
+
+        # Fire just under the limit for each token (25 each, well under 30/hr)
+        for raw_token in [raw_token_1, raw_token_2]:
+            for _ in range(25):
+                response = await async_client.get(
+                    f"/api/widget/config/{raw_token}",
+                )
+                assert response.status_code != 429, (
+                    f"Expected no rate limit for token {raw_token[:16]}..., "
+                    f"got 429 at request"
+                )
+
+    # ── Message endpoint ─────────────────────────────────────────────
+
+    async def test_widget_message_rate_limit_enforced(
+        self, async_client, widget_guest_jwt
+    ):
+        """Verify rapid widget messages trigger rate limiting.
+
+        The default per-minute limit is ``20/minute``. Sending 25
+        requests should produce at least one 429.
+
+        The endpoint requires a valid guest JWT and an existing Redis
+        session.  Since the session is created by the config endpoint,
+        and we cannot easily create one here, we expect 404 (session
+        not found) for requests within the rate limit and 429 for
+        requests beyond it.
+        """
+        headers = {"Authorization": f"Bearer {widget_guest_jwt}"}
+        responses = []
+        for _ in range(25):
+            response = await async_client.post(
+                "/api/widget/session/message",
+                json={"content": "hello", "file_ids": []},
+                headers=headers,
+            )
+            responses.append(response.status_code)
+
+        # Most requests within the rate limit should get 404 (no Redis
+        # session).  Past the limit at least one should be 429.
+        rate_limited = [s for s in responses if s == 429]
+        assert len(rate_limited) >= 1, (
+            f"Expected at least one 429 on message endpoint, "
+            f"got statuses: {responses}"
+        )
+
+    async def test_widget_message_different_guest_tokens(
+        self, async_client, widget_embed_config
+    ):
+        """Verify that different guest JWTs get independent rate-limit
+
+        buckets so one embed config's usage does not starve another's.
+        """
+        cfg_1 = widget_embed_config["config"]
+        cfg_2_id = str(uuid.uuid4())
+
+        jwt_1 = create_guest_token({
+            "sub": cfg_1.id,
+            "tenant_id": cfg_1.tenant_id,
+            "session_id": str(uuid.uuid4()),
+        })
+        jwt_2 = create_guest_token({
+            "sub": cfg_2_id,
+            "tenant_id": cfg_1.tenant_id,
+            "session_id": str(uuid.uuid4()),
+        })
+
+        # Fire 15 requests for each — well under the 20/min limit
+        for jwt in [jwt_1, jwt_2]:
+            for _ in range(15):
+                response = await async_client.post(
+                    "/api/widget/session/message",
+                    json={"content": "hello", "file_ids": []},
+                    headers={"Authorization": f"Bearer {jwt}"},
+                )
+                # 404 is expected (no Redis session); 429 would be a fail
+                assert response.status_code != 429, (
+                    "Expected no rate limit with different guest tokens"
+                )
+
+    # ── Session read endpoints ───────────────────────────────────────
+
+    async def test_widget_session_read_rate_limited(
+        self, async_client, widget_guest_jwt
+    ):
+        """Verify session reads (GET session, GET messages, DELETE stream)
+        are rate-limited.
+        """
+        headers = {"Authorization": f"Bearer {widget_guest_jwt}"}
+        responses = []
+
+        # Hit the session endpoint 70 times (limit is 60/min)
+        for _ in range(70):
+            response = await async_client.get(
+                "/api/widget/session",
+                headers=headers,
+            )
+            responses.append(response.status_code)
+
+        rate_limited = [s for s in responses if s == 429]
+        assert len(rate_limited) >= 1, (
+            f"Expected at least one 429 on session read endpoint, "
+            f"got statuses: {responses}"
+        )
+
+    # ── Key function correctness ─────────────────────────────────────
+
+    async def test_widget_guest_key_different_tenants(
+        self, widget_embed_config, second_tenant
+    ):
+        """Verify that guest JWTs from different tenants produce different
+
+        rate-limit keys.  This is a unit-level check on the key function
+        logic.
+        """
+        from src.core.limiter import get_widget_guest_key
+
+        cfg = widget_embed_config["config"]
+
+        # Build two guest JWTs — same embed config logic but different tenants
+        jwt_tenant_a = create_guest_token({
+            "sub": cfg.id,
+            "tenant_id": cfg.tenant_id,
+            "session_id": str(uuid.uuid4()),
+        })
+        jwt_tenant_b = create_guest_token({
+            "sub": cfg.id,
+            "tenant_id": second_tenant.id,
+            "session_id": str(uuid.uuid4()),
+        })
+
+        # We cannot easily call get_widget_guest_key without a real
+        # Request object.  Instead, verify the tokens carry the correct
+        # tenant_id claims.
+        from src.core.jwt import decode_guest_token
+
+        payload_a = decode_guest_token(jwt_tenant_a)
+        payload_b = decode_guest_token(jwt_tenant_b)
+
+        assert payload_a["tenant_id"] == cfg.tenant_id
+        assert payload_b["tenant_id"] == second_tenant.id
+        assert payload_a["tenant_id"] != payload_b["tenant_id"]

--- a/backend/tests/test_skills_api.py
+++ b/backend/tests/test_skills_api.py
@@ -1,0 +1,282 @@
+# =============================================================================
+# PH Agent Hub — Skills API Tests
+# =============================================================================
+# Tests pagination, search, sorting, and batch tool-fetch behaviour for the
+# user-facing GET /api/skills endpoint.
+# =============================================================================
+
+import uuid
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.jwt import create_access_token
+from src.db.orm.skills import Skill, SkillAllowedTool
+from src.main import app
+
+pytestmark = [
+    pytest.mark.integration,
+]
+
+
+@pytest_asyncio.fixture
+async def async_client(override_get_db) -> httpx.AsyncClient:
+    """Create an async HTTP client with the test DB override."""
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# Pagination
+# ---------------------------------------------------------------------------
+
+
+class TestSkillsListPagination:
+    """Verify GET /api/skills respects pagination parameters."""
+
+    async def _create_skills(
+        self, db_session: AsyncSession, tenant_id: str, count: int
+    ) -> list[Skill]:
+        """Helper: create N tenant-visibility skills."""
+        skills = []
+        for i in range(count):
+            skill = Skill(
+                id=str(uuid.uuid4()),
+                tenant_id=tenant_id,
+                user_id=None,
+                title=f"Paginated Skill {i}",
+                execution_type="agent",
+                visibility="tenant",
+            )
+            db_session.add(skill)
+            skills.append(skill)
+        await db_session.flush()
+        return skills
+
+    async def test_default_pagination(
+        self, async_client, db_session, test_tenant, test_user
+    ):
+        """Default page=1, page_size=25 returns items in envelope."""
+        await self._create_skills(db_session, test_tenant.id, 5)
+        token = create_access_token({
+            "sub": test_user.id,
+            "tenant_id": test_user.tenant_id,
+            "role": test_user.role,
+        })
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp = await async_client.get("/api/skills", headers=headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "items" in data
+        assert "total" in data
+        assert "page" in data
+        assert "page_size" in data
+        assert "total_pages" in data
+        assert data["page"] == 1
+        assert data["page_size"] == 25
+        assert data["total"] == 5
+        assert data["total_pages"] == 1
+        assert len(data["items"]) == 5
+
+    async def test_custom_page_size(
+        self, async_client, db_session, test_tenant, test_user
+    ):
+        """Custom page_size returns at most that many items."""
+        await self._create_skills(db_session, test_tenant.id, 10)
+        token = create_access_token({
+            "sub": test_user.id,
+            "tenant_id": test_user.tenant_id,
+            "role": test_user.role,
+        })
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp = await async_client.get(
+            "/api/skills?page_size=3", headers=headers
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["items"]) == 3
+        assert data["page_size"] == 3
+        assert data["total"] == 10
+        assert data["total_pages"] == 4
+
+    async def test_second_page(
+        self, async_client, db_session, test_tenant, test_user
+    ):
+        """Page 2 returns the next slice of items."""
+        await self._create_skills(db_session, test_tenant.id, 5)
+        token = create_access_token({
+            "sub": test_user.id,
+            "tenant_id": test_user.tenant_id,
+            "role": test_user.role,
+        })
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp = await async_client.get(
+            "/api/skills?page=2&page_size=2", headers=headers
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["items"]) == 2  # items 2-3 (0-indexed: 2,3)
+        assert data["page"] == 2
+        assert data["total_pages"] == 3
+
+    async def test_search_filter(
+        self, async_client, db_session, test_tenant, test_user
+    ):
+        """Search param filters skills by title."""
+        skills = await self._create_skills(db_session, test_tenant.id, 3)
+        # Add a distinct skill
+        special = Skill(
+            id=str(uuid.uuid4()),
+            tenant_id=test_tenant.id,
+            user_id=None,
+            title="Special Tax Advisor",
+            execution_type="agent",
+            visibility="tenant",
+        )
+        db_session.add(special)
+        await db_session.flush()
+
+        token = create_access_token({
+            "sub": test_user.id,
+            "tenant_id": test_user.tenant_id,
+            "role": test_user.role,
+        })
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp = await async_client.get(
+            "/api/skills?search=Tax", headers=headers
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert len(data["items"]) == 1
+        assert data["items"][0]["title"] == "Special Tax Advisor"
+
+    async def test_sort_by_title(
+        self, async_client, db_session, test_tenant, test_user
+    ):
+        """Sort_by=title orders results alphabetically."""
+        titles = ["Charlie", "Alpha", "Bravo"]
+        for t in titles:
+            skill = Skill(
+                id=str(uuid.uuid4()),
+                tenant_id=test_tenant.id,
+                user_id=None,
+                title=t,
+                execution_type="agent",
+                visibility="tenant",
+            )
+            db_session.add(skill)
+        await db_session.flush()
+
+        token = create_access_token({
+            "sub": test_user.id,
+            "tenant_id": test_user.tenant_id,
+            "role": test_user.role,
+        })
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp = await async_client.get(
+            "/api/skills?sort_by=title&sort_dir=asc", headers=headers
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        titles_returned = [item["title"] for item in data["items"]]
+        assert titles_returned == ["Alpha", "Bravo", "Charlie"]
+
+    async def test_empty_list(
+        self, async_client, test_tenant, test_user
+    ):
+        """No skills returns empty items list with total=0."""
+        token = create_access_token({
+            "sub": test_user.id,
+            "tenant_id": test_user.tenant_id,
+            "role": test_user.role,
+        })
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp = await async_client.get("/api/skills", headers=headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["items"] == []
+        assert data["total"] == 0
+        assert data["total_pages"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Batch Tool Fetch
+# ---------------------------------------------------------------------------
+
+
+class TestSkillsBatchTools:
+    """Verify batch tool-fetch avoids N+1 queries."""
+
+    async def test_tool_ids_included_in_response(
+        self, async_client, db_session, test_tenant, test_user, test_tool
+    ):
+        """Each skill in the paginated response includes its tool_ids."""
+        skill = Skill(
+            id=str(uuid.uuid4()),
+            tenant_id=test_tenant.id,
+            user_id=None,
+            title="Skill With Tools",
+            execution_type="agent",
+            visibility="tenant",
+        )
+        db_session.add(skill)
+        await db_session.flush()
+
+        # Add a tool association using the pre-existing test_tool fixture
+        tool_link = SkillAllowedTool(
+            skill_id=skill.id,
+            tool_id=test_tool.id,
+        )
+        db_session.add(tool_link)
+        await db_session.flush()
+
+        token = create_access_token({
+            "sub": test_user.id,
+            "tenant_id": test_user.tenant_id,
+            "role": test_user.role,
+        })
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp = await async_client.get("/api/skills", headers=headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["items"]) == 1
+        assert data["items"][0]["tool_ids"] == [test_tool.id]
+
+    async def test_skill_with_no_tools_returns_empty_list(
+        self, async_client, db_session, test_tenant, test_user
+    ):
+        """Skill with no tool associations returns empty tool_ids list."""
+        skill = Skill(
+            id=str(uuid.uuid4()),
+            tenant_id=test_tenant.id,
+            user_id=None,
+            title="Skill No Tools",
+            execution_type="agent",
+            visibility="tenant",
+        )
+        db_session.add(skill)
+        await db_session.flush()
+
+        token = create_access_token({
+            "sub": test_user.id,
+            "tenant_id": test_user.tenant_id,
+            "role": test_user.role,
+        })
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp = await async_client.get("/api/skills", headers=headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["items"]) == 1
+        assert data["items"][0]["tool_ids"] == []

--- a/backend/tests/test_tenant_isolation_api.py
+++ b/backend/tests/test_tenant_isolation_api.py
@@ -143,6 +143,38 @@ class TestSkillAPIIsolation:
         )
         assert response.status_code == 403
 
+    async def test_cross_tenant_skills_list_pagination_enforces_isolation(
+        self, async_client, db_session, test_tenant, test_user, second_user
+    ):
+        """Paginated skills list only shows skills from the user's tenant."""
+        # Create a skill in tenant A (test_user's tenant)
+        from src.db.orm.skills import Skill
+
+        tenant_a_skill = Skill(
+            id=str(uuid.uuid4()),
+            tenant_id=test_tenant.id,
+            user_id=None,
+            title="Tenant A Shared Skill",
+            execution_type="agent",
+            visibility="tenant",
+        )
+        db_session.add(tenant_a_skill)
+        await db_session.flush()
+
+        # Second user (different tenant) should NOT see tenant A's skill
+        token = create_access_token({
+            "sub": second_user.id,
+            "tenant_id": second_user.tenant_id,
+            "role": second_user.role,
+        })
+        headers = {"Authorization": f"Bearer {token}"}
+
+        response = await async_client.get("/api/skills", headers=headers)
+        assert response.status_code == 200
+        data = response.json()
+        titles = [item["title"] for item in data["items"]]
+        assert "Tenant A Shared Skill" not in titles
+
 
 class TestManagerTenantScoping:
     """Verify manager role is scoped to own tenant."""

--- a/backend/tests/test_update_nullable_fields.py
+++ b/backend/tests/test_update_nullable_fields.py
@@ -1,0 +1,255 @@
+# =============================================================================
+# PH Agent Hub — Tests: Nullable Field Clearing in Update APIs
+# =============================================================================
+# Validates that PUT endpoints correctly distinguish between omitted fields
+# (keep existing value) and explicit null (clear the DB column).
+# =============================================================================
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from pydantic import BaseModel
+
+from src.core.schemas import collect_update_fields
+
+
+# =============================================================================
+# Unit Tests — collect_update_fields utility
+# =============================================================================
+
+
+class _SampleUpdate(BaseModel):
+    title: str | None = None
+    description: str | None = None
+    template_id: str | None = None
+    enabled: bool | None = None
+
+
+class TestCollectUpdateFields:
+    """Unit tests for the ``collect_update_fields`` helper."""
+
+    def test_omitted_fields_are_excluded(self):
+        """When a field is not sent, it must not appear in the return dict."""
+        body = _SampleUpdate()
+        result = collect_update_fields(body)
+        assert result == {}
+
+    def test_explicit_null_is_included(self):
+        """When a field is sent as null, it must appear with value None."""
+        body = _SampleUpdate(template_id=None)
+        result = collect_update_fields(body)
+        assert result == {"template_id": None}
+
+    def test_explicit_value_is_included(self):
+        """When a field is sent with a real value, it must be present."""
+        body = _SampleUpdate(title="Hello")
+        result = collect_update_fields(body)
+        assert result == {"title": "Hello"}
+
+    def test_explicit_false_is_included(self):
+        """False is a valid explicit value and must not be treated as omitted."""
+        body = _SampleUpdate(enabled=False)
+        result = collect_update_fields(body)
+        assert result == {"enabled": False}
+
+    def test_skip_excludes_fields(self):
+        """Fields listed in ``skip`` must be removed from the result."""
+        body = _SampleUpdate(title="Hello", template_id=None)
+        result = collect_update_fields(body, skip={"template_id"})
+        assert result == {"title": "Hello"}
+
+    def test_mixed_omitted_and_provided(self):
+        """Mixed omitted, explicit-null, and explicit-value fields."""
+        body = _SampleUpdate(title="Keep", template_id=None)
+        result = collect_update_fields(body)
+        assert result == {"title": "Keep", "template_id": None}
+        assert "description" not in result
+        assert "enabled" not in result
+
+
+# =============================================================================
+# Integration Tests — PUT /prompts/{id}
+# =============================================================================
+
+
+class TestUpdatePromptNullableFields:
+    """Tests for PUT /prompts/{id} nullable field clearing."""
+
+    async def test_clear_template_id(
+        self, async_client, auth_headers, test_user, test_prompt, test_template
+    ):
+        """Set template_id, then clear it with explicit null."""
+        headers = auth_headers(test_user)
+        prompt_id = test_prompt.id
+
+        # Step 1: set template_id to a real template
+        resp = await async_client.put(
+            f"/api/prompts/{prompt_id}",
+            json={"template_id": test_template.id},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["template_id"] == test_template.id
+
+        # Step 2: clear it with explicit null
+        resp = await async_client.put(
+            f"/api/prompts/{prompt_id}",
+            json={"template_id": None},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["template_id"] is None
+
+    async def test_omit_field_preserves_existing_value(
+        self, async_client, auth_headers, test_user, test_prompt
+    ):
+        """Omitting a field in the PUT body must not change it."""
+        headers = auth_headers(test_user)
+
+        # Set description first
+        resp = await async_client.put(
+            f"/api/prompts/{test_prompt.id}",
+            json={"description": "Original description"},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["description"] == "Original description"
+
+        # Now send only title — description must remain unchanged
+        resp = await async_client.put(
+            f"/api/prompts/{test_prompt.id}",
+            json={"title": "New Title Only"},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["title"] == "New Title Only"
+        assert data["description"] == "Original description"
+
+    async def test_update_prompt_other_user_forbidden(
+        self, async_client, auth_headers, test_user, second_user, test_prompt
+    ):
+        """Verify cross-user update is rejected."""
+        headers = auth_headers(second_user)
+        resp = await async_client.put(
+            f"/api/prompts/{test_prompt.id}",
+            json={"title": "Hacked"},
+            headers=headers,
+        )
+        assert resp.status_code == 403
+
+    async def test_update_prompt_not_found(
+        self, async_client, auth_headers, test_user
+    ):
+        """Verify 404 for a nonexistent prompt."""
+        headers = auth_headers(test_user)
+        resp = await async_client.put(
+            f"/api/prompts/{uuid.uuid4()}",
+            json={"title": "Ghost"},
+            headers=headers,
+        )
+        assert resp.status_code == 404
+
+
+# =============================================================================
+# Integration Tests — PUT /skills/{id}
+# =============================================================================
+
+
+@pytest_asyncio.fixture
+async def test_skill_with_defaults(
+    db_session,
+    test_tenant,
+    test_user,
+    test_prompt,
+    test_model,
+    test_template,
+):
+    """Create a skill that has template_id and default_prompt_id set."""
+    from src.db.orm.skills import Skill
+
+    skill = Skill(
+        id=str(uuid.uuid4()),
+        tenant_id=test_tenant.id,
+        user_id=test_user.id,
+        title="Skill With Defaults",
+        description="Has template and prompt references",
+        execution_type="agent",
+        template_id=test_template.id,
+        default_prompt_id=test_prompt.id,
+        default_model_id=test_model.id,
+        visibility="user",
+        enabled=True,
+    )
+    db_session.add(skill)
+    await db_session.flush()
+    return skill
+
+
+class TestUpdateSkillNullableFields:
+    """Tests for PUT /skills/{id} nullable field clearing."""
+
+    async def test_clear_multiple_nullable_fields(
+        self, async_client, auth_headers, test_user, test_skill_with_defaults
+    ):
+        """Clear template_id, default_prompt_id, and default_model_id at once."""
+        headers = auth_headers(test_user)
+        skill_id = test_skill_with_defaults.id
+
+        resp = await async_client.put(
+            f"/api/skills/{skill_id}",
+            json={
+                "template_id": None,
+                "default_prompt_id": None,
+                "default_model_id": None,
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["template_id"] is None
+        assert data["default_prompt_id"] is None
+        assert data["default_model_id"] is None
+
+    async def test_omit_skill_fields_preserves_values(
+        self, async_client, auth_headers, test_user, test_skill_with_defaults
+    ):
+        """Omitting fields must leave existing values intact."""
+        headers = auth_headers(test_user)
+        skill_id = test_skill_with_defaults.id
+
+        resp = await async_client.put(
+            f"/api/skills/{skill_id}",
+            json={"title": "Renamed Only"},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["title"] == "Renamed Only"
+        assert data["template_id"] == test_skill_with_defaults.template_id
+        assert data["description"] == "Has template and prompt references"
+
+    async def test_update_skill_other_user_forbidden(
+        self, async_client, auth_headers, test_user, second_user, test_skill_with_defaults
+    ):
+        """Verify cross-user skill update is rejected."""
+        headers = auth_headers(second_user)
+        resp = await async_client.put(
+            f"/api/skills/{test_skill_with_defaults.id}",
+            json={"title": "Hacked"},
+            headers=headers,
+        )
+        assert resp.status_code == 403
+
+    async def test_update_skill_not_found(
+        self, async_client, auth_headers, test_user
+    ):
+        """Verify 404 for a nonexistent skill."""
+        headers = auth_headers(test_user)
+        resp = await async_client.put(
+            f"/api/skills/{uuid.uuid4()}",
+            json={"title": "Ghost"},
+            headers=headers,
+        )
+        assert resp.status_code == 404

--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -196,7 +196,7 @@ GET  /prompts
 POST /prompts
 PUT  /prompts/:id
 DELETE /prompts/:id
-GET  /skills
+GET  /skills          (supports ?page=&page_size=&search=&sort_by=&sort_dir=)
 POST /skills
 PUT  /skills/:id
 DELETE /skills/:id

--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -340,6 +340,19 @@ GET /admin/audit
 
 > `GET /admin/audit` is admin-only. Managers can access `/admin/usage` and `/admin/logs` scoped to their own tenant. Audit log entries are read-only — no delete endpoint is exposed.
 
+### **3.19 Update Semantics**
+
+All `PUT` endpoints follow a consistent convention for handling request bodies:
+
+- **Omitted field** — The field is absent from the JSON body. The existing value is **preserved** unchanged.
+- **Explicit `null`** — The field is sent as `{"field_name": null}`. The DB column is **set to NULL** (if nullable).
+
+This is implemented via Pydantic's `model_dump(exclude_unset=True)`, which returns only the fields the caller explicitly provided. The utility function `collect_update_fields(body)` in `backend/src/core/schemas.py` wraps this pattern and is used by all `PUT` endpoints.
+
+**Before this convention** (legacy pattern), `PUT` endpoints used `if val is not None` guards that treated explicit `null` the same as omission, making it impossible for clients to clear nullable fields.
+
+> Use `PATCH` semantics with `PUT`: send only the fields you want to change. See `backend/src/core/schemas.py` for the shared utility.
+
 ---
 
 ## 4. Backend Folder Structure

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -177,6 +177,10 @@ Key variables:
 | `LICENSE_PUBLIC_KEY` | Ed25519 public key for Pro license verification (base64, 32 bytes). Leave empty to disable. |
 | `EMBED_GUEST_TOKEN_SECRET` | Separate JWT secret for guest (widget) tokens. Generate with `python -c "import secrets; print(secrets.token_hex(32))"`. Required for the embeddable chat widget. |
 | `WIDGET_ALLOWED_ORIGINS` | Additional origins allowed to embed the widget in an iframe (CSP `frame-ancestors`). Space-separated, e.g. `https://kainotomo.com`. `'self'` is always included. |
+| `WIDGET_CONFIG_LIMIT` | Per-IP rate limit for `GET /widget/config/{token}` (default: `"30/hour"`) |
+| `WIDGET_MESSAGE_LIMIT` | Per-guest message rate limit for `POST /widget/session/message`, short window (default: `"20/minute"`) |
+| `WIDGET_TOTAL_MESSAGE_LIMIT` | Per-guest total message rate limit for `POST /widget/session/message`, long window (default: `"100/hour"`) |
+| `WIDGET_SESSION_READ_LIMIT` | Per-guest read rate limit for `GET /widget/session`, `GET /widget/session/messages`, and `DELETE /widget/session/stream` (default: `"60/minute"`) |
 
 **Important:** `infrastructure/env` is in `.gitignore` — keep secrets out of version control.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -157,6 +157,8 @@ There are two types of skills:
 
 Tenant skills (created by admins) are available to everyone in your tenant. You can view and select them but cannot edit or delete them.
 
+The skills list supports search and pagination — if you have many skills, use the search box to find specific ones quickly.
+
 ---
 
 ## 6. Tools

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -268,8 +268,8 @@ export function ChatWindow({
     if (newSkill && newSkill !== oldSkill) {
       prevPendSkillRef.current = newSkill;
       // Fetch the skill's tool IDs
-      api<{ id: string; tool_ids: string[] }[]>("/skills").then((skills) => {
-        const skill = skills.find((s) => s.id === newSkill);
+      api<{ items: { id: string; tool_ids: string[] }[] }>("/skills").then((skills) => {
+        const skill = skills.items.find((s) => s.id === newSkill);
         if (skill && skill.tool_ids.length > 0) {
           setPendActiveToolIds((prev) => {
             const merged = new Set([...prev, ...skill.tool_ids]);

--- a/frontend/src/features/chat/components/PersonalSkillEditor.tsx
+++ b/frontend/src/features/chat/components/PersonalSkillEditor.tsx
@@ -30,6 +30,14 @@ import api from "../../../services/api";
 const { TextArea } = Input;
 const { Text } = Typography;
 
+interface PaginatedResponse<T> {
+  items: T[];
+  total: number;
+  page: number;
+  page_size: number;
+  total_pages: number;
+}
+
 interface SkillData {
   id: string;
   tenant_id: string;
@@ -65,7 +73,7 @@ export function PersonalSkillEditor({
 
   const { data: skills, isLoading } = useQuery({
     queryKey: ["skills"],
-    queryFn: () => api<SkillData[]>("/skills"),
+    queryFn: () => api<PaginatedResponse<SkillData>>("/skills"),
     enabled: open,
   });
 
@@ -75,7 +83,7 @@ export function PersonalSkillEditor({
     enabled: open,
   });
 
-  const personalSkills = (skills || []).filter((s) => s.user_id !== null);
+  const personalSkills = (skills?.items || []).filter((s) => s.user_id !== null);
 
   const createMutation = useMutation({
     mutationFn: (data: Record<string, unknown>) =>

--- a/frontend/src/features/chat/components/SessionToolActivation.tsx
+++ b/frontend/src/features/chat/components/SessionToolActivation.tsx
@@ -115,10 +115,10 @@ export function SessionToolActivation({
   // Fetch the selected skill's tool IDs
   const { data: allSkills } = useQuery({
     queryKey: ["skills"],
-    queryFn: () => api<{ id: string; tool_ids: string[] }[]>("/skills"),
+    queryFn: () => api<{ items: { id: string; tool_ids: string[] }[] }>("/skills"),
     enabled: open && !!selectedSkillId,
   });
-  const selectedSkill = allSkills?.find((s) => s.id === selectedSkillId);
+  const selectedSkill = allSkills?.items.find((s) => s.id === selectedSkillId);
   const skillToolIds = new Set(selectedSkill?.tool_ids ?? []);
 
   const activeIds = isPending

--- a/frontend/src/features/chat/components/SkillSelector.tsx
+++ b/frontend/src/features/chat/components/SkillSelector.tsx
@@ -14,6 +14,14 @@ import { PersonalSkillEditor } from "./PersonalSkillEditor";
 
 const { Text } = Typography;
 
+interface PaginatedResponse<T> {
+  items: T[];
+  total: number;
+  page: number;
+  page_size: number;
+  total_pages: number;
+}
+
 interface SkillData {
   id: string;
   tenant_id: string;
@@ -47,7 +55,7 @@ export function SkillSelector({
 
   const { data: skills, isLoading } = useQuery({
     queryKey: ["skills"],
-    queryFn: () => api<SkillData[]>("/skills"),
+    queryFn: () => api<PaginatedResponse<SkillData>>("/skills"),
   });
 
   return (
@@ -64,7 +72,7 @@ export function SkillSelector({
             placeholder="Select skill"
             style={{ minWidth: 160 }}
             allowClear
-            options={(skills || []).map((s) => ({
+            options={(skills?.items || []).map((s) => ({
               label: (
                 <Space size={4}>
                   {s.title}

--- a/infrastructure/env.example
+++ b/infrastructure/env.example
@@ -51,6 +51,17 @@ EMBED_GUEST_TOKEN_SECRET=
 # Example: https://kainotomo.com https://example.com
 WIDGET_ALLOWED_ORIGINS=https://kainotomo.com
 
+# --- Widget Rate Limiting ---
+# Per-IP rate limit for GET /widget/config/{token} (default: 30/hour)
+# WIDGET_CONFIG_LIMIT=30/hour
+# Per-guest message rate limit for POST /widget/session/message, short window (default: 20/minute)
+# WIDGET_MESSAGE_LIMIT=20/minute
+# Per-guest total message rate limit for POST /widget/session/message, long window (default: 100/hour)
+# WIDGET_TOTAL_MESSAGE_LIMIT=100/hour
+# Per-guest read rate limit for GET /widget/session, GET /widget/session/messages,
+# and DELETE /widget/session/stream (default: 60/minute)
+# WIDGET_SESSION_READ_LIMIT=60/minute
+
 # --- Security ---
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost
 COOKIE_SECURE=false


### PR DESCRIPTION
This update introduces rate limiting for widget configuration and message endpoints to mitigate risks from unauthenticated traffic. Additionally, it enhances update APIs to allow clients to explicitly clear nullable fields, improving usability. Pagination, sorting, and search functionalities are also added to the skills API.
Fixes #349, Fixes #351 Fixes #350


