### PR TITLE
Fix file upload failure for temporary sessions

### DIFF
--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -2266,6 +2266,37 @@ async def upload_file(
         }
         await store_temp_session(session_id, data)
 
+    # ---- Temp → permanent promotion (Issue #368) -----------------------
+    # If the session is temporary (either newly lazy-created or loaded
+    # from Redis as “New Chat”), promote it to permanent before
+    # proceeding with the upload.
+    if data.get("is_temporary"):
+        logger.info(
+            "Promoting temp session %s to permanent on file upload",
+            session_id,
+        )
+        session_create = SessionCreate(
+            title=data.get("title", "New Chat"),
+            is_temporary=False,
+            is_pinned=data.get("is_pinned", False),
+            selected_template_id=data.get("selected_template_id"),
+            selected_skill_id=data.get("selected_skill_id"),
+            selected_model_id=data.get("selected_model_id"),
+            active_tool_ids=data.get("active_tool_ids"),
+            thinking_enabled=data.get("thinking_enabled"),
+            temperature=data.get("temperature"),
+            auto_route_enabled=data.get("auto_route_enabled", False),
+            auto_select_tools=data.get("auto_select_tools", True),
+        )
+        data = await _lazy_create_session(
+            db, session_id, session_create, current_user,
+        )
+        # Re-link any files uploaded during the pending phase
+        await upload_service.link_pending_uploads_to_session(
+            db, session_id, current_user.id,
+        )
+        await delete_temp_session(session_id)
+
     if not file.filename:
         raise ValidationError("File must have a filename")
 

