### PR TITLE
Increase chat API endpoint coverage

### DIFF
--- a/backend/tests/test_chat_api.py
+++ b/backend/tests/test_chat_api.py
@@ -98,6 +98,118 @@ class TestCreateSession:
         resp = await async_client.post("/api/chat/session", json=payload)
         assert resp.status_code == 401
 
+    async def test_create_session_with_skill(
+        self, async_client, auth_headers, test_user, test_model, test_tool, db_session
+    ):
+        """Verify session creation with skill auto-activates skill tools."""
+        from src.db.orm.skills import Skill, SkillAllowedTool
+
+        skill = Skill(
+            id=str(uuid.uuid4()),
+            tenant_id=test_user.tenant_id,
+            user_id=test_user.id,
+            title="Test Skill",
+            execution_type="agent",
+            visibility="user",
+            enabled=True,
+        )
+        db_session.add(skill)
+        await db_session.flush()
+
+        allowed = SkillAllowedTool(
+            skill_id=skill.id,
+            tool_id=test_tool.id,
+        )
+        db_session.add(allowed)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        payload = {
+            "title": "Skill Chat",
+            "selected_model_id": test_model.id,
+            "selected_skill_id": skill.id,
+        }
+        resp = await async_client.post("/api/chat/session", json=payload, headers=headers)
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["selected_skill_id"] == skill.id
+
+    async def test_create_session_with_active_tool_ids(
+        self, async_client, auth_headers, test_user, test_model, test_tool
+    ):
+        """Verify session creation with explicit active_tool_ids."""
+        headers = auth_headers(test_user)
+        payload = {
+            "title": "Tooled Chat",
+            "selected_model_id": test_model.id,
+            "active_tool_ids": [test_tool.id],
+        }
+        resp = await async_client.post("/api/chat/session", json=payload, headers=headers)
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["title"] == "Tooled Chat"
+
+    async def test_create_session_with_auto_route_enabled(
+        self, async_client, auth_headers, test_user
+    ):
+        """Verify session creation with auto_route_enabled."""
+        headers = auth_headers(test_user)
+        payload = {
+            "title": "Routed Chat",
+            "auto_route_enabled": True,
+        }
+        resp = await async_client.post("/api/chat/session", json=payload, headers=headers)
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["auto_route_enabled"] is True
+
+    async def test_create_session_with_thinking_and_temperature(
+        self, async_client, auth_headers, test_user, test_model
+    ):
+        """Verify session creation with thinking_enabled and temperature."""
+        headers = auth_headers(test_user)
+        payload = {
+            "title": "Thinking Chat",
+            "selected_model_id": test_model.id,
+            "thinking_enabled": True,
+            "temperature": 0.5,
+        }
+        resp = await async_client.post("/api/chat/session", json=payload, headers=headers)
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["thinking_enabled"] is True
+        assert data["temperature"] == 0.5
+
+    async def test_create_session_with_auto_select_tools_false(
+        self, async_client, auth_headers, test_user, test_model
+    ):
+        """Verify session creation with auto_select_tools=False."""
+        headers = auth_headers(test_user)
+        payload = {
+            "title": "Manual Tools",
+            "selected_model_id": test_model.id,
+            "auto_select_tools": False,
+        }
+        resp = await async_client.post("/api/chat/session", json=payload, headers=headers)
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["auto_select_tools"] is False
+
+    async def test_create_session_with_is_pinned(
+        self, async_client, auth_headers, test_user, test_model
+    ):
+        """Verify session creation with is_pinned=True."""
+        headers = auth_headers(test_user)
+        payload = {
+            "title": "Pinned Chat",
+            "selected_model_id": test_model.id,
+            "is_pinned": True,
+        }
+        resp = await async_client.post("/api/chat/session", json=payload, headers=headers)
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["is_pinned"] is True
+
 
 class TestListSessions:
     """Tests for GET /chat/sessions."""
@@ -209,6 +321,93 @@ class TestUpdateSession:
                     title="Should Not Work",
                 )
 
