### PR TITLE
## Description

### DIFF
--- a/backend/src/agents/runner.py
+++ b/backend/src/agents/runner.py
@@ -2986,7 +2986,7 @@ def _schedule_post_response_tasks(
                     temperature=temperature,
                 )
                 if questions:
-                    await store_follow_up_questions(session_id, questions)
+                    await store_follow_up_questions(tenant_id, session_id, questions)
             except Exception:
                 logger.exception(
                     "Failed to generate follow-up questions for session %s",

--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -1837,6 +1837,7 @@ class FollowUpQuestionsResponse(BaseModel):
 )
 async def get_follow_up_questions(
     session_id: str,
+    db: AsyncSession = Depends(get_db),
     current_user: UserORM = Depends(get_current_user),
 ):
     """Retrieve follow-up questions for a session from Redis.
@@ -1848,7 +1849,10 @@ async def get_follow_up_questions(
     """
     from ..core.redis import get_follow_up_questions as _redis_get_follow_up
 
-    questions = await _redis_get_follow_up(session_id)
+    data = await _load_session(db, session_id)
+    await _require_session_owner(data, current_user)
+
+    questions = await _redis_get_follow_up(current_user.tenant_id, session_id)
     return FollowUpQuestionsResponse(questions=questions or [])
 
 

--- a/backend/src/core/redis.py
+++ b/backend/src/core/redis.py
@@ -173,9 +173,9 @@ FOLLOW_UP_PREFIX = "follow_up:"
 
 
 async def store_follow_up_questions(
-    session_id: str, questions: list[str], ttl: int = 60
+    tenant_id: str, session_id: str, questions: list[str], ttl: int = 60
 ) -> None:
-    """Store follow-up questions for a session with a short TTL.
+    """Store follow-up questions for a tenant-scoped session with a short TTL.
 
     The short TTL ensures stale questions don't linger if the user
     navigates away before fetching them.
@@ -183,12 +183,12 @@ async def store_follow_up_questions(
     import json
 
     r = await get_redis()
-    key = f"{FOLLOW_UP_PREFIX}{session_id}"
+    key = f"{FOLLOW_UP_PREFIX}{tenant_id}:{session_id}"
     await r.setex(key, ttl, json.dumps(questions))
 
 
-async def get_follow_up_questions(session_id: str) -> list[str] | None:
-    """Retrieve follow-up questions from Redis.
+async def get_follow_up_questions(tenant_id: str, session_id: str) -> list[str] | None:
+    """Retrieve follow-up questions from Redis, scoped by tenant.
 
     Returns None if the key does not exist (questions not yet generated
     or already expired).
@@ -196,7 +196,7 @@ async def get_follow_up_questions(session_id: str) -> list[str] | None:
     import json
 
     r = await get_redis()
-    key = f"{FOLLOW_UP_PREFIX}{session_id}"
+    key = f"{FOLLOW_UP_PREFIX}{tenant_id}:{session_id}"
     raw = await r.get(key)
     if raw is None:
         return None

--- a/backend/tests/test_chat_api.py
+++ b/backend/tests/test_chat_api.py
@@ -2778,23 +2778,18 @@ class TestFollowUpQuestions:
             f"/api/chat/session/{test_session.id}/follow-up-questions",
             headers=headers,
         )
-        # Note: this endpoint currently does not validate session ownership.
-        # It returns 200 with questions from Redis or empty list.
-        # If ownership validation is added later, this should be 403.
-        assert resp.status_code in (200, 403)
+        assert resp.status_code == 403
 
     async def test_follow_up_nonexistent_session(
         self, async_client, auth_headers, test_user
     ):
-        """Verify follow-up questions for nonexistent session returns [] or 404."""
+        """Verify follow-up questions for nonexistent session returns 404."""
         headers = auth_headers(test_user)
         resp = await async_client.get(
             f"/api/chat/session/{str(uuid.uuid4())}/follow-up-questions",
             headers=headers,
         )
-        # Since the endpoint goes directly to Redis without session validation,
-        # it returns [] for non-existent sessions
-        assert resp.status_code in (200, 404)
+        assert resp.status_code == 404
 
     async def test_follow_up_requires_auth(
         self, async_client


### PR DESCRIPTION


The follow-up questions endpoint now includes session ownership validation to prevent cross-user information disclosure. This change ensures that only the owner of a session can retrieve its follow-up questions, addressing potential security vulnerabilities.



## Related Issue



Closes #395



## Type of Change



- [x] Bug fix (non-breaking change that fixes an issue)



## Testing



- [x] Tested locally with Docker Compose (dev)

- [x] Backend tests pass (`pytest backend/tests/ -m "not e2e and not slow"`)



## Checklist



- [x] My code follows the coding conventions of this project

- [x] I have self-reviewed my own code

- [x] I have commented complex code sections, particularly in hard-to-understand areas

- [x] I have updated the documentation (`docs/`) if my change affects user-facing behaviour or configuration

- [x] My changes generate no new warnings or errors

- [x] New and existing tests pass locally



## Screenshots (if applicable)



## Additional Notes



This update also scopes Redis lookups by tenant ID for added security.

