### PR TITLE
Add frontend unit tests for core chat components

### DIFF
--- a/frontend/src/features/chat/components/ModelSelector.test.tsx
+++ b/frontend/src/features/chat/components/ModelSelector.test.tsx
@@ -1,0 +1,283 @@
+// =============================================================================
+// ModelSelector — Unit Tests
+// =============================================================================
+// Tests focus on: options rendering (Auto + model list), "Set as default"
+// star toggle, value/onChange callbacks, loading and empty states.
+// =============================================================================
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ModelSelector } from "./ModelSelector";
+
+// ---------------------------------------------------------------------------
+// Mock external dependencies
+// ---------------------------------------------------------------------------
+
+const { mockApi, mockGetMe, mockSetDefaultModel } = vi.hoisted(() => ({
+  mockApi: vi.fn(),
+  mockGetMe: vi.fn(),
+  mockSetDefaultModel: vi.fn(),
+}));
+
+vi.mock("../../../services/api", () => ({
+  default: mockApi,
+  getToken: () => "test-token",
+}));
+
+vi.mock("../../../services/auth", () => ({
+  getMe: mockGetMe,
+  setDefaultModel: mockSetDefaultModel,
+}));
+
+// Mock Ant Design's Grid.useBreakpoint to return desktop breakpoints.
+vi.mock("antd", async (importOriginal) => {
+  const antd = await importOriginal<typeof import("antd")>();
+  return {
+    ...antd,
+    Grid: {
+      useBreakpoint: () => ({ xs: false, sm: true, md: true, lg: true, xl: true }),
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const FAKE_MODELS = [
+  {
+    id: "model-abc",
+    tenant_id: "t1",
+    name: "DeepSeek V4",
+    provider: "deepseek",
+    base_url: null,
+    enabled: true,
+    thinking_enabled: false,
+    max_tokens: 4096,
+    temperature: 0.7,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  },
+  {
+    id: "model-xyz",
+    tenant_id: "t1",
+    name: "GPT-5",
+    provider: "openai",
+    base_url: null,
+    enabled: true,
+    thinking_enabled: false,
+    max_tokens: 8192,
+    temperature: 0.7,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  },
+];
+
+const FAKE_USER = {
+  id: "u1",
+  email: "test@example.com",
+  display_name: "Test User",
+  role: "admin",
+  tenant_id: "t1",
+  is_active: true,
+  default_model_id: null,
+  created_at: "2024-01-01T00:00:00Z",
+};
+
+const AUTO_ROUTE_VALUE = "__auto__";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderModelSelector(props: Record<string, unknown> = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ModelSelector value="" onChange={vi.fn()} {...props} />
+    </QueryClientProvider>,
+  );
+}
+
+/** Wait for React async updates to settle */
+async function settle() {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 200));
+  });
+}
+
+/** Open the antd Select dropdown by clicking the selector */
+async function openSelect(user: ReturnType<typeof userEvent.setup>) {
+  const selector = document.querySelector(".ant-select-selector");
+  if (!selector) throw new Error("Select selector not found");
+  await user.click(selector);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ModelSelector", () => {
+  beforeEach(() => {
+    mockApi.mockReset();
+    mockGetMe.mockReset();
+    mockSetDefaultModel.mockReset();
+
+    mockApi.mockImplementation((url: string) => {
+      if (url === "/models") return Promise.resolve(FAKE_MODELS);
+      return Promise.resolve([]);
+    });
+    mockGetMe.mockResolvedValue(FAKE_USER);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  // ── Options rendering ──────────────────────────────────────────────────
+
+  it("renders Auto option and model list from API", async () => {
+    renderModelSelector();
+    await settle();
+
+    const user = userEvent.setup();
+    await openSelect(user);
+
+    // Auto option
+    expect(screen.getByText("⚡ Auto (Recommended)")).toBeInTheDocument();
+
+    // Model options
+    expect(screen.getByText("DeepSeek V4 (deepseek)")).toBeInTheDocument();
+    expect(screen.getByText("GPT-5 (openai)")).toBeInTheDocument();
+  });
+
+  // ── value / onChange callbacks ─────────────────────────────────────────
+
+  it("calls onChange with the selected model id when user picks an option", async () => {
+    const onChange = vi.fn();
+    renderModelSelector({ onChange });
+
+    // Give the component time to fetch models so the select is ready
+    await settle();
+
+    const user = userEvent.setup();
+    await openSelect(user);
+
+    // Click the first model option
+    const option = screen.getByText("DeepSeek V4 (deepseek)");
+    await user.click(option);
+
+    // antd Select passes (value, option) — check first arg
+    expect(onChange).toHaveBeenCalledWith(
+      "model-abc",
+      expect.objectContaining({ value: "model-abc" }),
+    );
+  });
+
+  it("reflects the value prop in the current selection", async () => {
+    renderModelSelector({ value: "model-xyz" });
+    await settle();
+
+    // With value="model-xyz", clicking the selector should show GPT-5 as selected
+    // We verify that the Select displays the selected label.
+    // In antd, when the Select has a value, it shows the label text somewhere
+    // inside the .ant-select-selection-item.
+    const selectionItem = document.querySelector(".ant-select-selection-item");
+    expect(selectionItem?.textContent).toMatch(/GPT-5/i);
+  });
+
+  // ── Star / Set-as-default toggle ───────────────────────────────────────
+
+  it("shows StarFilled when the selected model is the user's default", async () => {
+    mockGetMe.mockResolvedValue({ ...FAKE_USER, default_model_id: "model-abc" });
+    renderModelSelector({ value: "model-abc" });
+    await settle();
+
+    // The star button should be present (it renders when value is not auto)
+    const starButton = document.querySelector(
+      ".ant-btn-primary .anticon-star",
+    );
+    expect(starButton).toBeInTheDocument();
+  });
+
+  it("shows StarOutlined when the selected model is not the default", async () => {
+    mockGetMe.mockResolvedValue({ ...FAKE_USER, default_model_id: "model-xyz" });
+    renderModelSelector({ value: "model-abc" });
+    await settle();
+
+    // Star outlined icon should be present
+    const starIcon = document.querySelector(".anticon-star");
+    expect(starIcon).toBeInTheDocument();
+  });
+
+  it("calls setDefaultModel when star button is clicked, then shows loading", async () => {
+    mockSetDefaultModel.mockReturnValue(Promise.resolve());
+    renderModelSelector({ value: "model-abc" });
+    await settle();
+
+    const user = userEvent.setup();
+    // Find the star button (the one with class ant-btn next to the Select)
+    const starBtn = document.querySelector(
+      ".ant-space-compact .ant-btn",
+    );
+    expect(starBtn).toBeInTheDocument();
+
+    await user.click(starBtn!);
+
+    expect(mockSetDefaultModel).toHaveBeenCalledWith("model-abc");
+  });
+
+  // ── Loading state ──────────────────────────────────────────────────────
+
+  it("shows loading indicator while models are being fetched", async () => {
+    // Never resolve the API call so the query stays in loading state
+    mockApi.mockImplementation(() => new Promise(() => {}));
+
+    renderModelSelector();
+    await settle();
+
+    // antd Select renders a loading spinner (anticon-loading) when isLoading
+    const spinner = document.querySelector(".anticon-loading");
+    expect(spinner).toBeInTheDocument();
+  });
+
+  // ── Empty state ────────────────────────────────────────────────────────
+
+  it("shows only the Auto option when the model list is empty", async () => {
+    mockApi.mockResolvedValue([]);
+
+    // Override getMe to return a default model so the Select has a known value
+    mockGetMe.mockResolvedValue({ ...FAKE_USER, default_model_id: "model-xyz" });
+    renderModelSelector({ value: "model-xyz" });
+    await settle();
+
+    const user = userEvent.setup();
+    await openSelect(user);
+
+    // Auto option is always present
+    expect(screen.getByText("⚡ Auto (Recommended)")).toBeInTheDocument();
+    // Model options should NOT be present since the API returned empty
+    expect(screen.queryByText(/DeepSeek/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/GPT/i)).not.toBeInTheDocument();
+  });
+
+  // ── Thunderbolt for Auto ───────────────────────────────────────────────
+
+  it("shows thunderbolt icon instead of star when Auto is selected", async () => {
+    renderModelSelector({ value: AUTO_ROUTE_VALUE });
+    await settle();
+
+    // Thunderbolt icon should be present
+    const boltIcon = document.querySelector(".anticon-thunderbolt");
+    expect(boltIcon).toBeInTheDocument();
+
+    // Star icon should NOT be present
+    const starIcon = document.querySelector(".anticon-star");
+    expect(starIcon).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/chat/components/SessionSidebar.test.tsx
+++ b/frontend/src/features/chat/components/SessionSidebar.test.tsx
@@ -73,9 +73,9 @@ vi.mock("react-router-dom", () => ({
 // Mock child components from barrel export
 vi.mock("./", () => ({
   ContextIndicator: () => <div data-testid="context-indicator" />,
-  MemoryManager: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+  MemoryManager: ({ open }: { open: boolean }) =>
     open ? <div data-testid="memory-manager" /> : null,
-  SessionSearch: ({ onClose }: { onClose: () => void }) => (
+  SessionSearch: () => (
     <div data-testid="session-search" />
   ),
 }));
@@ -218,7 +218,7 @@ describe("SessionSidebar", () => {
   // ── New Chat (lazy UUID) ──────────────────────────────────────────────
 
   it("creates a lazy UUID and navigates on New Chat click", async () => {
-    const randomUUID = vi.spyOn(crypto, "randomUUID").mockReturnValue("lazy-uuid-123");
+    const randomUUID = vi.spyOn(crypto, "randomUUID").mockReturnValue("00000000-0000-0000-0000-000000000000");
     renderSidebar();
     await settle();
 
@@ -229,7 +229,7 @@ describe("SessionSidebar", () => {
     await user.click(newChatBtn);
 
     expect(randomUUID).toHaveBeenCalled();
-    expect(mockNavigate).toHaveBeenCalledWith("/chat/lazy-uuid-123");
+    expect(mockNavigate).toHaveBeenCalledWith("/chat/00000000-0000-0000-0000-000000000000");
 
     randomUUID.mockRestore();
   });

--- a/frontend/src/features/chat/components/SessionSidebar.test.tsx
+++ b/frontend/src/features/chat/components/SessionSidebar.test.tsx
@@ -1,0 +1,381 @@
+// =============================================================================
+// SessionSidebar — Unit Tests
+// =============================================================================
+// Tests cover: session list sorting (pinned first, by updated_at), new chat
+// creation flows, pin/rename/delete actions, active highlighting, mobile
+// drawer vs desktop sider, and error state.
+// =============================================================================
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { SessionSidebar } from "./SessionSidebar";
+
+// jsdom does not implement Element.scrollIntoView
+Element.prototype.scrollIntoView = vi.fn();
+
+// ---------------------------------------------------------------------------
+// Mock external dependencies
+// ---------------------------------------------------------------------------
+
+const {
+  mockListSessions,
+  mockCreateSession,
+  mockDeleteSession,
+  mockUpdateSession,
+  mockImportSession,
+} = vi.hoisted(() => ({
+  mockListSessions: vi.fn(),
+  mockCreateSession: vi.fn(),
+  mockDeleteSession: vi.fn(),
+  mockUpdateSession: vi.fn(),
+  mockImportSession: vi.fn(),
+}));
+
+vi.mock("../services/chat", () => ({
+  listSessions: mockListSessions,
+  createSession: mockCreateSession,
+  deleteSession: mockDeleteSession,
+  updateSession: mockUpdateSession,
+  exportSession: vi.fn(),
+  importSession: mockImportSession,
+  addTagToSession: vi.fn(),
+  removeTagFromSession: vi.fn(),
+}));
+
+// Mock AuthProvider
+const mockLogout = vi.fn();
+vi.mock("../../../providers/AuthProvider", () => ({
+  useAuth: () => ({
+    user: {
+      id: "u1",
+      email: "admin@test.com",
+      display_name: "Admin User",
+      role: "admin",
+      tenant_id: "t1",
+      is_active: true,
+      default_model_id: null,
+      created_at: "2024-01-01T00:00:00Z",
+    },
+    logout: mockLogout,
+  }),
+}));
+
+// Mock react-router-dom
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", () => ({
+  useParams: () => ({ sessionId: "session-1" }),
+  useNavigate: () => mockNavigate,
+  useLocation: () => ({ pathname: "/chat/session-1" }),
+}));
+
+// Mock child components from barrel export
+vi.mock("./", () => ({
+  ContextIndicator: () => <div data-testid="context-indicator" />,
+  MemoryManager: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+    open ? <div data-testid="memory-manager" /> : null,
+  SessionSearch: ({ onClose }: { onClose: () => void }) => (
+    <div data-testid="session-search" />
+  ),
+}));
+
+// Mock shared Logo component
+vi.mock("../../../shared/components/Logo", () => ({
+  Logo: ({ size, showText }: { size: number; showText?: boolean }) => (
+    <div data-testid="logo" data-size={size} data-show-text={String(!!showText)} />
+  ),
+}));
+
+// Mock Ant Design's Grid.useBreakpoint for desktop
+vi.mock("antd", async (importOriginal) => {
+  const antd = await importOriginal<typeof import("antd")>();
+  return {
+    ...antd,
+    Grid: {
+      useBreakpoint: () => ({ xs: false, sm: true, md: true, lg: true, xl: true }),
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const NOW = "2024-06-15T12:00:00Z";
+const EARLIER = "2024-06-14T10:00:00Z";
+const EARLIEST = "2024-06-13T08:00:00Z";
+
+const SESSIONS = [
+  {
+    id: "session-pinned-1",
+    title: "Pinned Session A",
+    is_pinned: true,
+    is_temporary: false,
+    updated_at: NOW,
+    tags: [],
+  },
+  {
+    id: "session-pinned-2",
+    title: "Pinned Session B",
+    is_pinned: true,
+    is_temporary: false,
+    updated_at: EARLIER,
+    tags: [],
+  },
+  {
+    id: "session-1",
+    title: "Active Session",
+    is_pinned: false,
+    is_temporary: false,
+    updated_at: NOW,
+    tags: [],
+  },
+  {
+    id: "session-old",
+    title: "Old Session",
+    is_pinned: false,
+    is_temporary: false,
+    updated_at: EARLIEST,
+    tags: [],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderSidebar() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SessionSidebar />
+    </QueryClientProvider>,
+  );
+}
+
+async function settle() {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 200));
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SessionSidebar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListSessions.mockResolvedValue(SESSIONS);
+    mockCreateSession.mockResolvedValue({ id: "new-session", title: "New Chat" });
+    mockDeleteSession.mockResolvedValue(undefined);
+    mockUpdateSession.mockResolvedValue(undefined);
+    mockImportSession.mockResolvedValue({ session_id: "imported-session", message_count: 5 });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  // ── Session list rendering (pinned first, sorted by updated_at) ────────
+
+  it("renders sessions sorted with pinned first, then by updated_at descending", async () => {
+    renderSidebar();
+    await settle();
+
+    // The rendered list items have data-session-id attributes
+    const items = document.querySelectorAll("[data-session-id]");
+    const ids = Array.from(items).map((el) => el.getAttribute("data-session-id"));
+
+    // Expected order: pinned-1 (pinned, newest), pinned-2 (pinned, older),
+    // session-1 (unpinned, newest), session-old (unpinned, oldest)
+    expect(ids).toEqual([
+      "session-pinned-1",
+      "session-pinned-2",
+      "session-1",
+      "session-old",
+    ]);
+  });
+
+  // ── Active session highlighting ───────────────────────────────────────
+
+  it("highlights the active session", async () => {
+    renderSidebar();
+    await settle();
+
+    const activeItem = document.querySelector(
+      '[data-session-id="session-1"]',
+    );
+    expect(activeItem).toBeInTheDocument();
+    // Active session gets a highlighted background
+    expect(activeItem).toHaveStyle({ background: "#e6f4ff" });
+  });
+
+  // ── New Chat (lazy UUID) ──────────────────────────────────────────────
+
+  it("creates a lazy UUID and navigates on New Chat click", async () => {
+    const randomUUID = vi.spyOn(crypto, "randomUUID").mockReturnValue("lazy-uuid-123");
+    renderSidebar();
+    await settle();
+
+    const user = userEvent.setup();
+
+    // Click the "New Chat" button
+    const newChatBtn = screen.getByRole("button", { name: /new chat/i });
+    await user.click(newChatBtn);
+
+    expect(randomUUID).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith("/chat/lazy-uuid-123");
+
+    randomUUID.mockRestore();
+  });
+
+  // ── Temporary Chat ────────────────────────────────────────────────────
+
+  it("calls createSession and navigates on Temporary Chat", async () => {
+    // Mock the Dropdown menu click
+    // The "New Chat" button + dropdown are in a Space.Compact.
+    renderSidebar();
+    await settle();
+
+    const user = userEvent.setup();
+
+    // Find the dropdown trigger (the button with the DownOutlined icon)
+    const dropdownBtn = document.querySelector(
+      ".ant-dropdown-trigger",
+    );
+    expect(dropdownBtn).toBeInTheDocument();
+
+    // Click the dropdown trigger to open the menu
+    await user.click(dropdownBtn!);
+
+    // Click "Temporary Chat" in the dropdown menu
+    const tempChatOption = screen.getByText("Temporary Chat");
+    await user.click(tempChatOption);
+
+    expect(mockCreateSession).toHaveBeenCalledWith(expect.objectContaining({
+      title: "New Chat",
+      is_temporary: true,
+      auto_route_enabled: true,
+    }));
+    expect(mockNavigate).toHaveBeenCalledWith("/chat/new-session");
+  });
+
+  // ── Pin action ────────────────────────────────────────────────────────
+
+  it("toggles pin when pin button is clicked", async () => {
+    renderSidebar();
+    await settle();
+
+    const user = userEvent.setup();
+
+    // Find the pin button for "Old Session" (which is not pinned)
+    const sessionItem = document.querySelector(
+      '[data-session-id="session-old"]',
+    );
+    expect(sessionItem).toBeInTheDocument();
+
+    // The pin button (PushpinOutlined) is in the actions
+    const pinBtn = sessionItem!.querySelector(".anticon-pushpin");
+    expect(pinBtn).toBeInTheDocument();
+    await user.click(pinBtn!.closest("button")!);
+
+    expect(mockUpdateSession).toHaveBeenCalledWith("session-old", {
+      is_pinned: true,
+    });
+  });
+
+  // ── Delete action ─────────────────────────────────────────────────────
+
+  it("deletes a session and navigates away if it is the active session", async () => {
+    renderSidebar();
+    await settle();
+
+    const user = userEvent.setup();
+
+    // Find the delete button for "session-1" (the active session)
+    const sessionItem = document.querySelector(
+      '[data-session-id="session-1"]',
+    );
+    const deleteBtn = sessionItem!.querySelector(".anticon-delete");
+    expect(deleteBtn).toBeInTheDocument();
+
+    // Click the delete button to trigger Popconfirm
+    await user.click(deleteBtn!.closest("button")!);
+
+    // The Popconfirm OK button has text "Delete" — use exact match to avoid
+    // colliding with the delete icon button's aria-label ("delete").
+    const confirmBtn = screen.getByRole("button", { name: "Delete" });
+    await user.click(confirmBtn);
+
+    expect(mockDeleteSession).toHaveBeenCalledWith("session-1");
+    // Since session-1 is the active session, navigate away
+    expect(mockNavigate).toHaveBeenCalledWith("/chat");
+  });
+
+  // ── Rename action ─────────────────────────────────────────────────────
+
+  it("opens edit modal, updates title, and calls updateSession on save", async () => {
+    renderSidebar();
+    await settle();
+
+    const user = userEvent.setup();
+
+    // Find the edit button for "Old Session"
+    const sessionItem = document.querySelector(
+      '[data-session-id="session-old"]',
+    );
+    const editBtn = sessionItem!.querySelector(".anticon-edit");
+    expect(editBtn).toBeInTheDocument();
+
+    // Click the edit button
+    await user.click(editBtn!.closest("button")!);
+
+    // Modal should appear with the session title
+    const titleInput = screen.getByPlaceholderText("Chat title");
+    expect(titleInput).toBeInTheDocument();
+    expect(titleInput).toHaveValue("Old Session");
+
+    // Change the title
+    await user.clear(titleInput);
+    await user.type(titleInput, "Renamed Session");
+
+    // Click OK button on the modal
+    const okBtn = screen.getByRole("button", { name: /ok/i });
+    await user.click(okBtn);
+
+    expect(mockUpdateSession).toHaveBeenCalledWith("session-old", {
+      title: "Renamed Session",
+    });
+  });
+
+  // ── Error state ───────────────────────────────────────────────────────
+
+  it("shows error alert when listSessions fails", async () => {
+    mockListSessions.mockRejectedValue(new Error("Network error"));
+
+    renderSidebar();
+    await settle();
+
+    expect(screen.getByText("Failed to load sessions")).toBeInTheDocument();
+    expect(screen.getByText("Network error")).toBeInTheDocument();
+  });
+
+  // ── Loading state ─────────────────────────────────────────────────────
+
+  it("shows loading indicator while sessions are fetching", async () => {
+    // Never resolve so it stays in loading
+    mockListSessions.mockImplementation(() => new Promise(() => {}));
+
+    renderSidebar();
+    await settle();
+
+    // Ant Design List shows a Spin when loading
+    const spinner = document.querySelector(".ant-spin");
+    expect(spinner).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/chat/components/SessionToolActivation.test.tsx
+++ b/frontend/src/features/chat/components/SessionToolActivation.test.tsx
@@ -1,0 +1,305 @@
+// =============================================================================
+// SessionToolActivation — Unit Tests
+// =============================================================================
+// Tests focus on: tool list rendering grouped by category, activation toggle
+// interactions, always-on tools display, isPending mode, and empty state.
+// =============================================================================
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { SessionToolActivation } from "./SessionToolActivation";
+
+// ---------------------------------------------------------------------------
+// Mock external dependencies
+// ---------------------------------------------------------------------------
+
+const { mockApi, mockListSessionTools, mockAddSessionTool, mockRemoveSessionTool, mockSetToolAlwaysOn, mockListAlwaysOnTools } = vi.hoisted(() => ({
+  mockApi: vi.fn(),
+  mockListSessionTools: vi.fn(),
+  mockAddSessionTool: vi.fn(),
+  mockRemoveSessionTool: vi.fn(),
+  mockSetToolAlwaysOn: vi.fn(),
+  mockListAlwaysOnTools: vi.fn(),
+}));
+
+vi.mock("../../../services/api", () => ({
+  default: mockApi,
+  getToken: () => "test-token",
+}));
+
+vi.mock("../services/chat", () => ({
+  listSessionTools: mockListSessionTools,
+  addSessionTool: mockAddSessionTool,
+  removeSessionTool: mockRemoveSessionTool,
+  setToolAlwaysOn: mockSetToolAlwaysOn,
+  listAlwaysOnTools: mockListAlwaysOnTools,
+}));
+
+// Mock Ant Design's Grid.useBreakpoint for desktop
+vi.mock("antd", async (importOriginal) => {
+  const antd = await importOriginal<typeof import("antd")>();
+  return {
+    ...antd,
+    Grid: {
+      useBreakpoint: () => ({ xs: false, sm: true, md: true, lg: true, xl: true }),
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const AVAILABLE_TOOLS = [
+  {
+    id: "tool-web",
+    name: "Web Search",
+    description: "Search the web",
+    category: "web",
+    enabled: true,
+    tenant_id: "t1",
+    config: {},
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  },
+  {
+    id: "tool-fin",
+    name: "Stock Price",
+    description: "Get stock prices",
+    category: "financial",
+    enabled: true,
+    tenant_id: "t1",
+    config: {},
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  },
+  {
+    id: "tool-util",
+    name: "Calculator",
+    description: "Perform calculations",
+    category: "utility",
+    enabled: true,
+    tenant_id: "t1",
+    config: {},
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  },
+];
+
+const ACTIVE_TOOLS = [
+  { id: "tool-web", name: "Web Search", description: "Search the web", category: "web" },
+];
+
+const ALWAYS_ON_IDS = ["tool-util"];
+
+const SKILLS_RESPONSE = {
+  items: [
+    { id: "skill-1", tool_ids: ["tool-web"] },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderToolActivation(props: Record<string, unknown> = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SessionToolActivation
+        sessionId="test-session"
+        open={true}
+        onClose={vi.fn()}
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+async function settle() {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 200));
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SessionToolActivation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockApi.mockImplementation((url: string) => {
+      if (url === "/chat/session/tools/available") return Promise.resolve(AVAILABLE_TOOLS);
+      if (url === "/skills") return Promise.resolve(SKILLS_RESPONSE);
+      return Promise.resolve([]);
+    });
+    mockListSessionTools.mockResolvedValue(ACTIVE_TOOLS);
+    mockListAlwaysOnTools.mockResolvedValue(ALWAYS_ON_IDS);
+    mockAddSessionTool.mockResolvedValue(undefined);
+    mockRemoveSessionTool.mockResolvedValue(undefined);
+    mockSetToolAlwaysOn.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── Tool list rendering grouped by category ────────────────────────────
+
+  it("renders tools grouped by category with headers", async () => {
+    renderToolActivation();
+    await settle();
+
+    // Category headers (in order: financial, web, utility)
+    const financialHeader = screen.getByText("Financial");
+    const webHeader = screen.getByText("Web");
+    const utilityHeader = screen.getByText("Utility");
+
+    expect(financialHeader).toBeInTheDocument();
+    expect(webHeader).toBeInTheDocument();
+    expect(utilityHeader).toBeInTheDocument();
+
+    // Tool names
+    expect(screen.getByText("Stock Price")).toBeInTheDocument();
+    expect(screen.getByText("Web Search")).toBeInTheDocument();
+    expect(screen.getByText("Calculator")).toBeInTheDocument();
+  });
+
+  // ── Activation toggle interactions ─────────────────────────────────────
+
+  /** Find the always-on and active switch elements for a named tool row. */
+  function toolSwitches(toolName: string) {
+    const item = screen.getByText(toolName).closest(".ant-list-item");
+    if (!item) throw new Error(`Tool "${toolName}" not found`);
+    const switches = item.querySelectorAll<HTMLElement>(".ant-switch");
+    return { alwaysOn: switches[0], active: switches[1] };
+  }
+
+  it("calls addSessionTool when activating a tool", async () => {
+    renderToolActivation();
+    await settle();
+
+    const user = userEvent.setup();
+
+    // "Stock Price" is not in ACTIVE_TOOLS → its active switch is unchecked
+    const { active } = toolSwitches("Stock Price");
+    expect(active).not.toHaveClass("ant-switch-checked");
+
+    await user.click(active);
+
+    expect(mockAddSessionTool).toHaveBeenCalledWith("test-session", "tool-fin");
+  });
+
+  it("calls removeSessionTool when deactivating an active tool", async () => {
+    renderToolActivation();
+    await settle();
+
+    const user = userEvent.setup();
+
+    // "Web Search" IS in ACTIVE_TOOLS → its active switch is checked
+    const { active } = toolSwitches("Web Search");
+    expect(active).toHaveClass("ant-switch-checked");
+
+    await user.click(active);
+
+    expect(mockRemoveSessionTool).toHaveBeenCalledWith("test-session", "tool-web");
+  });
+
+  // ── Always-on tools display ────────────────────────────────────────────
+
+  it("shows always-on switch checked for always-on tools", async () => {
+    renderToolActivation();
+    await settle();
+
+    // Calculator (tool-util) is in ALWAYS_ON_IDS
+    const { alwaysOn } = toolSwitches("Calculator");
+    expect(alwaysOn).toHaveClass("ant-switch-checked");
+  });
+
+  it("calls setToolAlwaysOn when toggling always-on", async () => {
+    renderToolActivation();
+    await settle();
+
+    const user = userEvent.setup();
+
+    // Calculator is always-on → toggling it off calls setToolAlwaysOn(..., false)
+    const { alwaysOn } = toolSwitches("Calculator");
+    expect(alwaysOn).toHaveClass("ant-switch-checked");
+
+    await user.click(alwaysOn);
+
+    expect(mockSetToolAlwaysOn).toHaveBeenCalledWith("tool-util", false);
+  });
+
+  // ── Auto-select tools toggle ───────────────────────────────────────────
+
+  it("fires onAutoSelectToolsChange when toggling the auto-select switch", async () => {
+    const onAutoSelectToolsChange = vi.fn();
+    renderToolActivation({ onAutoSelectToolsChange });
+    await settle();
+
+    const user = userEvent.setup();
+
+    // The auto-select switch is inside the drawer body, before any tool list
+    const allSwitches = document.querySelectorAll<HTMLElement>(".ant-drawer-body .ant-switch");
+    expect(allSwitches.length).toBeGreaterThanOrEqual(1);
+
+    // First switch in the drawer body is the auto-select toggle
+    await user.click(allSwitches[0]);
+
+    expect(onAutoSelectToolsChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── isPending mode ─────────────────────────────────────────────────────
+
+  it("uses pendingActiveToolIds and calls onPendingToolToggle in isPending mode", async () => {
+    const onPendingToolToggle = vi.fn();
+    renderToolActivation({
+      isPending: true,
+      pendingActiveToolIds: ["tool-fin"],
+      onPendingToolToggle,
+    });
+    await settle();
+
+    const user = userEvent.setup();
+
+    // In pending mode, listSessionTools should NOT be called
+    expect(mockListSessionTools).not.toHaveBeenCalled();
+
+    // "Stock Price" (tool-fin) is in pendingActiveToolIds → active switch checked
+    // "Web Search" (tool-web) is NOT → active switch unchecked → clicking calls toggle
+    const { active } = toolSwitches("Web Search");
+    expect(active).not.toHaveClass("ant-switch-checked");
+
+    await user.click(active);
+
+    expect(onPendingToolToggle).toHaveBeenCalledWith("tool-web", true);
+  });
+
+  // ── Skill tool tagging ─────────────────────────────────────────────────
+
+  it('shows "from skill" tag for tools associated with the selected skill', async () => {
+    renderToolActivation({ selectedSkillId: "skill-1" });
+    await settle();
+
+    // skill-1 has tool_ids: ["tool-web"], so Web Search should have the tag
+    expect(screen.getByText("from skill")).toBeInTheDocument();
+  });
+
+  // ── Empty state ────────────────────────────────────────────────────────
+
+  it('shows "No tools available" when the available tools list is empty', async () => {
+    mockApi.mockResolvedValue([]);
+
+    renderToolActivation();
+    await settle();
+
+    expect(screen.getByText("No tools available for your tenant")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/chat/hooks/useStream.test.ts
+++ b/frontend/src/features/chat/hooks/useStream.test.ts
@@ -41,7 +41,7 @@ function sseEvent(
   event: string,
   data: Record<string, unknown>,
 ) {
-  const lastCall = mockFetchEventSource.mock.calls.at(-1);
+  const lastCall = mockFetchEventSource.mock.calls[mockFetchEventSource.mock.calls.length - 1];
   if (!lastCall) throw new Error("fetchEventSource was never called");
   const config = lastCall[1] as {
     onmessage?: (ev: { event: string; data: string }) => void;

--- a/frontend/src/features/chat/hooks/useStream.test.ts
+++ b/frontend/src/features/chat/hooks/useStream.test.ts
@@ -1,0 +1,324 @@
+// =============================================================================
+// useStream — Unit Tests
+// =============================================================================
+// Tests cover: SSE connection lifecycle (startStream, startRegenerateStream,
+// startEditStream), token accumulation callbacks, stop/cancel via DELETE,
+// error handling, demo/widget fallback, and abort cleanup on unmount.
+// =============================================================================
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useStream } from "./useStream";
+
+// ---------------------------------------------------------------------------
+// Mock external dependencies
+// ---------------------------------------------------------------------------
+
+const { mockFetchEventSource, mockFetch, mockGetToken } = vi.hoisted(() => ({
+  mockFetchEventSource: vi.fn(),
+  mockFetch: vi.fn(),
+  mockGetToken: vi.fn(),
+}));
+
+vi.mock("@microsoft/fetch-event-source", () => ({
+  fetchEventSource: mockFetchEventSource,
+  EventStreamContentType: "text/event-stream",
+}));
+
+vi.mock("../../../services/api", () => ({
+  getToken: mockGetToken,
+}));
+
+// Mock global fetch for DELETE /stream and demo-mode fallback
+vi.stubGlobal("fetch", mockFetch);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Simulate an SSE event on the latest fetchEventSource config. */
+function sseEvent(
+  event: string,
+  data: Record<string, unknown>,
+) {
+  const lastCall = mockFetchEventSource.mock.calls.at(-1);
+  if (!lastCall) throw new Error("fetchEventSource was never called");
+  const config = lastCall[1] as {
+    onmessage?: (ev: { event: string; data: string }) => void;
+  };
+  config.onmessage?.({ event, data: JSON.stringify(data) });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useStream", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetToken.mockReturnValue("test-token");
+    mockFetch.mockReset();
+    // Default: fetchEventSource calls onclose after a brief delay
+    mockFetchEventSource.mockImplementation(
+      async (_url: string, config: { onclose?: () => void }) => {
+        setTimeout(() => config.onclose?.(), 50);
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // ── SSE connection lifecycle ──────────────────────────────────────────
+
+  it("startStream POSTs to the correct URL with headers and body", async () => {
+    const { result } = renderHook(() => useStream());
+
+    await act(async () => {
+      await result.current.startStream(
+        "session-1",
+        "Hello",
+        ["file-1"],
+        0.7,
+        { custom: "data" },
+        {},
+      );
+    });
+
+    expect(mockFetchEventSource).toHaveBeenCalledWith(
+      "/api/chat/session/session-1/message",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          Authorization: "Bearer test-token",
+        }),
+        openWhenHidden: true,
+      }),
+    );
+
+    const bodyArg = mockFetchEventSource.mock.calls[0][1] as { body: string };
+    expect(JSON.parse(bodyArg.body)).toEqual({
+      content: "Hello",
+      file_ids: ["file-1"],
+      temperature: 0.7,
+      session_data: { custom: "data" },
+    });
+  });
+
+  // ── Token accumulation ────────────────────────────────────────────────
+
+  it("calls onToken callback when token events arrive", async () => {
+    const { result } = renderHook(() => useStream());
+    const onToken = vi.fn();
+
+    act(() => {
+      result.current.startStream("session-1", "Hello", [], undefined, {}, { onToken });
+    });
+
+    await waitFor(() => {
+      expect(mockFetchEventSource).toHaveBeenCalled();
+    });
+
+    act(() => {
+      sseEvent("token", { delta: "Hello", message_id: "msg-1" });
+      sseEvent("token", { delta: " world", message_id: "msg-1" });
+    });
+
+    expect(onToken).toHaveBeenCalledTimes(2);
+    expect(onToken).toHaveBeenNthCalledWith(1, "Hello", "msg-1");
+    // Hook passes through the delta as-is (includes leading space)
+    expect(onToken).toHaveBeenNthCalledWith(2, " world", "msg-1");
+  });
+
+  // ── onMessageComplete callback ────────────────────────────────────────
+
+  it("calls onMessageComplete when message_complete event arrives", async () => {
+    const { result } = renderHook(() => useStream());
+    const onMessageComplete = vi.fn();
+
+    act(() => {
+      result.current.startStream("session-1", "Hello", [], undefined, {}, { onMessageComplete });
+    });
+
+    await waitFor(() => expect(mockFetchEventSource).toHaveBeenCalled());
+
+    act(() => {
+      sseEvent("message_complete", {
+        session_id: "session-1",
+        message_id: "msg-1",
+        content: "Hello world",
+        model_id: "model-abc",
+        model_name: "DeepSeek V4",
+        tokens_in: 10,
+        tokens_out: 20,
+      });
+    });
+
+    expect(onMessageComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session_id: "session-1",
+        message_id: "msg-1",
+        content: "Hello world",
+        model_id: "model-abc",
+      }),
+    );
+  });
+
+  // ── Stop / cancel stream ──────────────────────────────────────────────
+
+  it("stopStream sends DELETE and sets streaming to false", async () => {
+    vi.useFakeTimers();
+    mockFetch.mockResolvedValue({ ok: true });
+
+    const { result } = renderHook(() => useStream());
+
+    // Override fetchEventSource to never close (simulate in-flight stream)
+    mockFetchEventSource.mockImplementation(
+      () => new Promise(() => {}),
+    );
+
+    act(() => {
+      result.current.startStream("session-1", "Hello", [], undefined, {}, {});
+    });
+
+    // streaming flips to true synchronously inside startStream
+    expect(result.current.streaming).toBe(true);
+
+    await act(async () => {
+      result.current.stopStream("session-1");
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/chat/session/session-1/stream",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+
+    // stopStream sets streaming=false via a 2s safety-net timeout
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.streaming).toBe(false);
+
+    vi.useRealTimers();
+  });
+
+  // ── Error handling ────────────────────────────────────────────────────
+
+  it("calls onError when error event arrives", async () => {
+    const { result } = renderHook(() => useStream());
+    const onError = vi.fn();
+
+    act(() => {
+      result.current.startStream("session-1", "Hello", [], undefined, {}, { onError });
+    });
+
+    await waitFor(() => expect(mockFetchEventSource).toHaveBeenCalled());
+
+    act(() => {
+      sseEvent("error", {
+        session_id: "session-1",
+        message_id: "msg-1",
+        error: "Something went wrong",
+      });
+    });
+
+    expect(onError).toHaveBeenCalledWith("Something went wrong", "msg-1");
+  });
+
+  // ── startRegenerateStream ─────────────────────────────────────────────
+
+  it("startRegenerateStream POSTs to the regenerate endpoint", async () => {
+    const { result } = renderHook(() => useStream());
+
+    await act(async () => {
+      await result.current.startRegenerateStream("session-1", "msg-1", {});
+    });
+
+    expect(mockFetchEventSource).toHaveBeenCalledWith(
+      "/api/chat/session/session-1/message/msg-1/regenerate",
+      expect.any(Object),
+    );
+  });
+
+  // ── startEditStream ───────────────────────────────────────────────────
+
+  it("startEditStream PUTs to the edit endpoint with content", async () => {
+    const { result } = renderHook(() => useStream());
+
+    await act(async () => {
+      await result.current.startEditStream("session-1", "msg-1", "Edited content", 0.5, {});
+    });
+
+    expect(mockFetchEventSource).toHaveBeenCalledWith(
+      "/api/chat/session/session-1/message/msg-1",
+      expect.objectContaining({ method: "PUT" }),
+    );
+
+    const bodyArg = mockFetchEventSource.mock.calls[0][1] as { body: string };
+    expect(JSON.parse(bodyArg.body)).toEqual({
+      content: "Edited content",
+      temperature: 0.5,
+    });
+  });
+
+  // ── Demo/widget fallback mode ─────────────────────────────────────────
+
+  it("uses regular fetch instead of SSE when apiPrefix is not 'chat'", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        content: "Demo response",
+        message_id: "demo-msg-1",
+      }),
+    });
+
+    const { result } = renderHook(() => useStream("demo"));
+    const onToken = vi.fn();
+    const onMessageComplete = vi.fn();
+
+    await act(async () => {
+      await result.current.startStream("demo-session", "Hello", [], undefined, {}, {
+        onToken,
+        onMessageComplete,
+      });
+    });
+
+    expect(mockFetchEventSource).not.toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/demo/session/message",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining("Hello"),
+      }),
+    );
+
+    expect(onMessageComplete).toHaveBeenCalled();
+    expect(onToken).toHaveBeenCalled();
+  });
+
+  // ── Cleanup on unmount ────────────────────────────────────────────────
+
+  it("aborts the stream controller on unmount when stream is active", async () => {
+    const { result, unmount } = renderHook(() => useStream());
+
+    mockFetchEventSource.mockImplementation(
+      () => new Promise(() => {}),
+    );
+
+    act(() => {
+      result.current.startStream("session-1", "Hello", [], undefined, {}, {});
+    });
+
+    expect(result.current.streaming).toBe(true);
+
+    const abortSpy = vi.spyOn(AbortController.prototype, "abort");
+
+    unmount();
+
+    expect(abortSpy).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/chat/routes/ChatPage.test.tsx
+++ b/frontend/src/features/chat/routes/ChatPage.test.tsx
@@ -1,0 +1,247 @@
+// =============================================================================
+// ChatPage — Unit Tests
+// =============================================================================
+// Tests cover: routing to new/saved/temp sessions, correct isPending prop
+// derivation, session loading and 404 fallback, welcome screen with
+// New Chat / Temporary Chat buttons.
+// =============================================================================
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { ChatPage } from "./ChatPage";
+
+// ---------------------------------------------------------------------------
+// Mock external dependencies
+// ---------------------------------------------------------------------------
+
+const {
+  mockGetSession,
+  mockCreateSession,
+  mockUpdateSession,
+} = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  mockCreateSession: vi.fn(),
+  mockUpdateSession: vi.fn(),
+}));
+
+vi.mock("../services/chat", () => ({
+  getSession: mockGetSession,
+  createSession: mockCreateSession,
+  updateSession: mockUpdateSession,
+}));
+
+// Mock react-router-dom at the test level so we can control sessionId per test
+const mockNavigate = vi.fn();
+let mockSessionId: string | undefined = undefined;
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return {
+    ...actual,
+    useParams: () => ({ sessionId: mockSessionId }),
+    useNavigate: () => mockNavigate,
+  };
+});
+
+// Mock child components
+vi.mock("../components/SessionSidebar", () => ({
+  SessionSidebar: () => <div data-testid="session-sidebar" />,
+}));
+
+vi.mock("../components/ChatWindow", () => ({
+  ChatWindow: (props: Record<string, unknown>) => (
+    <div
+      data-testid="chat-window"
+      data-session-id={props.sessionId as string}
+      data-is-pending={String(!!props.isPending)}
+      data-is-temporary={String(!!props.isTemporary)}
+    />
+  ),
+}));
+
+// Mock Ant Design's Grid.useBreakpoint for desktop
+vi.mock("antd", async (importOriginal) => {
+  const antd = await importOriginal<typeof import("antd")>();
+  return {
+    ...antd,
+    Grid: {
+      useBreakpoint: () => ({ xs: false, sm: true, md: true, lg: true, xl: true }),
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const FAKE_SESSION = {
+  id: "session-1",
+  title: "Test Session",
+  is_temporary: false,
+  selected_model_id: "model-abc",
+  selected_template_id: null,
+  selected_skill_id: "skill-1",
+  temperature: 0.7,
+  cross_session_retrieval_enabled: true,
+  auto_route_enabled: false,
+  auto_select_tools: true,
+  is_pinned: false,
+  tags: [],
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderChatPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <ChatPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+async function settle() {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 200));
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ChatPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNavigate.mockReset();
+    mockGetSession.mockReset();
+    mockCreateSession.mockReset();
+    mockUpdateSession.mockReset();
+    mockSessionId = undefined;
+
+    mockGetSession.mockResolvedValue(FAKE_SESSION);
+    mockCreateSession.mockResolvedValue({ id: "new-temp", title: "New Chat" });
+    mockUpdateSession.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  // ── No sessionId → welcome screen ─────────────────────────────────────
+
+  it("renders welcome screen with New Chat buttons when no sessionId in URL", async () => {
+    mockSessionId = undefined;
+    renderChatPage();
+    await settle();
+
+    expect(screen.getByText("Welcome to PH Agent Hub")).toBeInTheDocument();
+    expect(screen.getByText("Select a conversation from the sidebar or start a new one")).toBeInTheDocument();
+
+    const newChatBtn = screen.getByRole("button", { name: /new chat/i });
+    expect(newChatBtn).toBeInTheDocument();
+
+    const newTempChatBtn = screen.getByRole("button", { name: /new temporary chat/i });
+    expect(newTempChatBtn).toBeInTheDocument();
+  });
+
+  // ── New Chat button creates UUID and navigates ─────────────────────────
+
+  it("generates a UUID and navigates on New Chat button click", async () => {
+    const randomUUID = vi.spyOn(crypto, "randomUUID").mockReturnValue("lazy-uuid-456");
+    mockSessionId = undefined;
+    renderChatPage();
+    await settle();
+
+    const user = userEvent.setup();
+    const newChatBtn = screen.getByRole("button", { name: /new chat/i });
+    await user.click(newChatBtn);
+
+    expect(randomUUID).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith("/chat/lazy-uuid-456");
+
+    randomUUID.mockRestore();
+  });
+
+  // ── Temporary Chat button creates session and navigates ────────────────
+
+  it("calls createSession and navigates on New Temporary Chat click", async () => {
+    mockSessionId = undefined;
+    renderChatPage();
+    await settle();
+
+    const user = userEvent.setup();
+    const newTempChatBtn = screen.getByRole("button", { name: /new temporary chat/i });
+    await user.click(newTempChatBtn);
+
+    expect(mockCreateSession).toHaveBeenCalledWith({
+      title: "New Chat",
+      is_temporary: true,
+    });
+    expect(mockNavigate).toHaveBeenCalledWith("/chat/new-temp");
+  });
+
+  // ── sessionId with loaded session → ChatWindow with props ──────────────
+
+  it("renders ChatWindow with correct props when session is loaded", async () => {
+    mockSessionId = "session-1";
+    renderChatPage();
+    await settle();
+
+    const chatWindow = screen.getByTestId("chat-window");
+    expect(chatWindow).toBeInTheDocument();
+    expect(chatWindow).toHaveAttribute("data-session-id", "session-1");
+    expect(chatWindow).toHaveAttribute("data-is-pending", "false");
+    expect(chatWindow).toHaveAttribute("data-is-temporary", "false");
+  });
+
+  // ── sessionId with loading → Spin ──────────────────────────────────────
+
+  it("shows loading spinner while session is being fetched", async () => {
+    mockSessionId = "session-1";
+    // Don't resolve the query
+    mockGetSession.mockImplementation(() => new Promise(() => {}));
+
+    renderChatPage();
+    await settle();
+
+    expect(document.querySelector(".ant-spin")).toBeInTheDocument();
+  });
+
+  // ── sessionId with 404 → ChatWindow with isPending ─────────────────────
+
+  it("renders ChatWindow with isPending when session is not found (404)", async () => {
+    mockSessionId = "nonexistent-id";
+    mockGetSession.mockRejectedValue(new Error("Not found"));
+
+    renderChatPage();
+    await settle();
+
+    const chatWindow = screen.getByTestId("chat-window");
+    expect(chatWindow).toBeInTheDocument();
+    expect(chatWindow).toHaveAttribute("data-session-id", "nonexistent-id");
+    expect(chatWindow).toHaveAttribute("data-is-pending", "true");
+  });
+
+  // ── SessionSidebar always rendered ─────────────────────────────────────
+
+  it("always renders the SessionSidebar", async () => {
+    mockSessionId = undefined;
+    renderChatPage();
+    await settle();
+
+    expect(screen.getByTestId("session-sidebar")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/chat/routes/ChatPage.test.tsx
+++ b/frontend/src/features/chat/routes/ChatPage.test.tsx
@@ -160,7 +160,7 @@ describe("ChatPage", () => {
   // ── New Chat button creates UUID and navigates ─────────────────────────
 
   it("generates a UUID and navigates on New Chat button click", async () => {
-    const randomUUID = vi.spyOn(crypto, "randomUUID").mockReturnValue("lazy-uuid-456");
+    const randomUUID = vi.spyOn(crypto, "randomUUID").mockReturnValue("00000000-0000-0000-0000-000000000000");
     mockSessionId = undefined;
     renderChatPage();
     await settle();
@@ -170,7 +170,7 @@ describe("ChatPage", () => {
     await user.click(newChatBtn);
 
     expect(randomUUID).toHaveBeenCalled();
-    expect(mockNavigate).toHaveBeenCalledWith("/chat/lazy-uuid-456");
+    expect(mockNavigate).toHaveBeenCalledWith("/chat/00000000-0000-0000-0000-000000000000");
 
     randomUUID.mockRestore();
   });


### PR DESCRIPTION
Unit tests for core chat components have been added to improve test coverage and prevent issues like the auto-model-select bug from shipping undetected. This addresses the lack of tests in the chat feature, specifically for components such as `ModelSelector`, `SessionToolActivation`, `SessionSidebar`, `useStream`, and `ChatPage`.

Closes #402

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring / Code style cleanup
- [ ] Infrastructure / CI / Build
- [ ] Other (please describe):

## Testing

- [x] Tested locally with Docker Compose (dev)
- [ ] Backend tests pass (`pytest backend/tests/ -m "not e2e and not slow"`)
- [x] Frontend builds without errors (`npm run build`)
- [x] Manual testing completed (added unit tests for chat components)

## Checklist

- [x] My code follows the coding conventions of this project
- [x] I have self-reviewed my own code
- [ ] I have commented complex code sections, particularly in hard-to-understand areas
- [ ] I have updated the documentation (`docs/`) if my change affects user-facing behaviour or configuration
- [x] My changes generate no new warnings or errors
- [x] New and existing tests pass locally

## Screenshots (if applicable)

## Additional Notes

```

