### PR TITLE
Gradually raise CI coverage threshold (--cov-fail-under)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,11 @@ jobs:
             --cov=src/api \
             --cov-report=term \
             --cov-report=xml \
-            --cov-fail-under=30
+            --cov-fail-under=40
+          # Coverage threshold progression (Issue #381):
+          #   30 → 40  (current step)
+          #   40 → 55  (next target)
+          #   55 → 70  (final target)
 
       - name: Upload coverage to summary
         if: always()


### PR DESCRIPTION
## Description

Gradually increase the minimum coverage threshold in CI from 30% to 40% as part of the ongoing effort to improve test coverage.

## Related Issue

Closes #381

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring / Code style cleanup
- [x] Infrastructure / CI / Build
- [ ] Other (please describe):

## Testing

- [ ] Tested locally with Docker Compose (dev)
- [ ] Backend tests pass (`pytest backend/tests/ -m "not e2e and not slow"`)
- [ ] Frontend builds without errors (`npm run build`)
- [ ] Manual testing completed (describe what you tested)

## Checklist

- [ ] My code follows the coding conventions of this project
- [ ] I have self-reviewed my own code
- [ ] I have commented complex code sections, particularly in hard-to-understand areas
- [ ] I have updated the documentation (`docs/`) if my change affects user-facing behaviour or configuration
- [ ] My changes generate no new warnings or errors
- [ ] New and existing tests pass locally

## Screenshots (if applicable)

## Additional Notes

This change is part of a planned progression to increase coverage thresholds to 70% as more coverage is added.