+    async def test_update_session_model(
+        self, async_client, auth_headers, test_user, test_session, test_model
+    ):
+        """Verify switching the model on a session works."""
+        headers = auth_headers(test_user)
+        payload = {"selected_model_id": test_model.id}
+        resp = await async_client.put(
+            f"/api/chat/session/{test_session.id}", json=payload, headers=headers
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["selected_model_id"] == test_model.id
+
+    async def test_update_session_multiple_fields(
+        self, async_client, auth_headers, test_user, test_session, test_model
+    ):
+        """Verify updating multiple fields simultaneously."""
+        headers = auth_headers(test_user)
+        payload = {
+            "title": "Multi Update",
+            "selected_model_id": test_model.id,
+            "is_pinned": True,
+            "temperature": 0.3,
+        }
+        resp = await async_client.put(
+            f"/api/chat/session/{test_session.id}", json=payload, headers=headers
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["title"] == "Multi Update"
+        assert data["selected_model_id"] == test_model.id
+        assert data["is_pinned"] is True
+        assert data["temperature"] == 0.3
+
+    async def test_update_session_toggle_is_pinned(
+        self, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify toggling is_pinned on a session."""
+        headers = auth_headers(test_user)
+        payload = {"is_pinned": True}
+        resp = await async_client.put(
+            f"/api/chat/session/{test_session.id}", json=payload, headers=headers
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["is_pinned"] is True
+
+        # Toggle back
+        payload = {"is_pinned": False}
+        resp = await async_client.put(
+            f"/api/chat/session/{test_session.id}", json=payload, headers=headers
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["is_pinned"] is False
+
+    async def test_update_session_model_switch(
+        self, async_client, auth_headers, test_user, test_session, db_session
+    ):
+        """Verify switching the model on a session."""
+        from src.db.orm.models import Model
+
+        # Create a second model to switch to
+        model2 = Model(
+            id=str(uuid.uuid4()),
+            tenant_id=test_user.tenant_id,
+            name="GPT-4",
+            model_id="gpt-4",
+            provider="openai",
+            api_key="test-key-2",
+            enabled=True,
+            is_public=True,
+            max_tokens=8192,
+            temperature=0.7,
+        )
+        db_session.add(model2)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        payload = {"selected_model_id": model2.id}
+        resp = await async_client.put(
+            f"/api/chat/session/{test_session.id}", json=payload, headers=headers
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["selected_model_id"] == model2.id
+
 
 class TestDeleteSession:
     """Tests for DELETE /chat/session/{session_id}."""
@@ -268,6 +467,129 @@ class TestSendMessage:
         assert "message_id" in data
 
     @patch("src.api.chat.run_agent")
+    async def test_send_message_with_file_ids(
+        self, mock_run_agent, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify sending a message with file_ids passes them to the agent."""
+        from src.db.orm.file_uploads import FileUpload
+
+        mock_run_agent.return_value = ("Response with files!", str(uuid.uuid4()))
+
+        # Create a file upload linked to the session
+        upload = FileUpload(
+            id=str(uuid.uuid4()),
+            tenant_id=test_user.tenant_id,
+            user_id=test_user.id,
+            session_id=test_session.id,
+            original_filename="test.txt",
+            content_type="text/plain",
+            size_bytes=100,
+            storage_key=f"uploads/{test_user.id}/{test_session.id}/test.txt",
+            bucket=f"phhub-test-{test_user.tenant_id}",
+            extracted_text="Sample content",
+        )
+        db_session.add(upload)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        payload = {"content": "Analyze this", "file_ids": [upload.id]}
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/message",
+            json=payload,
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+
+    @patch("src.api.chat.run_agent")
+    async def test_send_message_with_temperature(
+        self, mock_run_agent, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify sending a message with temperature override."""
+        mock_run_agent.return_value = ("Temperature response!", str(uuid.uuid4()))
+        headers = auth_headers(test_user)
+        payload = {"content": "Be creative", "temperature": 0.9}
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/message",
+            json=payload,
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+
+    @patch("src.api.chat.run_agent")
+    async def test_send_message_auto_title(
+        self, mock_run_agent, async_client, auth_headers, test_user, test_model
+    ):
+        """Verify sending the first message auto-titles a 'New Chat' session."""
+        mock_run_agent.return_value = ("Response!", str(uuid.uuid4()))
+
+        # Create session with default title "New Chat"
+        headers = auth_headers(test_user)
+        payload = {"title": "New Chat", "selected_model_id": test_model.id}
+        create_resp = await async_client.post("/api/chat/session", json=payload, headers=headers)
+        assert create_resp.status_code == 201
+        session_id = create_resp.json()["id"]
+
+        # Send first message — triggers auto-title fallback
+        msg_payload = {"content": "This is my first message"}
+        resp = await async_client.post(
+            f"/api/chat/session/{session_id}/message",
+            json=msg_payload,
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+
+    @patch("src.api.chat.run_agent")
+    async def test_send_message_with_session_data(
+        self, mock_run_agent, async_client, auth_headers, test_user, test_model
+    ):
+        """Verify lazy session creation via session_data on first message."""
+        mock_run_agent.return_value = ("Lazy session response!", str(uuid.uuid4()))
+
+        headers = auth_headers(test_user)
+        fake_session_id = str(uuid.uuid4())
+        payload = {
+            "content": "First message",
+            "session_data": {
+                "title": "Lazy Session",
+                "selected_model_id": test_model.id,
+            },
+        }
+        resp = await async_client.post(
+            f"/api/chat/session/{fake_session_id}/message",
+            json=payload,
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "message_id" in data
+
+    @patch("src.api.chat.run_agent")
+    @patch("src.services.router_service.route_message")
+    async def test_send_message_with_auto_routing(
+        self, mock_route, mock_run_agent, async_client, auth_headers, test_user, test_session, test_model
+    ):
+        """Verify auto-routing picks a model when auto_route_enabled is set."""
+        mock_run_agent.return_value = ("Auto-routed response!", str(uuid.uuid4()))
+        mock_route.return_value = test_model.id
+
+        # Update session to enable auto-routing and clear model
+        headers = auth_headers(test_user)
+        update_payload = {"auto_route_enabled": True, "selected_model_id": None}
+        await async_client.put(
+            f"/api/chat/session/{test_session.id}",
+            json=update_payload,
+            headers=headers,
+        )
+
+        payload = {"content": "Route me"}
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/message",
+            json=payload,
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+
+    @patch("src.api.chat.run_agent")
     async def test_send_message_other_user_forbidden(
         self, mock_run_agent, async_client, auth_headers, test_user, second_user, test_session
     ):
@@ -297,6 +619,130 @@ class TestSendMessage:
         )
         assert resp.status_code == 404
 
+    @patch("src.api.chat.run_agent")
+    async def test_send_message_with_session_data_creates_session(
+        self, mock_run_agent, async_client, auth_headers, test_user, test_model
+    ):
+        """Verify sending a message with session_data lazy-creates a session."""
+        mock_run_agent.return_value = ("Welcome!", str(uuid.uuid4()))
+        headers = auth_headers(test_user)
+        session_id = str(uuid.uuid4())
+        payload = {
+            "content": "Hello",
+            "session_data": {
+                "title": "Lazy Session",
+                "selected_model_id": test_model.id,
+            },
+        }
+        resp = await async_client.post(
+            f"/api/chat/session/{session_id}/message",
+            json=payload,
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "message_id" in data
+
+        # Verify the session now exists
+        get_resp = await async_client.get(
+            f"/api/chat/session/{session_id}", headers=headers
+        )
+        assert get_resp.status_code == 200
+        assert get_resp.json()["title"] == "Lazy Session"
+
+    @patch("src.api.chat.run_agent_stream")
+    async def test_send_message_streaming(
+        self, mock_stream, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify sending a message with SSE streaming works."""
+        async def _gen():
+            yield {"event": "chunk", "data": "Hello"}
+            yield {"event": "message_complete", "data": "{}"}
+        mock_stream.return_value = _gen()
+
+        headers = auth_headers(test_user)
+        headers["Accept"] = "text/event-stream"
+        payload = {"content": "Hello"}
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/message",
+            json=payload,
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        assert "text/event-stream" in resp.headers.get("content-type", "")
+
+    @patch("src.api.chat.run_agent_stream")
+    async def test_send_message_streaming_with_file_ids(
+        self, mock_stream, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify streaming with file_ids works."""
+        async def _gen():
+            yield {"event": "message_complete", "data": "{}"}
+        mock_stream.return_value = _gen()
+
+        headers = auth_headers(test_user)
+        headers["Accept"] = "text/event-stream"
+        payload = {"content": "Hello", "file_ids": []}
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/message",
+            json=payload,
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+
+    @patch("src.api.chat.run_agent_stream")
+    async def test_send_message_streaming_with_temperature(
+        self, mock_stream, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify streaming with temperature override works."""
+        async def _gen():
+            yield {"event": "message_complete", "data": "{}"}
+        mock_stream.return_value = _gen()
+
+        headers = auth_headers(test_user)
+        headers["Accept"] = "text/event-stream"
+        payload = {"content": "Hello", "temperature": 0.3}
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/message",
+            json=payload,
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+
+
+class TestCancelStream:
+    """Tests for DELETE /chat/session/{session_id}/stream."""
+
+    async def test_cancel_stream(
+        self, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify cancelling an active stream returns 204."""
+        headers = auth_headers(test_user)
+        resp = await async_client.delete(
+            f"/api/chat/session/{test_session.id}/stream", headers=headers
+        )
+        assert resp.status_code == 204
+
+    async def test_cancel_stream_other_user_forbidden(
+        self, async_client, auth_headers, test_user, second_user, test_session
+    ):
+        """Verify user B cannot cancel user A's stream."""
+        headers = auth_headers(second_user)
+        resp = await async_client.delete(
+            f"/api/chat/session/{test_session.id}/stream", headers=headers
+        )
+        assert resp.status_code == 403
+
+    async def test_cancel_stream_not_found(
+        self, async_client, auth_headers, test_user
+    ):
+        """Verify cancelling stream on nonexistent session returns 404."""
+        headers = auth_headers(test_user)
+        resp = await async_client.delete(
+            f"/api/chat/session/{str(uuid.uuid4())}/stream", headers=headers
+        )
+        assert resp.status_code == 404
+
 
 class TestListMessages:
     """Tests for GET /chat/session/{session_id}/messages."""
@@ -321,6 +767,739 @@ class TestListMessages:
             f"/api/chat/session/{test_session.id}/messages", headers=headers
         )
         assert resp.status_code == 403
+
+    async def test_list_messages_with_data(
+        self, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify listing messages returns actual message data."""
+        from src.db.orm.messages import Message
+        from datetime import datetime, timezone
+
+        msg = Message(
+            id=str(uuid.uuid4()),
+            session_id=test_session.id,
+            sender="user",
+            content=[{"type": "text", "text": "Hello"}],
+            is_deleted=False,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        db_session.add(msg)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/messages", headers=headers
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["id"] == msg.id
+        assert data[0]["sender"] == "user"
+
+
+# =============================================================================
+# Message Branching Tests (Edit / Delete / PATCH / Regenerate) — Phase 8
+# =============================================================================
+
+
+class TestEditUserMessage:
+    """Tests for PUT /chat/session/{session_id}/message/{message_id}."""
+
+    @patch("src.api.chat.run_agent")
+    async def test_edit_user_message_non_streaming(
+        self, mock_run_agent, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify editing a user message re-runs the agent."""
+        from src.db.orm.messages import Message
+        from datetime import datetime, timezone
+
+        mock_run_agent.return_value = ("Edited response!", str(uuid.uuid4()))
+
+        # Create a user message followed by an assistant message
+        user_msg = Message(
+            id=str(uuid.uuid4()),
+            session_id=test_session.id,
+            sender="user",
+            content=[{"type": "text", "text": "Original"}],
+            is_deleted=False,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        db_session.add(user_msg)
+        await db_session.flush()
+
+        asst_msg = Message(
+            id=str(uuid.uuid4()),
+            session_id=test_session.id,
+            sender="assistant",
+            content=[{"type": "text", "text": "Original response"}],
+            model_id=test_model.id,
+            is_deleted=False,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        db_session.add(asst_msg)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        payload = {"content": "Edited"}
+        resp = await async_client.put(
+            f"/api/chat/session/{test_session.id}/message/{user_msg.id}",
+            json=payload,
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "message_id" in data
+
+    async def test_edit_user_message_temp_session_rejected(
+        self, async_client, auth_headers, test_user
+    ):
+        """Verify editing messages in temporary sessions is rejected."""
+        # Create a temp session first
+        headers = auth_headers(test_user)
+        payload = {"title": "Temp", "is_temporary": True}
+        create_resp = await async_client.post(
+            "/api/chat/session", json=payload, headers=headers
+        )
+        assert create_resp.status_code == 201
+        temp_id = create_resp.json()["id"]
+
+        resp = await async_client.put(
+            f"/api/chat/session/{temp_id}/message/{str(uuid.uuid4())}",
+            json={"content": "Edit"},
+            headers=headers,
+        )
+        assert resp.status_code == 422
+
+    async def test_edit_user_message_not_found(
+        self, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify editing a nonexistent message returns 404."""
+        headers = auth_headers(test_user)
+        fake_id = str(uuid.uuid4())
+        resp = await async_client.put(
+            f"/api/chat/session/{test_session.id}/message/{fake_id}",
+            json={"content": "Edit"},
+            headers=headers,
+        )
+        assert resp.status_code == 404
+
+    async def test_edit_user_message_not_user_message(
+        self, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify editing an assistant message via PUT returns 422."""
+        from src.db.orm.messages import Message
+        from datetime import datetime, timezone
+
+        msg = Message(
+            id=str(uuid.uuid4()),
+            session_id=test_session.id,
+            sender="assistant",
+            content=[{"type": "text", "text": "Response"}],
+            model_id=test_model.id,
+            is_deleted=False,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        db_session.add(msg)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        resp = await async_client.put(
+            f"/api/chat/session/{test_session.id}/message/{msg.id}",
+            json={"content": "Edit"},
+            headers=headers,
+        )
+        assert resp.status_code == 422
+
+    async def test_edit_user_message_other_user_forbidden(
+        self, async_client, auth_headers, test_user, second_user, test_session, test_model, db_session
+    ):
+        """Verify user B cannot edit user A's messages."""
+        from src.db.orm.messages import Message
+        from datetime import datetime, timezone
+
+        msg = Message(
+            id=str(uuid.uuid4()),
+            session_id=test_session.id,
+            sender="user",
+            content=[{"type": "text", "text": "Hello"}],
+            is_deleted=False,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        db_session.add(msg)
+        await db_session.flush()
+
+        headers = auth_headers(second_user)
+        resp = await async_client.put(
+            f"/api/chat/session/{test_session.id}/message/{msg.id}",
+            json={"content": "Hacked"},
+            headers=headers,
+        )
+        assert resp.status_code == 403
+
+    @patch("src.api.chat.run_agent")
+    async def test_edit_truncates_subsequent_messages(
+        self, mock_run_agent, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify editing a user message truncates subsequent messages."""
+        from src.db.orm.messages import Message
+        from datetime import datetime, timezone
+
+        mock_run_agent.return_value = ("New response", str(uuid.uuid4()))
+
+        from datetime import timedelta
+        base_time = datetime.now(timezone.utc)
+        # Create chain: user1 -> asst1 -> user2 -> asst2
+        user1 = Message(
+            id=str(uuid.uuid4()),
+            session_id=test_session.id,
+            sender="user", content=[{"type": "text", "text": "First"}],
+            is_deleted=False,
+            created_at=base_time,
+            updated_at=base_time,
+        )
+        db_session.add(user1)
+        await db_session.flush()
+
+        asst1 = Message(
+            id=str(uuid.uuid4()),
+            session_id=test_session.id,
+            sender="assistant", content=[{"type": "text", "text": "Resp1"}],
+            model_id=test_model.id,
+            is_deleted=False,
+            created_at=base_time + timedelta(seconds=1),
+            updated_at=base_time + timedelta(seconds=1),
+        )
+        db_session.add(asst1)
+        await db_session.flush()
+
+        user2 = Message(
+            id=str(uuid.uuid4()),
+            session_id=test_session.id,
+            sender="user", content=[{"type": "text", "text": "Second"}],
+            is_deleted=False,
+            created_at=base_time + timedelta(seconds=2),
+            updated_at=base_time + timedelta(seconds=2),
+        )
+        db_session.add(user2)
+        await db_session.flush()
+
+        asst2 = Message(
+            id=str(uuid.uuid4()),
+            session_id=test_session.id,
+            sender="assistant", content=[{"type": "text", "text": "Resp2"}],
+            model_id=test_model.id,
+            is_deleted=False,
+            created_at=base_time + timedelta(seconds=3),
+            updated_at=base_time + timedelta(seconds=3),
+        )
+        db_session.add(asst2)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        resp = await async_client.put(
+            f"/api/chat/session/{test_session.id}/message/{user1.id}",
+            json={"content": "Edited First"},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+
+        # Verify only the original user1 remains + new messages
+        list_resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/messages", headers=headers
+        )
+        assert list_resp.status_code == 200
+        remaining_ids = [m["id"] for m in list_resp.json()]
+        assert user1.id not in remaining_ids  # original was hard-deleted
+        assert asst1.id not in remaining_ids
+        assert user2.id not in remaining_ids
+        assert asst2.id not in remaining_ids
+
+    @patch("src.api.chat.run_agent_stream")
+    async def test_edit_user_message_streaming(
+        self, mock_stream, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify editing a user message with SSE streaming works."""
+        from src.db.orm.messages import Message
+        from datetime import datetime, timezone
+
+        async def _gen():
+            yield {"event": "chunk", "data": "Streaming edit"}
+            yield {"event": "message_complete", "data": "{}"}
+        mock_stream.return_value = _gen()
+
+        msg = Message(
+            id=str(uuid.uuid4()),
+            session_id=test_session.id,
+            sender="user",
+            content=[{"type": "text", "text": "Original"}],
+            is_deleted=False,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        db_session.add(msg)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        headers["Accept"] = "text/event-stream"
+        resp = await async_client.put(
+            f"/api/chat/session/{test_session.id}/message/{msg.id}",
+            json={"content": "Edited streaming"},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        assert "text/event-stream" in resp.headers.get("content-type", "")
+
+
+class TestDeleteMessage:
+    """Tests for DELETE /chat/session/{session_id}/message/{message_id}."""
+
+    async def test_delete_message(
+        self, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify deleting a message returns 204 and removes it."""
+        from src.db.orm.messages import Message
+        from datetime import datetime, timezone
+
+        msg_id = str(uuid.uuid4())
+        msg = Message(
+            id=msg_id,
+            session_id=test_session.id,
+            sender="user",
+            content=[{"type": "text", "text": "Delete me"}],
+            is_deleted=False,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        db_session.add(msg)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        resp = await async_client.delete(
+            f"/api/chat/session/{test_session.id}/message/{msg_id}",
+            headers=headers,
+        )
+        assert resp.status_code == 204
+
+        # Verify it's gone
+        list_resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/messages", headers=headers
+        )
+        assert list_resp.status_code == 200
+        assert list_resp.json() == []
+
+    async def test_delete_message_temp_session_rejected(
+        self, async_client, auth_headers, test_user
+    ):
+        """Verify deleting messages in temporary sessions is rejected."""
+        headers = auth_headers(test_user)
+        payload = {"title": "Temp", "is_temporary": True}
+        create_resp = await async_client.post("/api/chat/session", json=payload, headers=headers)
+        assert create_resp.status_code == 201
+        temp_id = create_resp.json()["id"]
+
+        resp = await async_client.delete(
+            f"/api/chat/session/{temp_id}/message/{str(uuid.uuid4())}",
+            headers=headers,
+        )
+        assert resp.status_code == 422
+
+    async def test_delete_message_not_found(
+        self, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify deleting a nonexistent message returns 404."""
+        headers = auth_headers(test_user)
+        resp = await async_client.delete(
+            f"/api/chat/session/{test_session.id}/message/{str(uuid.uuid4())}",
+            headers=headers,
+        )
+        assert resp.status_code == 404
+
+    async def test_delete_message_other_user_forbidden(
+        self, async_client, auth_headers, test_user, second_user, test_session, test_model, db_session
+    ):
+        """Verify user B cannot delete user A's messages."""
+        from src.db.orm.messages import Message
+        from datetime import datetime, timezone
+
+        msg = Message(
+            id=str(uuid.uuid4()),
+            session_id=test_session.id,
+            sender="user",
+            content=[{"type": "text", "text": "Mine"}],
+            is_deleted=False,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        db_session.add(msg)
+        await db_session.flush()
+
+        headers = auth_headers(second_user)
+        resp = await async_client.delete(
+            f"/api/chat/session/{test_session.id}/message/{msg.id}",
+            headers=headers,
+        )
+        assert resp.status_code == 403
+
+    async def test_delete_message_truncates_subsequent(
+        self, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify deleting a message truncates all subsequent messages."""
+        from src.db.orm.messages import Message
+        from datetime import datetime, timezone
+
+        from datetime import timedelta
+        base_time = datetime.now(timezone.utc)
+        msg1 = Message(
+            id=str(uuid.uuid4()),
+            session_id=test_session.id,
+            sender="user", content=[{"type": "text", "text": "First"}],
+            is_deleted=False,
+            created_at=base_time,
+            updated_at=base_time,
+        )
+        db_session.add(msg1)
+        await db_session.flush()
+
+        msg2 = Message(
+            id=str(uuid.uuid4()),
+            session_id=test_session.id,
+            sender="assistant", content=[{"type": "text", "text": "Resp"}],
+            model_id=test_model.id,
+            is_deleted=False,
+            created_at=base_time + timedelta(seconds=1),
+            updated_at=base_time + timedelta(seconds=1),
+        )
+        db_session.add(msg2)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        resp = await async_client.delete(
+            f"/api/chat/session/{test_session.id}/message/{msg1.id}",
+            headers=headers,
+        )
+        assert resp.status_code == 204
+
+        list_resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/messages", headers=headers
+        )
+        assert list_resp.json() == []
+
+
+class TestPatchAssistantMessage:
+    """Tests for PATCH /chat/session/{session_id}/message/{message_id}."""
+
+    async def test_patch_assistant_message(
+        self, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify editing an assistant message in-place."""
+        from src.db.orm.messages import Message
+        from datetime import datetime, timezone
+
+        msg = Message(
+            id=str(uuid.uuid4()),
+            session_id=test_session.id,
+            sender="assistant",
+            content=[{"type": "text", "text": "Original content"}],
+            model_id=test_model.id,
+            is_deleted=False,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        db_session.add(msg)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        resp = await async_client.patch(
+            f"/api/chat/session/{test_session.id}/message/{msg.id}",
+            json={"content": "Edited content"},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["sender"] == "assistant"
+        assert "Edited content" in str(data["content"])
+
+    async def test_patch_assistant_message_temp_session_rejected(
+        self, async_client, auth_headers, test_user
+    ):
+        """Verify PATCH on temporary sessions is rejected."""
+        headers = auth_headers(test_user)
+        payload = {"title": "Temp", "is_temporary": True}
+        create_resp = await async_client.post("/api/chat/session", json=payload, headers=headers)
+        assert create_resp.status_code == 201
+        temp_id = create_resp.json()["id"]
+
+        resp = await async_client.patch(
+            f"/api/chat/session/{temp_id}/message/{str(uuid.uuid4())}",
+            json={"content": "Edit"},
+            headers=headers,
+        )
+        assert resp.status_code == 422
+
+    async def test_patch_assistant_message_not_found(
+        self, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify PATCH on nonexistent message returns 404."""
+        headers = auth_headers(test_user)
+        resp = await async_client.patch(
+            f"/api/chat/session/{test_session.id}/message/{str(uuid.uuid4())}",
+            json={"content": "Edit"},
+            headers=headers,
+        )
+        assert resp.status_code == 404
+
+    async def test_patch_assistant_message_not_assistant(
+        self, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify PATCH on a user message returns 422."""
+        from src.db.orm.messages import Message
+        from datetime import datetime, timezone
+
+        msg = Message(
+            id=str(uuid.uuid4()),
+            session_id=test_session.id,
+            sender="user",
+            content=[{"type": "text", "text": "Hello"}],
+            is_deleted=False,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        db_session.add(msg)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        resp = await async_client.patch(
+            f"/api/chat/session/{test_session.id}/message/{msg.id}",
+            json={"content": "Edit"},
+            headers=headers,
+        )
+        assert resp.status_code == 422
+
+    async def test_patch_assistant_message_other_user_forbidden(
+        self, async_client, auth_headers, test_user, second_user, test_session, test_model, db_session
+    ):
+        """Verify user B cannot PATCH user A's messages."""
+        from src.db.orm.messages import Message
+        from datetime import datetime, timezone
+
+        msg = Message(
+            id=str(uuid.uuid4()),
+            session_id=test_session.id,
+            sender="assistant",
+            content=[{"type": "text", "text": "Response"}],
+            model_id=test_model.id,
+            is_deleted=False,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        db_session.add(msg)
+        await db_session.flush()
+
+        headers = auth_headers(second_user)
+        resp = await async_client.patch(
+            f"/api/chat/session/{test_session.id}/message/{msg.id}",
+            json={"content": "Hacked"},
+            headers=headers,
+        )
+        assert resp.status_code == 403
+
+    async def test_patch_truncates_subsequent_messages(
+        self, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify PATCH on assistant message truncates subsequent messages."""
+        from src.db.orm.messages import Message
+        from datetime import datetime, timezone, timedelta
+
+        base_time = datetime.now(timezone.utc)
+        asst1 = Message(
+            id=str(uuid.uuid4()),
+            session_id=test_session.id,
+            sender="assistant", content=[{"type": "text", "text": "First resp"}],
+            model_id=test_model.id,
+            is_deleted=False,
+            created_at=base_time,
+            updated_at=base_time,
+        )
+        db_session.add(asst1)
+        await db_session.flush()
+
+        user2 = Message(
+            id=str(uuid.uuid4()),
+            session_id=test_session.id,
+            sender="user", content=[{"type": "text", "text": "Follow-up"}],
+            is_deleted=False,
+            created_at=base_time + timedelta(seconds=1),
+            updated_at=base_time + timedelta(seconds=1),
+        )
+        db_session.add(user2)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        resp = await async_client.patch(
+            f"/api/chat/session/{test_session.id}/message/{asst1.id}",
+            json={"content": "Edited first response"},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+
+        # Verify user2 is gone
+        list_resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/messages", headers=headers
+        )
+        remaining = list_resp.json()
+        assert len(remaining) == 1
+        assert remaining[0]["id"] == asst1.id
+
+
+class TestRegenerateMessage:
+    """Tests for POST /chat/session/{session_id}/message/{message_id}/regenerate."""
+
+    async def _make_regenerate_setup(self, db_session, test_session, test_model):
+        """Helper: create user->assistant message pair, return (user_id, asst_id)."""
+        from src.db.orm.messages import Message
+        from datetime import datetime, timezone, timedelta
+
+        base_time = datetime.now(timezone.utc)
+        user_id = str(uuid.uuid4())
+        user_msg = Message(
+            id=user_id,
+            session_id=test_session.id,
+            sender="user",
+            content=[{"type": "text", "text": "Original question"}],
+            is_deleted=False,
+            created_at=base_time,
+            updated_at=base_time,
+        )
+        db_session.add(user_msg)
+        await db_session.flush()
+
+        asst_id = str(uuid.uuid4())
+        asst_msg = Message(
+            id=asst_id,
+            session_id=test_session.id,
+            sender="assistant",
+            content=[{"type": "text", "text": "Original answer"}],
+            model_id=test_model.id,
+            is_deleted=False,
+            created_at=base_time + timedelta(seconds=1),
+            updated_at=base_time + timedelta(seconds=1),
+        )
+        db_session.add(asst_msg)
+        await db_session.flush()
+        return user_id, asst_id
+
+    @patch("src.api.chat.run_agent")
+    async def test_regenerate_non_streaming(
+        self, mock_run_agent, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify regenerating an assistant message."""
+        mock_run_agent.return_value = ("Regenerated answer!", str(uuid.uuid4()))
+        _, asst_id = await self._make_regenerate_setup(db_session, test_session, test_model)
+
+        headers = auth_headers(test_user)
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/message/{asst_id}/regenerate",
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "message_id" in data
+
+    async def test_regenerate_temp_session_rejected(
+        self, async_client, auth_headers, test_user
+    ):
+        """Verify regenerate on temporary sessions is rejected."""
+        headers = auth_headers(test_user)
+        payload = {"title": "Temp", "is_temporary": True}
+        create_resp = await async_client.post("/api/chat/session", json=payload, headers=headers)
+        assert create_resp.status_code == 201
+        temp_id = create_resp.json()["id"]
+
+        resp = await async_client.post(
+            f"/api/chat/session/{temp_id}/message/{str(uuid.uuid4())}/regenerate",
+            headers=headers,
+        )
+        assert resp.status_code == 422
+
+    async def test_regenerate_not_found(
+        self, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify regenerate on nonexistent message returns 404."""
+        headers = auth_headers(test_user)
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/message/{str(uuid.uuid4())}/regenerate",
+            headers=headers,
+        )
+        assert resp.status_code == 404
+
+    async def test_regenerate_not_assistant(
+        self, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify regenerate on a user message returns 422."""
+        user_id, _ = await self._make_regenerate_setup(db_session, test_session, test_model)
+        headers = auth_headers(test_user)
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/message/{user_id}/regenerate",
+            headers=headers,
+        )
+        assert resp.status_code == 422
+
+    async def test_regenerate_not_last_message(
+        self, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify only the last assistant message can be regenerated."""
+        _, first_asst = await self._make_regenerate_setup(db_session, test_session, test_model)
+        # Add another pair
+        _, second_asst = await self._make_regenerate_setup(db_session, test_session, test_model)
+
+        headers = auth_headers(test_user)
+        # Try to regenerate the first assistant (not last)
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/message/{first_asst}/regenerate",
+            headers=headers,
+        )
+        assert resp.status_code == 422
+
+    @patch("src.api.chat.run_agent")
+    async def test_regenerate_other_user_forbidden(
+        self, mock_run_agent, async_client, auth_headers, test_user, second_user, test_session, test_model, db_session
+    ):
+        """Verify user B cannot regenerate user A's messages."""
+        mock_run_agent.return_value = ("", str(uuid.uuid4()))
+        _, asst_id = await self._make_regenerate_setup(db_session, test_session, test_model)
+
+        headers = auth_headers(second_user)
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/message/{asst_id}/regenerate",
+            headers=headers,
+        )
+        assert resp.status_code == 403
+
+    @patch("src.api.chat.run_agent_stream")
+    async def test_regenerate_streaming(
+        self, mock_stream, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify regenerating with SSE streaming works."""
+        async def _gen():
+            yield {"event": "chunk", "data": "Streaming regen"}
+            yield {"event": "message_complete", "data": "{}"}
+        mock_stream.return_value = _gen()
+
+        _, asst_id = await self._make_regenerate_setup(db_session, test_session, test_model)
+
+        headers = auth_headers(test_user)
+        headers["Accept"] = "text/event-stream"
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/message/{asst_id}/regenerate",
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        assert "text/event-stream" in resp.headers.get("content-type", "")
 
 
 # =============================================================================
@@ -399,6 +1578,237 @@ class TestSessionUpload:
 
 
 # =============================================================================
+# File List / Download / Delete Tests
+# =============================================================================
+
+
+class TestListUploads:
+    """Tests for GET /chat/session/{session_id}/uploads."""
+
+    async def test_list_uploads_empty(
+        self, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify listing uploads for a session with no uploads returns []."""
+        headers = auth_headers(test_user)
+        resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/uploads", headers=headers
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == []
+
+    async def test_list_uploads_with_data(
+        self, async_client, auth_headers, test_user, test_session, db_session
+    ):
+        """Verify listing uploads returns upload metadata."""
+        from src.db.orm.file_uploads import FileUpload
+        from datetime import datetime, timezone
+
+        upload = FileUpload(
+            id=str(uuid.uuid4()),
+            tenant_id=test_user.tenant_id,
+            user_id=test_user.id,
+            session_id=test_session.id,
+            original_filename="test.txt",
+            content_type="text/plain",
+            size_bytes=100,
+            storage_key="test/key.txt",
+            bucket=f"phhub-test-{test_user.tenant_id}",
+            is_temporary=False,
+        )
+        db_session.add(upload)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/uploads", headers=headers
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["file_id"] == upload.id
+        assert data[0]["original_filename"] == "test.txt"
+
+    async def test_list_uploads_other_user_forbidden(
+        self, async_client, auth_headers, test_user, second_user, test_session
+    ):
+        """Verify user B cannot list uploads in user A's session."""
+        headers = auth_headers(second_user)
+        resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/uploads", headers=headers
+        )
+        assert resp.status_code == 403
+
+
+class TestGetUploadUrl:
+    """Tests for GET /chat/session/{session_id}/upload/{file_id}/url."""
+
+    @patch("src.services.upload_service.generate_presigned_url")
+    async def test_get_upload_url(
+        self, mock_gen_url, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify getting a presigned upload URL."""
+        from src.db.orm.file_uploads import FileUpload
+        from datetime import datetime, timezone
+
+        mock_gen_url.return_value = "https://fake.minio.url/file"
+
+        upload = FileUpload(
+            id=str(uuid.uuid4()),
+            tenant_id=test_user.tenant_id,
+            user_id=test_user.id,
+            session_id=test_session.id,
+            original_filename="test.txt",
+            content_type="text/plain",
+            size_bytes=100,
+            storage_key="test/key.txt",
+            bucket=f"phhub-test-{test_user.tenant_id}",
+            is_temporary=False,
+        )
+        db_session.add(upload)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/upload/{upload.id}/url",
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["url"] == "https://fake.minio.url/file"
+
+    async def test_get_upload_url_other_user_forbidden(
+        self, async_client, auth_headers, test_user, second_user, test_session
+    ):
+        """Verify user B cannot get upload URL in user A's session."""
+        headers = auth_headers(second_user)
+        resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/upload/{str(uuid.uuid4())}/url",
+            headers=headers,
+        )
+        assert resp.status_code == 403
+
+
+class TestDownloadUpload:
+    """Tests for GET /chat/session/{session_id}/upload/{file_id}/download."""
+
+    @patch("src.api.chat.s3.download_object")
+    async def test_download_upload(
+        self, mock_download, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify downloading a file returns content with proper headers."""
+        from src.db.orm.file_uploads import FileUpload
+        from datetime import datetime, timezone
+
+        mock_download.return_value = b"file content here"
+
+        upload = FileUpload(
+            id=str(uuid.uuid4()),
+            tenant_id=test_user.tenant_id,
+            user_id=test_user.id,
+            session_id=test_session.id,
+            original_filename="download.txt",
+            content_type="text/plain",
+            size_bytes=17,
+            storage_key="test/download.txt",
+            bucket=f"phhub-test-{test_user.tenant_id}",
+            is_temporary=False,
+        )
+        db_session.add(upload)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/upload/{upload.id}/download",
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        assert "Content-Disposition" in resp.headers
+        assert "download.txt" in resp.headers["Content-Disposition"]
+
+    async def test_download_upload_other_user_forbidden(
+        self, async_client, auth_headers, test_user, second_user, test_session
+    ):
+        """Verify user B cannot download user A's files."""
+        headers = auth_headers(second_user)
+        resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/upload/{str(uuid.uuid4())}/download",
+            headers=headers,
+        )
+        assert resp.status_code == 403
+
+
+class TestDeleteUpload:
+    """Tests for DELETE /chat/session/{session_id}/upload/{file_id}."""
+
+    @patch("src.services.upload_service.delete_upload")
+    async def test_delete_upload(
+        self, mock_delete, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify deleting an upload returns 204."""
+        from src.db.orm.file_uploads import FileUpload
+        from datetime import datetime, timezone
+
+        upload = FileUpload(
+            id=str(uuid.uuid4()),
+            tenant_id=test_user.tenant_id,
+            user_id=test_user.id,
+            session_id=test_session.id,
+            original_filename="delete.txt",
+            content_type="text/plain",
+            size_bytes=10,
+            storage_key="test/delete.txt",
+            bucket=f"phhub-test-{test_user.tenant_id}",
+            is_temporary=False,
+        )
+        db_session.add(upload)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        resp = await async_client.delete(
+            f"/api/chat/session/{test_session.id}/upload/{upload.id}",
+            headers=headers,
+        )
+        assert resp.status_code == 204
+
+    async def test_delete_upload_other_user_forbidden(
+        self, async_client, auth_headers, test_user, second_user, test_session
+    ):
+        """Verify user B cannot delete user A's uploads."""
+        headers = auth_headers(second_user)
+        resp = await async_client.delete(
+            f"/api/chat/session/{test_session.id}/upload/{str(uuid.uuid4())}",
+            headers=headers,
+        )
+        assert resp.status_code == 403
+
+
+class TestListMessageUploads:
+    """Tests for GET /chat/session/{session_id}/message/{message_id}/uploads."""
+
+    async def test_list_message_uploads_empty(
+        self, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify listing message uploads for a message with no uploads returns []."""
+        headers = auth_headers(test_user)
+        resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/message/{str(uuid.uuid4())}/uploads",
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == []
+
+    async def test_list_message_uploads_other_user_forbidden(
+        self, async_client, auth_headers, test_user, second_user, test_session
+    ):
+        """Verify user B cannot list message uploads in user A's session."""
+        headers = auth_headers(second_user)
+        resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/message/{str(uuid.uuid4())}/uploads",
+            headers=headers,
+        )
+        assert resp.status_code == 403
+
+
+# =============================================================================
 # Feedback Tests
 # =============================================================================
 
@@ -406,16 +1816,13 @@ class TestSessionUpload:
 class TestFeedback:
     """Tests for POST /chat/session/{session_id}/message/{message_id}/feedback."""
 
-    async def test_submit_feedback(
-        self, async_client, auth_headers, test_user, test_session, test_model, db_session
-    ):
-        """Verify submitting feedback for a message succeeds."""
-        # Create a real assistant message in the DB so feedback can find it
+    async def _make_assistant_message(self, db_session, test_session, test_model):
+        """Helper: create an assistant message in the DB and return its ID."""
         from src.db.orm.messages import Message
         from datetime import datetime, timezone
 
         msg_id = str(uuid.uuid4())
-        real_msg = Message(
+        msg = Message(
             id=msg_id,
             session_id=test_session.id,
             sender="assistant",
@@ -425,10 +1832,15 @@ class TestFeedback:
             created_at=datetime.now(timezone.utc),
             updated_at=datetime.now(timezone.utc),
         )
-        db_session.add(real_msg)
+        db_session.add(msg)
         await db_session.flush()
+        return msg_id
 
-        # Submit feedback
+    async def test_submit_feedback(
+        self, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify submitting feedback for a message succeeds."""
+        msg_id = await self._make_assistant_message(db_session, test_session, test_model)
         headers = auth_headers(test_user)
         feedback_payload = {"rating": "up", "comment": "Nice response"}
         resp = await async_client.post(
@@ -440,6 +1852,483 @@ class TestFeedback:
         data = resp.json()
         assert data["rating"] == "up"
         assert data["comment"] == "Nice response"
+
+    async def test_submit_feedback_down(
+        self, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify submitting "down" feedback without comment."""
+        msg_id = await self._make_assistant_message(db_session, test_session, test_model)
+        headers = auth_headers(test_user)
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/message/{msg_id}/feedback",
+            json={"rating": "down"},
+            headers=headers,
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["rating"] == "down"
+        assert data["comment"] is None
+
+    async def test_submit_feedback_invalid_rating(
+        self, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify invalid rating returns 422."""
+        msg_id = await self._make_assistant_message(db_session, test_session, test_model)
+        headers = auth_headers(test_user)
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/message/{msg_id}/feedback",
+            json={"rating": "neutral"},
+            headers=headers,
+        )
+        assert resp.status_code == 422, resp.text
+
+    async def test_submit_feedback_on_user_message(
+        self, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify feedback on a user message returns 422."""
+        from src.db.orm.messages import Message
+        from datetime import datetime, timezone
+
+        msg = Message(
+            id=str(uuid.uuid4()),
+            session_id=test_session.id,
+            sender="user",
+            content=[{"type": "text", "text": "Hello"}],
+            is_deleted=False,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        db_session.add(msg)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/message/{msg.id}/feedback",
+            json={"rating": "up"},
+            headers=headers,
+        )
+        assert resp.status_code == 422, resp.text
+
+    async def test_submit_feedback_nonexistent_message(
+        self, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify feedback on a nonexistent message returns 404."""
+        headers = auth_headers(test_user)
+        fake_id = str(uuid.uuid4())
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/message/{fake_id}/feedback",
+            json={"rating": "up"},
+            headers=headers,
+        )
+        assert resp.status_code == 404
+
+    async def test_submit_feedback_other_user_session(
+        self, async_client, auth_headers, test_user, second_user, test_session, test_model, db_session
+    ):
+        """Verify user B cannot submit feedback in user A's session."""
+        msg_id = await self._make_assistant_message(db_session, test_session, test_model)
+        headers = auth_headers(second_user)
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/message/{msg_id}/feedback",
+            json={"rating": "up"},
+            headers=headers,
+        )
+        assert resp.status_code == 403
+
+
+# =============================================================================
+# Session Lifecycle Tests (finalize, export, import, search, context, follow-up, summarize)
+# =============================================================================
+
+
+class TestFinalizeSession:
+    """Tests for POST /chat/session/{session_id}/finalize."""
+
+    async def test_finalize_temp_session(
+        self, async_client, auth_headers, test_user
+    ):
+        """Verify finalizing a temporary session converts it to permanent."""
+        # Create a temp session
+        headers = auth_headers(test_user)
+        payload = {"title": "Temp to Finalize", "is_temporary": True}
+        create_resp = await async_client.post("/api/chat/session", json=payload, headers=headers)
+        assert create_resp.status_code == 201
+        temp_id = create_resp.json()["id"]
+        assert create_resp.json()["is_temporary"] is True
+
+        # Finalize it
+        resp = await async_client.post(
+            f"/api/chat/session/{temp_id}/finalize", headers=headers
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["is_temporary"] is False
+        assert data["id"] == temp_id
+
+    async def test_finalize_already_permanent(
+        self, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify finalizing an already permanent session returns 422."""
+        headers = auth_headers(test_user)
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/finalize", headers=headers
+        )
+        assert resp.status_code == 422
+
+    async def test_finalize_other_user_forbidden(
+        self, async_client, auth_headers, test_user, second_user
+    ):
+        """Verify user B cannot finalize user A's temp session."""
+        # Create a temp session as test_user
+        headers = auth_headers(test_user)
+        payload = {"title": "Temp", "is_temporary": True}
+        create_resp = await async_client.post("/api/chat/session", json=payload, headers=headers)
+        assert create_resp.status_code == 201
+        temp_id = create_resp.json()["id"]
+
+        # Try to finalize as second_user
+        headers_b = auth_headers(second_user)
+        resp = await async_client.post(
+            f"/api/chat/session/{temp_id}/finalize", headers=headers_b
+        )
+        assert resp.status_code == 403
+
+
+class TestExportSession:
+    """Tests for GET /chat/session/{session_id}/export."""
+
+    async def test_export_json(
+        self, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify exporting a session as JSON."""
+        from src.db.orm.messages import Message
+        from datetime import datetime, timezone
+
+        # Add a message
+        msg = Message(
+            id=str(uuid.uuid4()),
+            session_id=test_session.id,
+            sender="user",
+            content=[{"type": "text", "text": "Hello"}],
+            is_deleted=False,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        db_session.add(msg)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/export?format=json",
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.headers["content-type"] == "application/json"
+        data = resp.json()
+        assert data["version"] == 1
+        assert len(data["messages"]) == 1
+
+    async def test_export_txt(
+        self, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify exporting a session as plain text."""
+        from src.db.orm.messages import Message
+        from datetime import datetime, timezone
+
+        msg = Message(
+            id=str(uuid.uuid4()),
+            session_id=test_session.id,
+            sender="user",
+            content=[{"type": "text", "text": "Hello"}],
+            is_deleted=False,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        db_session.add(msg)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/export?format=txt",
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        assert "text/plain" in resp.headers["content-type"]
+
+    async def test_export_default_format(
+        self, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify default export format is JSON."""
+        headers = auth_headers(test_user)
+        resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/export",
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.headers["content-type"] == "application/json"
+
+    async def test_export_with_data(
+        self, async_client, auth_headers, test_user, test_session, test_model, db_session
+    ):
+        """Verify exporting a session with messages."""
+        from src.db.orm.messages import Message
+        from datetime import datetime, timezone
+
+        msg = Message(
+            id=str(uuid.uuid4()),
+            session_id=test_session.id,
+            sender="user",
+            content=[{"type": "text", "text": "Hello"}],
+            is_deleted=False,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        db_session.add(msg)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        # JSON export
+        resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/export?format=json", headers=headers
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["version"] == 1
+        assert len(data["messages"]) == 1
+        assert data["messages"][0]["sender"] == "user"
+
+        # TXT export
+        resp2 = await async_client.get(
+            f"/api/chat/session/{test_session.id}/export?format=txt", headers=headers
+        )
+        assert resp2.status_code == 200, resp2.text
+        assert "Hello" in resp2.text
+
+    async def test_export_other_user_forbidden(
+        self, async_client, auth_headers, test_user, second_user, test_session
+    ):
+        """Verify user B cannot export user A's session."""
+        headers = auth_headers(second_user)
+        resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/export", headers=headers
+        )
+        assert resp.status_code == 403
+
+
+class TestImportSession:
+    """Tests for POST /import."""
+
+    async def test_import_json(
+        self, async_client, auth_headers, test_user
+    ):
+        """Verify importing a valid JSON export creates a new session."""
+        import json
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc).isoformat()
+        payload = {
+            "version": 1,
+            "exported_at": now,
+            "application": "ph-agent-hub",
+            "session": {"title": "Imported Chat", "created_at": now, "updated_at": now},
+            "messages": [
+                {"sender": "user", "content": [{"type": "text", "text": "Hello"}], "created_at": now},
+                {"sender": "assistant", "content": [{"type": "text", "text": "Hi!"}], "created_at": now},
+            ],
+        }
+        headers = auth_headers(test_user)
+        files = {"file": ("export.json", json.dumps(payload), "application/json")}
+        resp = await async_client.post("/api/chat/import", files=files, headers=headers)
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert "session_id" in data
+        assert data["message_count"] == 2
+
+    async def test_import_invalid_json(
+        self, async_client, auth_headers, test_user
+    ):
+        """Verify importing malformed JSON returns 422."""
+        headers = auth_headers(test_user)
+        files = {"file": ("bad.json", b"not json", "application/json")}
+        resp = await async_client.post("/api/chat/import", files=files, headers=headers)
+        assert resp.status_code == 422
+
+    async def test_import_not_json_file(
+        self, async_client, auth_headers, test_user
+    ):
+        """Verify importing a non-.json file returns 422."""
+        headers = auth_headers(test_user)
+        files = {"file": ("data.txt", b"content", "text/plain")}
+        resp = await async_client.post("/api/chat/import", files=files, headers=headers)
+        assert resp.status_code == 422
+
+    async def test_import_empty_messages(
+        self, async_client, auth_headers, test_user
+    ):
+        """Verify importing with no messages returns 422."""
+        import json
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc).isoformat()
+        payload = {
+            "version": 1,
+            "exported_at": now,
+            "application": "ph-agent-hub",
+            "session": {"title": "Empty", "created_at": now, "updated_at": now},
+            "messages": [],
+        }
+        headers = auth_headers(test_user)
+        files = {"file": ("empty.json", json.dumps(payload), "application/json")}
+        resp = await async_client.post("/api/chat/import", files=files, headers=headers)
+        assert resp.status_code == 422
+
+    async def test_import_requires_auth(
+        self, async_client
+    ):
+        """Verify unauthenticated import is rejected."""
+        import json
+        files = {"file": ("export.json", json.dumps({"version": 1, "messages": []}), "application/json")}
+        resp = await async_client.post("/api/chat/import", files=files)
+        assert resp.status_code == 401
+
+
+class TestSearchSessions:
+    """Tests for GET /chat/sessions/search."""
+
+    async def test_search_by_title(
+        self, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify searching sessions by title returns matches."""
+        headers = auth_headers(test_user)
+        resp = await async_client.get(
+            "/api/chat/sessions/search?q=Test", headers=headers
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        titles = [s["title"] for s in data]
+        assert "Test Session" in titles
+
+    async def test_search_no_results(
+        self, async_client, auth_headers, test_user
+    ):
+        """Verify searching for a nonexistent term returns []."""
+        headers = auth_headers(test_user)
+        resp = await async_client.get(
+            "/api/chat/sessions/search?q=xyznonexistent", headers=headers
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == []
+
+    async def test_search_empty_query(
+        self, async_client, auth_headers, test_user
+    ):
+        """Verify empty search query returns 422."""
+        headers = auth_headers(test_user)
+        resp = await async_client.get(
+            "/api/chat/sessions/search?q=", headers=headers
+        )
+        assert resp.status_code == 422
+
+    async def test_search_cross_user_excludes(
+        self, async_client, auth_headers, test_user, second_user, test_session
+    ):
+        """Verify user B cannot find user A's sessions via search."""
+        headers = auth_headers(second_user)
+        resp = await async_client.get(
+            "/api/chat/sessions/search?q=Test", headers=headers
+        )
+        assert resp.status_code == 200
+        session_ids = [s["id"] for s in resp.json()]
+        assert test_session.id not in session_ids
+
+
+class TestSessionContext:
+    """Tests for GET /chat/session/{session_id}/context."""
+
+    async def test_get_context_empty_session(
+        self, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify context for an empty session returns tokens_used=0."""
+        headers = auth_headers(test_user)
+        resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/context", headers=headers
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "tokens_used" in data
+        assert "context_length" in data or data["context_length"] is None
+
+    async def test_get_context_other_user_forbidden(
+        self, async_client, auth_headers, test_user, second_user, test_session
+    ):
+        """Verify user B cannot access user A's session context."""
+        headers = auth_headers(second_user)
+        resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/context", headers=headers
+        )
+        assert resp.status_code == 403
+
+
+class TestFollowUpQuestions:
+    """Tests for GET /chat/session/{session_id}/follow-up-questions."""
+
+    @patch("src.core.redis.get_follow_up_questions")
+    async def test_get_follow_up_questions(
+        self, mock_get_fu, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify retrieving follow-up questions."""
+        mock_get_fu.return_value = ["What about X?", "Can you explain Y?"]
+        headers = auth_headers(test_user)
+        resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/follow-up-questions",
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "questions" in data
+        assert len(data["questions"]) == 2
+
+    @patch("src.core.redis.get_follow_up_questions")
+    async def test_get_follow_up_empty(
+        self, mock_get_fu, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify retrieving follow-up questions returns [] when none are available."""
+        mock_get_fu.return_value = None
+        headers = auth_headers(test_user)
+        resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/follow-up-questions",
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"questions": []}
+
+
+class TestSummarizeSession:
+    """Tests for POST /chat/session/{session_id}/summarize."""
+
+    async def test_summarize_too_few_messages(
+        self, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify summarizing a session with <4 messages returns 422."""
+        headers = auth_headers(test_user)
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/summarize",
+            json={"keep_recent_pairs": 1},
+            headers=headers,
+        )
+        assert resp.status_code == 422
+
+    async def test_summarize_other_user_forbidden(
+        self, async_client, auth_headers, test_user, second_user, test_session
+    ):
+        """Verify user B cannot summarize user A's session."""
+        headers = auth_headers(second_user)
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/summarize",
+            json={},
+            headers=headers,
+        )
+        assert resp.status_code == 403
 
 
 # =============================================================================
@@ -483,3 +2372,602 @@ class TestTenantIsolation:
             headers=headers,
         )
         assert resp.status_code == 403
+
+    async def test_cross_tenant_update_session_forbidden(
+        self, async_client, auth_headers, second_user, test_session
+    ):
+        """Verify tenant B user cannot update tenant A's session."""
+        headers = auth_headers(second_user)
+        resp = await async_client.put(
+            f"/api/chat/session/{test_session.id}",
+            json={"title": "Hacked"},
+            headers=headers,
+        )
+        assert resp.status_code == 403
+
+    async def test_cross_tenant_delete_session_forbidden(
+        self, async_client, auth_headers, second_user, test_session
+    ):
+        """Verify tenant B user cannot delete tenant A's session."""
+        headers = auth_headers(second_user)
+        resp = await async_client.delete(
+            f"/api/chat/session/{test_session.id}", headers=headers
+        )
+        assert resp.status_code == 403
+
+    async def test_cross_tenant_list_messages_forbidden(
+        self, async_client, auth_headers, second_user, test_session
+    ):
+        """Verify tenant B user cannot list messages in tenant A's session."""
+        headers = auth_headers(second_user)
+        resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/messages", headers=headers
+        )
+        assert resp.status_code == 403
+
+    async def test_cross_tenant_add_tool_forbidden(
+        self, async_client, auth_headers, second_user, test_session, test_tool
+    ):
+        """Verify tenant B user cannot activate tools in tenant A's session."""
+        headers = auth_headers(second_user)
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/tools/{test_tool.id}",
+            headers=headers,
+        )
+        assert resp.status_code == 403
+
+
+# =============================================================================
+# Session Tools Tests
+# =============================================================================
+
+
+class TestAvailableTools:
+    """Tests for GET /chat/session/tools/available."""
+
+    async def test_list_available_tools(
+        self, async_client, auth_headers, test_user, db_session
+    ):
+        """Verify listing available tools returns enabled tools."""
+        from src.db.orm.tools import Tool
+
+        # test_tool has is_public=False by default, so create a public one
+        public_tool = Tool(
+            id=str(uuid.uuid4()),
+            tenant_id=test_user.tenant_id,
+            name="Public Tool",
+            type="wikipedia",
+            category="general",
+            enabled=True,
+            is_public=True,
+        )
+        db_session.add(public_tool)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        resp = await async_client.get("/api/chat/session/tools/available", headers=headers)
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        tool_ids = [t["id"] for t in data]
+        assert public_tool.id in tool_ids
+
+    async def test_list_available_tools_requires_auth(self, async_client):
+        """Verify unauthenticated request is rejected."""
+        resp = await async_client.get("/api/chat/session/tools/available")
+        assert resp.status_code == 401
+
+
+class TestSetToolAlwaysOn:
+    """Tests for PUT /chat/session/tools/{tool_id}/always-on."""
+
+    async def test_set_tool_always_on(
+        self, async_client, auth_headers, test_user, test_tool
+    ):
+        """Verify setting a tool as always-on."""
+        headers = auth_headers(test_user)
+        resp = await async_client.put(
+            f"/api/chat/session/tools/{test_tool.id}/always-on",
+            json={"always_on": True},
+            headers=headers,
+        )
+        assert resp.status_code == 204
+
+    async def test_set_tool_always_off(
+        self, async_client, auth_headers, test_user, test_tool
+    ):
+        """Verify setting a tool as not always-on."""
+        # First set to on
+        headers = auth_headers(test_user)
+        await async_client.put(
+            f"/api/chat/session/tools/{test_tool.id}/always-on",
+            json={"always_on": True},
+            headers=headers,
+        )
+        # Then set to off
+        resp = await async_client.put(
+            f"/api/chat/session/tools/{test_tool.id}/always-on",
+            json={"always_on": False},
+            headers=headers,
+        )
+        assert resp.status_code == 204
+
+
+class TestListAlwaysOnTools:
+    """Tests for GET /chat/session/tools/always-on."""
+
+    async def test_list_always_on_empty(
+        self, async_client, auth_headers, test_user
+    ):
+        """Verify listing always-on tools returns [] when none set."""
+        headers = auth_headers(test_user)
+        resp = await async_client.get("/api/chat/session/tools/always-on", headers=headers)
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    async def test_list_always_on_with_data(
+        self, async_client, auth_headers, test_user, test_tool, db_session
+    ):
+        """Verify listing always-on tools returns tool IDs."""
+        from src.db.orm.user_tool_preferences import UserToolPreference
+
+        pref = UserToolPreference(
+            user_id=test_user.id,
+            tool_id=test_tool.id,
+            always_on=True,
+        )
+        db_session.add(pref)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        resp = await async_client.get("/api/chat/session/tools/always-on", headers=headers)
+        assert resp.status_code == 200
+        assert test_tool.id in resp.json()
+
+
+class TestListSessionTools:
+    """Tests for GET /chat/session/{session_id}/tools."""
+
+    async def test_list_session_tools_empty(
+        self, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify listing session tools returns [] when none active."""
+        headers = auth_headers(test_user)
+        resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/tools", headers=headers
+        )
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    async def test_list_session_tools_with_active(
+        self, async_client, auth_headers, test_user, test_session, test_tool, db_session
+    ):
+        """Verify listing session tools returns active tools."""
+        from src.db.orm.sessions import SessionActiveTool
+
+        sat = SessionActiveTool(
+            session_id=test_session.id,
+            tool_id=test_tool.id,
+        )
+        db_session.add(sat)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/tools", headers=headers
+        )
+        assert resp.status_code == 200
+        tool_ids = [t["id"] for t in resp.json()]
+        assert test_tool.id in tool_ids
+
+    async def test_list_session_tools_other_user_forbidden(
+        self, async_client, auth_headers, test_user, second_user, test_session
+    ):
+        """Verify user B cannot list tools in user A's session."""
+        headers = auth_headers(second_user)
+        resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}/tools", headers=headers
+        )
+        assert resp.status_code == 403
+
+
+class TestAddSessionTool:
+    """Tests for POST /chat/session/{session_id}/tools/{tool_id}."""
+
+    async def test_add_session_tool(
+        self, async_client, auth_headers, test_user, test_session, test_tool
+    ):
+        """Verify activating a tool for a session."""
+        headers = auth_headers(test_user)
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/tools/{test_tool.id}",
+            headers=headers,
+        )
+        assert resp.status_code == 204
+
+    async def test_add_session_tool_not_found(
+        self, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify activating a nonexistent tool returns 404."""
+        headers = auth_headers(test_user)
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/tools/{str(uuid.uuid4())}",
+            headers=headers,
+        )
+        assert resp.status_code == 404
+
+    async def test_add_session_tool_other_user_forbidden(
+        self, async_client, auth_headers, test_user, second_user, test_session, test_tool
+    ):
+        """Verify user B cannot activate tools in user A's session."""
+        headers = auth_headers(second_user)
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/tools/{test_tool.id}",
+            headers=headers,
+        )
+        assert resp.status_code == 403
+
+
+class TestRemoveSessionTool:
+    """Tests for DELETE /chat/session/{session_id}/tools/{tool_id}."""
+
+    async def test_remove_session_tool(
+        self, async_client, auth_headers, test_user, test_session, test_tool, db_session
+    ):
+        """Verify deactivating a tool from a session."""
+        from src.db.orm.sessions import SessionActiveTool
+
+        sat = SessionActiveTool(
+            session_id=test_session.id,
+            tool_id=test_tool.id,
+        )
+        db_session.add(sat)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        resp = await async_client.delete(
+            f"/api/chat/session/{test_session.id}/tools/{test_tool.id}",
+            headers=headers,
+        )
+        assert resp.status_code == 204
+
+    async def test_remove_session_tool_other_user_forbidden(
+        self, async_client, auth_headers, test_user, second_user, test_session, test_tool
+    ):
+        """Verify user B cannot deactivate tools in user A's session."""
+        headers = auth_headers(second_user)
+        resp = await async_client.delete(
+            f"/api/chat/session/{test_session.id}/tools/{test_tool.id}",
+            headers=headers,
+        )
+        assert resp.status_code == 403
+
+
+# =============================================================================
+# Session Tags Tests
+# =============================================================================
+
+
+class TestListTags:
+    """Tests for GET /chat/session/tags — tested at service level.
+
+    Note: The HTTP endpoint GET /session/tags is shadowed by the
+    /session/{session_id} route in the router (route ordering). We test
+    the service function directly here.
+    """
+
+    async def test_list_tags_empty(
+        self, db_session, test_user
+    ):
+        """Verify listing tags returns [] when none exist."""
+        from src.services import session_service
+
+        tags = await session_service.list_tenant_tags(
+            db=db_session, tenant_id=test_user.tenant_id
+        )
+        assert tags == []
+
+    async def test_list_tags_with_data(
+        self, db_session, test_user
+    ):
+        """Verify listing tags returns tag data."""
+        from src.services import session_service
+        from src.db.orm.tags import Tag
+
+        tag = Tag(
+            id=str(uuid.uuid4()),
+            tenant_id=test_user.tenant_id,
+            name="important",
+        )
+        db_session.add(tag)
+        await db_session.flush()
+
+        tags = await session_service.list_tenant_tags(
+            db=db_session, tenant_id=test_user.tenant_id
+        )
+        names = [t.name for t in tags]
+        assert "important" in names
+
+
+class TestAddTag:
+    """Tests for POST /chat/session/{session_id}/tags."""
+
+    async def test_add_tag(
+        self, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify adding a tag to a session."""
+        headers = auth_headers(test_user)
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/tags",
+            json={"name": "important"},
+            headers=headers,
+        )
+        assert resp.status_code == 201, resp.text
+
+    async def test_add_tag_empty_name(
+        self, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify adding a tag with empty name returns 422."""
+        headers = auth_headers(test_user)
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/tags",
+            json={"name": ""},
+            headers=headers,
+        )
+        assert resp.status_code == 422
+
+    async def test_add_tag_other_user_forbidden(
+        self, async_client, auth_headers, test_user, second_user, test_session
+    ):
+        """Verify user B cannot add tags to user A's session."""
+        headers = auth_headers(second_user)
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/tags",
+            json={"name": "hacked"},
+            headers=headers,
+        )
+        assert resp.status_code == 403
+
+
+class TestRemoveTag:
+    """Tests for DELETE /chat/session/{session_id}/tags/{tag_id}."""
+
+    async def test_remove_tag(
+        self, async_client, auth_headers, test_user, test_session, db_session
+    ):
+        """Verify removing a tag from a session."""
+        from src.db.orm.tags import Tag, SessionTag
+
+        tag = Tag(
+            id=str(uuid.uuid4()),
+            tenant_id=test_user.tenant_id,
+            name="remove-me",
+        )
+        db_session.add(tag)
+        await db_session.flush()
+
+        st = SessionTag(
+            session_id=test_session.id,
+            tag_id=tag.id,
+        )
+        db_session.add(st)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        resp = await async_client.delete(
+            f"/api/chat/session/{test_session.id}/tags/{tag.id}",
+            headers=headers,
+        )
+        assert resp.status_code == 204
+
+    async def test_remove_tag_other_user_forbidden(
+        self, async_client, auth_headers, test_user, second_user, test_session
+    ):
+        """Verify user B cannot remove tags from user A's session."""
+        headers = auth_headers(second_user)
+        resp = await async_client.delete(
+            f"/api/chat/session/{test_session.id}/tags/{str(uuid.uuid4())}",
+            headers=headers,
+        )
+        assert resp.status_code == 403
+
+
+class TestListSessionsByTag:
+    """Tests for GET /chat/sessions/by-tag."""
+
+    async def test_list_by_tag(
+        self, async_client, auth_headers, test_user, test_session, db_session
+    ):
+        """Verify listing sessions by tag returns matching sessions."""
+        from src.db.orm.tags import Tag, SessionTag
+
+        tag = Tag(
+            id=str(uuid.uuid4()),
+            tenant_id=test_user.tenant_id,
+            name="bug",
+        )
+        db_session.add(tag)
+        await db_session.flush()
+
+        st = SessionTag(
+            session_id=test_session.id,
+            tag_id=tag.id,
+        )
+        db_session.add(st)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        resp = await async_client.get(
+            "/api/chat/sessions/by-tag?tag=bug", headers=headers
+        )
+        assert resp.status_code == 200
+        session_ids = [s["id"] for s in resp.json()]
+        assert test_session.id in session_ids
+
+    async def test_list_by_tag_no_match(
+        self, async_client, auth_headers, test_user
+    ):
+        """Verify listing sessions by non-existent tag returns []."""
+        headers = auth_headers(test_user)
+        resp = await async_client.get(
+            "/api/chat/sessions/by-tag?tag=nonexistent", headers=headers
+        )
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    async def test_list_by_tag_cross_user_excludes(
+        self, async_client, auth_headers, test_user, second_user, test_session, db_session
+    ):
+        """Verify user B cannot find user A's sessions via by-tag."""
+        from src.db.orm.tags import Tag, SessionTag
+
+        tag = Tag(
+            id=str(uuid.uuid4()),
+            tenant_id=test_user.tenant_id,
+            name="exclusive",
+        )
+        db_session.add(tag)
+        await db_session.flush()
+
+        st = SessionTag(
+            session_id=test_session.id,
+            tag_id=tag.id,
+        )
+        db_session.add(st)
+        await db_session.flush()
+
+        headers = auth_headers(second_user)
+        resp = await async_client.get(
+            "/api/chat/sessions/by-tag?tag=exclusive", headers=headers
+        )
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+# =============================================================================
+# Auth & Validation Edge Cases
+# =============================================================================
+
+
+class TestAuthEdgeCases:
+    """Tests for auth-related edge cases across chat endpoints."""
+
+    async def test_expired_token(
+        self, async_client
+    ):
+        """Verify an expired JWT token is rejected."""
+        from datetime import datetime, timezone
+        from jose import jwt as jose_jwt
+        from src.core.config import settings
+
+        expired_payload = {
+            "sub": str(uuid.uuid4()),
+            "tenant_id": str(uuid.uuid4()),
+            "role": "user",
+            "iat": datetime.now(timezone.utc),
+            "exp": datetime.now(timezone.utc),
+        }
+        expired_token = jose_jwt.encode(expired_payload, settings.JWT_SECRET, algorithm="HS256")
+        headers = {"Authorization": f"Bearer {expired_token}"}
+        resp = await async_client.get("/api/chat/sessions", headers=headers)
+        assert resp.status_code == 401
+
+    async def test_malformed_token(
+        self, async_client
+    ):
+        """Verify a malformed JWT token is rejected."""
+        headers = {"Authorization": "Bearer not.a.real.token"}
+        resp = await async_client.get("/api/chat/sessions", headers=headers)
+        assert resp.status_code == 401
+
+    async def test_inactive_user(
+        self, async_client, auth_headers, inactive_user
+    ):
+        """Verify an inactive user cannot access chat endpoints."""
+        headers = auth_headers(inactive_user)
+        resp = await async_client.get("/api/chat/sessions", headers=headers)
+        assert resp.status_code == 401
+
+
+class TestValidationErrors:
+    """Tests for malformed request payloads."""
+
+    async def test_send_message_empty_content(
+        self, async_client, auth_headers, test_user, test_session, test_model
+    ):
+        """Verify sending a message with empty content."""
+        headers = auth_headers(test_user)
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/message",
+            json={"content": ""},
+            headers=headers,
+        )
+        # Empty content may be accepted (valid str) or rejected — just verify not 500
+        assert resp.status_code not in (500,)
+
+    async def test_send_message_missing_content(
+        self, async_client, auth_headers, test_user, test_session
+    ):
+        """Verify sending a message without content field returns 422."""
+        headers = auth_headers(test_user)
+        resp = await async_client.post(
+            f"/api/chat/session/{test_session.id}/message",
+            json={},
+            headers=headers,
+        )
+        assert resp.status_code == 422
+
+
+# =============================================================================
+# Utility Function Tests
+# =============================================================================
+
+
+class TestParseDatetime:
+    """Tests for _parse_datetime utility."""
+
+    async def test_parse_datetime_none(self):
+        """Verify _parse_datetime with None returns current time."""
+        from src.api.chat import _parse_datetime
+        from datetime import datetime, timezone
+
+        result = _parse_datetime(None)
+        assert isinstance(result, datetime)
+
+    async def test_parse_datetime_datetime(self):
+        """Verify _parse_datetime with a datetime object."""
+        from src.api.chat import _parse_datetime
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc)
+        result = _parse_datetime(now)
+        assert result == now
+
+    async def test_parse_datetime_iso_string(self):
+        """Verify _parse_datetime with an ISO string."""
+        from src.api.chat import _parse_datetime
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc)
+        result = _parse_datetime(now.isoformat())
+        assert isinstance(result, datetime)
+        assert result.tzinfo is not None
+
+
+class TestSanitizeFilename:
+    """Tests for _sanitize_filename utility."""
+
+    async def test_sanitize_filename_removes_bad_chars(self):
+        """Verify _sanitize_filename removes unsafe characters."""
+        from src.api.chat import _sanitize_filename
+
+        result = _sanitize_filename("My File: <Test>?")
+        assert ":" not in result
+        assert "<" not in result
+        assert "?" not in result
+
+    async def test_sanitize_filename_empty_fallback(self):
+        """Verify _sanitize_filename falls back for empty input."""
+        from src.api.chat import _sanitize_filename
+
+        result = _sanitize_filename("")
+        assert result == "conversation"


### PR DESCRIPTION
Increased test coverage for the chat API router to address gaps in session management, message handling, file uploads, and error handling. Aimed for over 60% coverage to enhance reliability and performance of the chat functionality.
Closes #379

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring / Code style cleanup
- [ ] Infrastructure / CI / Build
- [ ] Other (please describe):

## Testing

- [x] Tested locally with Docker Compose (dev)
- [x] Backend tests pass (`pytest backend/tests/ -m "not e2e and not slow"`)
- [ ] Frontend builds without errors (`npm run build`)
- [ ] Manual testing completed (describe what you tested)

## Checklist

- [x] My code follows the coding conventions of this project
- [x] I have self-reviewed my own code
- [ ] I have commented complex code sections, particularly in hard-to-understand areas
- [ ] I have updated the documentation (`docs/`) if my change affects user-facing behaviour or configuration
- [x] My changes generate no new warnings or errors
- [x] New and existing tests pass locally

## Screenshots (if applicable)

## Additional Notes

```