--- a/backend/src/services/upload_service.py
+++ b/backend/src/services/upload_service.py
@@ -246,8 +246,10 @@ async def create_upload(
     # 3. Determine if this is a temporary session
     is_temp = session_data.get("is_temporary", False)
 
-    # 3a. Reject uploads to temporary sessions (lazy / guest sessions)
-    #     that have not yet been promoted to permanent.
+    # 3a. Temporary sessions are rejected here.  The upload endpoint
+    #     (upload_file in chat.py) promotes temp sessions to permanent
+    #     before calling this function, so this branch should be
+    #     unreachable under normal operation.
     if is_temp:
         raise ForbiddenError(
             "File uploads are not supported in temporary sessions. "

--- a/backend/tests/test_chat_api.py
+++ b/backend/tests/test_chat_api.py
@@ -357,9 +357,10 @@ class TestSessionUpload:
     async def test_upload_to_temp_session_rejected(
         self, async_client, auth_headers, test_user
     ):
-        """Verify uploads to temporary sessions return 403.
+        """Verify uploads to temporary sessions auto-promote and succeed.
 
-        Validates Step 0c: temp session upload guard.
+        Validates that the temp session is promoted to permanent
+        on file upload (Issue #368).
         """
         # Create a temp session first
         headers = auth_headers(test_user)
@@ -370,14 +371,18 @@ class TestSessionUpload:
         assert create_resp.status_code == 201
         temp_session_id = create_resp.json()["id"]
 
-        # Try to upload to it
+        # Try to upload to it — should auto-promote and succeed
         files = {"file": ("test.txt", b"Hello", "text/plain")}
         resp = await async_client.post(
             f"/api/chat/session/{temp_session_id}/upload",
             files=files,
             headers=headers,
         )
-        assert resp.status_code == 403, resp.text
+        # Should NOT be 403 (session is auto-promoted). May be 200/201
+        # if MinIO available, or 422/500 if MinIO is not running.
+        assert resp.status_code != 403, (
+            "Temp session upload should auto-promote, not return 403"
+        )
 
     async def test_upload_to_other_user_session_forbidden(
         self, async_client, auth_headers, test_user, second_user, test_session

--- a/backend/tests/test_regression.py
+++ b/backend/tests/test_regression.py
@@ -155,16 +155,17 @@ class TestCredentialTenantIsolation:
 
 
 class TestTempSessionUploadGuard:
-    """Verify temporary session upload rejection.
+    """Verify temporary session uploads auto-promote to permanent.
 
     Regression for: upload_service.create_upload() had ForbiddenError
-    in docstring but never raised it.
+    in docstring but never raised it. Updated for Issue #368 where
+    temp sessions are now promoted to permanent on upload.
     """
 
     async def test_upload_to_temp_session_returns_403(
         self, async_client, auth_headers, test_user
     ):
-        """Verify uploading to a temporary session returns 403."""
+        """Verify uploading to a temporary session auto-promotes and succeeds."""
         headers = auth_headers(test_user)
         create_resp = await async_client.post(
             "/api/chat/session",
@@ -180,7 +181,11 @@ class TestTempSessionUploadGuard:
             files=files,
             headers=headers,
         )
-        assert resp.status_code == 403, resp.text
+        # Should NOT be 403 (session is auto-promoted). May be 200/201
+        # if MinIO available, or 422/500 if MinIO is not running.
+        assert resp.status_code != 403, (
+            "Temp session upload should auto-promote, not return 403"
+        )
 
     async def test_upload_to_permanent_session_not_blocked(
         self, async_client, auth_headers, test_user, test_session

--- a/backend/tests/test_upload_auth.py
+++ b/backend/tests/test_upload_auth.py
@@ -205,10 +205,12 @@ class TestUploadInputValidation:
             files=files,
             headers=headers,
         )
-        # Should NOT be 404 (lazy session is created).  May be 200/201
-        # if MinIO available, or 422/500 if MinIO is not running.
-        assert resp.status_code != 404, (
-            "Uploading to a nonexistent ID should create a lazy session, not 404"
+        # Should NOT be 404 (lazy session is created) or 403 (session is
+        # auto-promoted).  May be 200/201 if MinIO available, or 422/500
+        # if MinIO is not running.
+        assert resp.status_code not in (404, 403), (
+            "Uploading to a nonexistent ID should create a lazy session, "
+            "not 404 or 403"
         )
 
     async def test_upload_with_path_traversal_filename(

--- a/backend/tests/test_upload_flow.py
+++ b/backend/tests/test_upload_flow.py
@@ -74,10 +74,10 @@ class TestFileUpload:
 class TestTempSessionUploadGuard:
     """Verify temp session upload rejection (validates Step 0c)."""
 
-    async def test_upload_to_temp_session_returns_403(
+    async def test_upload_to_temp_session_promotes_and_succeeds(
         self, async_client, auth_headers, test_user
     ):
-        """Verify uploading to a temporary session returns 403 Forbidden."""
+        """Verify uploading to a temporary session auto-promotes and succeeds."""
         # Create a temp session
         headers = auth_headers(test_user)
         create_resp = await async_client.post(
@@ -88,14 +88,18 @@ class TestTempSessionUploadGuard:
         assert create_resp.status_code == 201
         temp_id = create_resp.json()["id"]
 
-        # Try uploading
+        # Try uploading — should auto-promote the temp session and succeed
         files = {"file": ("test.txt", b"data", "text/plain")}
         resp = await async_client.post(
             f"/api/chat/session/{temp_id}/upload",
             files=files,
             headers=headers,
         )
-        assert resp.status_code == 403, resp.text
+        # Should NOT be 403 (session is auto-promoted).  May be 200/201
+        # if MinIO available, or 422/500 if MinIO is not running.
+        assert resp.status_code != 403, (
+            "Temp session upload should auto-promote, not return 403"
+        )
 
     async def test_upload_to_permanent_session_allowed(
         self, async_client, auth_headers, test_user, test_session


### PR DESCRIPTION
Promote temporary sessions to permanent during file uploads, resolving the issue where uploads failed for new or temporary chats. This change ensures that files can be uploaded successfully in these scenarios.
Closes #368

