### PR TITLE
Fix email reply functionality and enhance error handling

### DIFF
--- a/backend/src/tools/email.py
+++ b/backend/src/tools/email.py
@@ -1995,6 +1995,7 @@ async def _reply_via_gmail_api(access_token, email_id, body, reply_all=False, at
                 msg["References"] = f"{original_references} {original_msg_id}".strip() if original_references else original_msg_id
         else:
             msg = MimeText(body, "plain", "utf-8")
+            msg["From"] = "me"
             msg["To"] = original_sender
             msg["Subject"] = reply_subject
             if original_msg_id:
@@ -2011,7 +2012,18 @@ async def _reply_via_gmail_api(access_token, email_id, body, reply_all=False, at
             )
             if r2.status_code in (200, 201):
                 return {"status": "ok", "message": "Reply sent.", "provider": "gmail"}
-            return {"error": f"Gmail reply failed: HTTP {r2.status_code}", "status": "error"}
+            # Try to extract Gmail API error details from response body
+            error_detail = ""
+            try:
+                body_data = r2.json()
+                error_detail = body_data.get("error", {}).get("message", "")
+            except Exception:
+                pass
+            msg = f"Gmail reply failed: HTTP {r2.status_code}"
+            if error_detail:
+                msg += f" - {error_detail}"
+            logger.warning(msg)
+            return {"error": msg, "status": "error"}
 
     except Exception as exc:
         logger.error("Gmail reply failed: %s", exc)
@@ -2106,14 +2118,14 @@ async def _reply_via_imap(host, port, username, password, email_id, body, reply_
                 msg["In-Reply-To"] = original_msg_id
                 msg["References"] = f"{original_references} {original_msg_id}".strip() if original_references else original_msg_id
         else:
+            msg = MimeText(body, "plain", "utf-8")
+            msg["From"] = username
             if reply_all:
                 all_to = original_from
                 if original_to:
                     all_to = f"{all_to}, {original_to}"
-                msg = MimeText(body, "plain", "utf-8")
                 msg["To"] = all_to
             else:
-                msg = MimeText(body, "plain", "utf-8")
                 msg["To"] = original_sender
             msg["Subject"] = reply_subject
             if original_msg_id:

--- a/backend/tests/test_tools_communication.py
+++ b/backend/tests/test_tools_communication.py
@@ -2056,6 +2056,78 @@ class TestEmailImapTool:
         assert "sender@test.com" in msg_str
         assert "other@test.com" in msg_str
 
+    async def test_imap_reply_sets_from_header(self, imap_tools_with_smtp):
+        """IMAP reply: From header is set (no SMTP 501 error)."""
+        mock_conn = MagicMock()
+        mock_conn.select = MagicMock(return_value=("OK", [b"1"]))
+        mock_conn.login = MagicMock(return_value=("OK", [b"1"]))
+        header_bytes = (
+            b"From: sender@test.com\r\n"
+            b"Subject: Original\r\n"
+            b"Message-ID: <orig@test.com>\r\n"
+            b"To: user@test.com\r\n"
+        )
+        mock_conn.fetch = MagicMock(
+            return_value=("OK", [(b"1 (BODY.PEEK[HEADER] {0}", header_bytes)])
+        )
+        mock_conn.logout = MagicMock()
+
+        mock_smtp = MagicMock()
+        mock_smtp.starttls = MagicMock()
+        mock_smtp.login = MagicMock()
+        mock_smtp.send_message = MagicMock()
+        mock_smtp.quit = MagicMock()
+
+        with (
+            patch("imaplib.IMAP4_SSL", return_value=mock_conn),
+            patch("smtplib.SMTP", return_value=mock_smtp),
+        ):
+            result = await imap_tools_with_smtp["reply_email"](
+                email_id="1", body="Reply body",
+            )
+
+        assert result["status"] == "ok"
+        sent_msg = mock_smtp.send_message.call_args[0][0]
+        msg_str = sent_msg.as_string()
+        # From header must be present to avoid SMTP 501
+        assert "From:" in msg_str, "Reply must have a From header"
+        assert "user" in msg_str.split("From:")[1].split("\n")[0]
+
+    async def test_imap_reply_reply_all_sets_from_header(self, imap_tools_with_smtp):
+        """IMAP reply with reply_all: From header is set."""
+        mock_conn = MagicMock()
+        mock_conn.select = MagicMock(return_value=("OK", [b"1"]))
+        mock_conn.login = MagicMock(return_value=("OK", [b"1"]))
+        header_bytes = (
+            b"From: sender@test.com\r\n"
+            b"Subject: Original\r\n"
+            b"Message-ID: <orig@test.com>\r\n"
+            b"To: user@test.com, other@test.com\r\n"
+        )
+        mock_conn.fetch = MagicMock(
+            return_value=("OK", [(b"1 (BODY.PEEK[HEADER] {0}", header_bytes)])
+        )
+        mock_conn.logout = MagicMock()
+
+        mock_smtp = MagicMock()
+        mock_smtp.starttls = MagicMock()
+        mock_smtp.login = MagicMock()
+        mock_smtp.send_message = MagicMock()
+        mock_smtp.quit = MagicMock()
+
+        with (
+            patch("imaplib.IMAP4_SSL", return_value=mock_conn),
+            patch("smtplib.SMTP", return_value=mock_smtp),
+        ):
+            result = await imap_tools_with_smtp["reply_email"](
+                email_id="1", body="Reply all", reply_all=True,
+            )
+
+        assert result["status"] == "ok"
+        sent_msg = mock_smtp.send_message.call_args[0][0]
+        msg_str = sent_msg.as_string()
+        assert "From:" in msg_str, "Reply must have a From header"
+
 
 # ===================================================================
 # 11. Email — Credential Resolution


### PR DESCRIPTION
## Description

Enhance email reply functionality by ensuring the 'From' header is correctly set to prevent SMTP errors. Improve error handling for Gmail API replies to provide more informative error messages.

## Related Issue

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Tested locally with Docker Compose (dev)
- [x] Backend tests pass (`pytest backend/tests/ -m "not e2e and not slow"`)

## Checklist

- [x] My code follows the coding conventions of this project
- [x] I have self-reviewed my own code
- [x] I have commented complex code sections, particularly in hard-to-understand areas
- [x] I have updated the documentation (`docs/`) if my change affects user-facing behaviour or configuration
- [x] My changes generate no new warnings or errors
- [x] New and existing tests pass locally

## Screenshots (if applicable)

## Additional Notes

