### PR TITLE
A2A tool fidelity — structured I/O, examples, and Part type support

### DIFF
--- a/backend/src/api/a2a_server.py
+++ b/backend/src/api/a2a_server.py
@@ -69,14 +69,16 @@ async def get_agent_card(request: Request):
             ).limit(50)
         )
         for skill in result.scalars().all():
+            # Read A2A metadata from the skill's a2a_metadata column (Issue #408)
+            a2a_meta = skill.a2a_metadata or {}
             skills.append({
                 "id": str(skill.id),
                 "name": skill.name,
                 "description": skill.description or "",
-                "tags": [],
-                "examples": [],
-                "inputModes": ["text/plain"],
-                "outputModes": ["text/plain"],
+                "tags": a2a_meta.get("tags", []),
+                "examples": a2a_meta.get("examples", []),
+                "inputModes": a2a_meta.get("inputModes") or ["text/plain"],
+                "outputModes": a2a_meta.get("outputModes") or ["text/plain"],
             })
     except Exception:
         logger.warning("Failed to load skills for Agent Card", exc_info=True)
@@ -145,12 +147,10 @@ async def a2a_send_message(
     Receives a SendMessageRequest, runs it through the agent runner,
     and returns a Task or Message response per the A2A spec.
     """
-    # Extract user message
+    # Extract user message content from all Part types
     msg = body.message or {}
     parts = msg.get("parts", [])
-    text_content = ""
-    for part in parts:
-        text_content += part.get("text", "")
+    text_content = _extract_text_from_parts(parts)
 
     # Create a task ID
     task_id = str(uuid.uuid4())
@@ -236,9 +236,7 @@ async def a2a_send_message_stream(
 
     msg = body.message or {}
     parts = msg.get("parts", [])
-    text_content = ""
-    for part in parts:
-        text_content += part.get("text", "")
+    text_content = _extract_text_from_parts(parts)
 
     task_id = str(uuid.uuid4())
     context_id = str(uuid.uuid4())
@@ -398,8 +396,38 @@ async def a2a_cancel_task(task_id: str):
 
 
 # ---------------------------------------------------------------------------
-# Internal helper
+# Internal helpers
 # ---------------------------------------------------------------------------
+
+
+def _extract_text_from_parts(parts: list[dict]) -> str:
+    """Extract a combined text representation from A2A Parts of all types.
+
+    Handles ``text``, ``data`` (JSON), ``url`` (file references), and
+    ``raw`` (binary) parts per A2A spec Section 4.1.6.
+    """
+    chunks: list[str] = []
+    for part in parts:
+        if "text" in part and part["text"]:
+            chunks.append(part["text"])
+        elif "data" in part and part["data"] is not None:
+            data_val = part["data"]
+            if isinstance(data_val, str):
+                chunks.append(data_val)
+            else:
+                chunks.append(json.dumps(data_val, ensure_ascii=False))
+        elif "url" in part and part["url"]:
+            filename = part.get("filename", "")
+            label = f"[file: {filename}]" if filename else "[url]"
+            chunks.append(f"{label} {part['url']}")
+        elif "raw" in part and part["raw"]:
+            filename = part.get("filename", "")
+            raw_val = part["raw"]
+            # raw is base64-encoded in JSON
+            size = len(raw_val) if isinstance(raw_val, str) else 0
+            label = f"[binary: {filename}]" if filename else "[binary]"
+            chunks.append(f"{label} (base64, {size} chars)")
+    return "\n".join(chunks)
 
 
 async def _run_a2a_agent(text_content: str) -> str:

--- a/backend/src/api/admin.py
+++ b/backend/src/api/admin.py
@@ -2029,6 +2029,7 @@ class AdminSkillCreate(BaseModel):
     cross_session_retrieval_enabled: bool = False
     cross_session_max_snippets: int = 3
     cross_session_min_score: float = 0.30
+    a2a_metadata: dict | None = None
 
 
 class AdminSkillUpdate(BaseModel):
@@ -2047,6 +2048,7 @@ class AdminSkillUpdate(BaseModel):
     cross_session_retrieval_enabled: bool | None = None
     cross_session_max_snippets: int | None = None
     cross_session_min_score: float | None = None
+    a2a_metadata: dict | None = None
 
 
 class AdminSkillResponse(BaseModel):
@@ -2064,6 +2066,7 @@ class AdminSkillResponse(BaseModel):
     enabled: bool
     cross_session_retrieval_enabled: bool
     cross_session_max_snippets: int
+    a2a_metadata: dict | None = None
     cross_session_min_score: float
     created_at: datetime
     updated_at: datetime
@@ -2148,6 +2151,7 @@ async def admin_create_skill(
         cross_session_retrieval_enabled=body.cross_session_retrieval_enabled,
         cross_session_max_snippets=body.cross_session_max_snippets,
         cross_session_min_score=body.cross_session_min_score,
+        a2a_metadata=body.a2a_metadata,
     )
     tools = await _svc_list_skill_tools(db, skill.id)
     resp = AdminSkillResponse.model_validate(skill)
@@ -2185,7 +2189,7 @@ async def admin_update_skill(
         "visibility", "template_id", "default_prompt_id", "default_model_id",
         "enabled",
         "cross_session_retrieval_enabled", "cross_session_max_snippets",
-        "cross_session_min_score",
+        "cross_session_min_score", "a2a_metadata",
     ):
         val = getattr(body, field, None)
         if val is not None:

--- a/backend/src/api/skills.py
+++ b/backend/src/api/skills.py
@@ -39,6 +39,7 @@ class SkillCreate(BaseModel):
     cross_session_retrieval_enabled: bool = False
     cross_session_max_snippets: int = 3
     cross_session_min_score: float = 0.30
+    a2a_metadata: dict | None = None
 
 
 class SkillUpdate(BaseModel):
@@ -54,6 +55,7 @@ class SkillUpdate(BaseModel):
     cross_session_retrieval_enabled: bool | None = None
     cross_session_max_snippets: int | None = None
     cross_session_min_score: float | None = None
+    a2a_metadata: dict | None = None
 
 
 class SkillResponse(BaseModel):
@@ -72,6 +74,7 @@ class SkillResponse(BaseModel):
     cross_session_retrieval_enabled: bool
     cross_session_max_snippets: int
     cross_session_min_score: float
+    a2a_metadata: dict | None = None
     created_at: datetime
     updated_at: datetime
     tool_ids: list[str] = []
@@ -149,6 +152,7 @@ async def create_skill(
         cross_session_retrieval_enabled=body.cross_session_retrieval_enabled,
         cross_session_max_snippets=body.cross_session_max_snippets,
         cross_session_min_score=body.cross_session_min_score,
+        a2a_metadata=body.a2a_metadata,
     )
     tools = await _svc_list_skill_tools(db, skill.id)
     resp = SkillResponse.model_validate(skill)

--- a/backend/src/db/migrations/versions/c2d3e4f5a6b7_add_a2a_metadata_to_skills.py
+++ b/backend/src/db/migrations/versions/c2d3e4f5a6b7_add_a2a_metadata_to_skills.py
@@ -1,0 +1,39 @@
+"""add_a2a_metadata_to_skills
+
+Add a nullable JSON column ``a2a_metadata`` to the ``skills`` table for
+storing A2A Agent Card skill metadata (inputModes, outputModes, examples,
+tags).  This allows the A2A server's Agent Card endpoint to declare
+accurate per-skill I/O modes instead of hardcoding ``["text/plain"]``.
+
+Revision ID: c2d3e4f5a6b7
+Revises: b1a2c3d4e5f6
+Create Date: 2026-06-22
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c2d3e4f5a6b7"
+down_revision: Union[str, None] = "b1a2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "skills",
+        sa.Column(
+            "a2a_metadata",
+            sa.JSON(),
+            nullable=True,
+            comment="A2A Agent Card per-skill metadata: {inputModes, outputModes, examples, tags}",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("skills", "a2a_metadata")

--- a/backend/src/db/orm/skills.py
+++ b/backend/src/db/orm/skills.py
@@ -5,7 +5,7 @@
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import String, Boolean, Integer, Float, DateTime, Enum, ForeignKey, func
+from sqlalchemy import String, Boolean, Integer, Float, DateTime, Enum, ForeignKey, JSON, func
 from sqlalchemy.dialects.mysql import CHAR
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -59,6 +59,12 @@ class Skill(Base):
     )
     cross_session_min_score: Mapped[float] = mapped_column(
         Float, default=0.30, nullable=False
+    )
+
+    # ---- A2A Agent Card metadata (Issue #408) ------------------------------
+    a2a_metadata: Mapped[dict | None] = mapped_column(
+        JSON, nullable=True,
+        comment="A2A Agent Card per-skill metadata: {inputModes, outputModes, examples, tags}",
     )
 
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/src/services/a2a_service.py
+++ b/backend/src/services/a2a_service.py
@@ -255,6 +255,10 @@ async def test_a2a_connection(
                 "id": s.id,
                 "name": s.name,
                 "description": s.description,
+                "inputModes": _safe_list(getattr(s, "input_modes", None) or getattr(s, "inputModes", None)),
+                "outputModes": _safe_list(getattr(s, "output_modes", None) or getattr(s, "outputModes", None)),
+                "examples": _safe_list(getattr(s, "examples", None)),
+                "tags": _safe_list(getattr(s, "tags", None)),
             }
             for s in agent_card.skills
         ] if agent_card.skills else []
@@ -318,6 +322,9 @@ async def sync_a2a_tools(
     discovered_skills = agent_card.skills or []
     discovered_ids = {s.id for s in discovered_skills}
 
+    # Cache the full Agent Card JSON for later use (media type negotiation, etc.)
+    _cache_agent_card(server, agent_card)
+
     # Fetch existing Tool records for this A2A server
     result = await db.execute(
         select(Tool).where(
@@ -341,6 +348,11 @@ async def sync_a2a_tools(
             "skill_id": skill.id,
             "skill_name": skill_name,
             "skill_description": skill.description or "",
+            # A2A protocol metadata (Issue #408)
+            "input_modes": _safe_list(getattr(skill, "input_modes", None) or getattr(skill, "inputModes", None)),
+            "output_modes": _safe_list(getattr(skill, "output_modes", None) or getattr(skill, "outputModes", None)),
+            "examples": _safe_list(getattr(skill, "examples", None)),
+            "tags": _safe_list(getattr(skill, "tags", None)),
         }
 
         if skill.id in existing_tools:
@@ -383,6 +395,39 @@ async def sync_a2a_tools(
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _safe_list(value) -> list:
+    """Return *value* as a list, or an empty list if it is None."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _cache_agent_card(server: A2aServer, agent_card) -> None:
+    """Store a JSON-serializable snapshot of the Agent Card in
+    ``server.agent_card_cache`` and update the timestamp."""
+    try:
+        # Try protobuf MessageToDict / to_json first
+        if hasattr(agent_card, "to_json"):
+            server.agent_card_cache = json.loads(agent_card.to_json())
+        elif hasattr(agent_card, "MessageToDict"):
+            from google.protobuf.json_format import MessageToDict
+            server.agent_card_cache = MessageToDict(agent_card)
+        else:
+            # Fallback: build a minimal dict from known fields
+            server.agent_card_cache = {
+                "name": getattr(agent_card, "name", ""),
+                "description": getattr(agent_card, "description", ""),
+                "defaultInputModes": _safe_list(getattr(agent_card, "default_input_modes", None) or getattr(agent_card, "defaultInputModes", None)),
+                "defaultOutputModes": _safe_list(getattr(agent_card, "default_output_modes", None) or getattr(agent_card, "defaultOutputModes", None)),
+            }
+    except Exception:
+        logger.warning("Failed to cache Agent Card for server %s", server.id, exc_info=True)
+        return
+    server.agent_card_cached_at = datetime.now(timezone.utc)
 
 
 def _validate_binding_fields(

--- a/backend/src/services/skill_service.py
+++ b/backend/src/services/skill_service.py
@@ -140,6 +140,7 @@ async def create_skill(
     cross_session_retrieval_enabled: bool = False,
     cross_session_max_snippets: int = 3,
     cross_session_min_score: float = 0.30,
+    a2a_metadata: dict | None = None,
 ) -> Skill:
     """Create a new skill with optional tool associations.
 
@@ -164,6 +165,7 @@ async def create_skill(
         cross_session_retrieval_enabled=cross_session_retrieval_enabled,
         cross_session_max_snippets=cross_session_max_snippets,
         cross_session_min_score=cross_session_min_score,
+        a2a_metadata=a2a_metadata,
     )
     db.add(skill)
     await db.flush()  # Get the skill ID before adding join rows

--- a/backend/src/tools/a2a.py
+++ b/backend/src/tools/a2a.py
@@ -44,6 +44,10 @@ async def build_a2a_tool_callables(
     skill_id = config.get("skill_id")
     skill_name = config.get("skill_name", tool.name)
     skill_description = config.get("skill_description", "")
+    input_modes = config.get("input_modes", [])
+    output_modes = config.get("output_modes", [])
+    examples = config.get("examples", [])
+    tags = config.get("tags", [])
 
     if not a2a_server_id or not skill_id:
         logger.warning("A2A tool %s has missing a2a_server_id or skill_id", tool.id)
@@ -68,6 +72,10 @@ async def build_a2a_tool_callables(
         skill_id=skill_id,
         skill_name=skill_name,
         skill_description=skill_description,
+        input_modes=input_modes,
+        output_modes=output_modes,
+        examples=examples,
+        tags=tags,
         cleanup_clients=cleanup_clients,
     )
 
@@ -79,14 +87,57 @@ async def _make_a2a_skill_callable(
     skill_id: str,
     skill_name: str,
     skill_description: str,
+    input_modes: list[str],
+    output_modes: list[str],
+    examples: list[str],
+    tags: list[str],
     cleanup_clients: list,
 ):
     """Create a FunctionTool-like callable that delegates to a remote A2A skill.
 
     Returns a MAF-compatible function decorated with @tool that, when invoked,
-    sends a message to the remote A2A agent via the a2a-sdk client.
+    sends a message to the remote A2A agent via the a2a-sdk client.  The
+    function supports all four A2A Part types (text, data, url, raw) and
+    negotiates media types via ``SendMessageConfiguration.acceptedOutputModes``.
     """
     from agent_framework import tool
+
+    # Resolve default I/O modes from the cached Agent Card (fallback to skill-level)
+    cached_card = server.agent_card_cache or {}
+    agent_default_inputs: list[str] = cached_card.get("defaultInputModes", [])
+    agent_default_outputs: list[str] = cached_card.get("defaultOutputModes", [])
+
+    effective_input_modes = input_modes if input_modes else agent_default_inputs
+    effective_output_modes = output_modes if output_modes else agent_default_outputs
+
+    # Build a rich docstring for the LLM
+    doc_parts: list[str] = [skill_description or f"Call the remote A2A agent skill: {skill_name}"]
+
+    if effective_input_modes:
+        if "application/json" in effective_input_modes:
+            doc_parts.append(
+                "\nInput format: This skill accepts JSON. "
+                "Pass your request as a JSON string and it will be sent as structured data."
+            )
+        else:
+            doc_parts.append(
+                f"\nInput format(s): {', '.join(effective_input_modes)}"
+            )
+
+    if effective_output_modes:
+        doc_parts.append(
+            f"Output format(s): {', '.join(effective_output_modes)}"
+        )
+
+    if tags:
+        doc_parts.append(f"Tags: {', '.join(tags)}")
+
+    if examples:
+        doc_parts.append("Examples:")
+        for i, ex in enumerate(examples, 1):
+            doc_parts.append(f"  {i}. {ex}")
+
+    rich_docstring = "\n".join(doc_parts)
 
     # Store the A2A client on the cleanup_clients list so the runner
     # can close it after the agent run
@@ -94,17 +145,11 @@ async def _make_a2a_skill_callable(
 
     @tool
     async def a2a_skill_callable(query: str) -> str:
-        """Call a remote A2A agent skill.
-
-        Args:
-            query: The text query to send to the remote agent.
-
-        Returns:
-            The agent's response text.
-        """
+        """DOCSTRING_PLACEHOLDER"""
         nonlocal a2a_client_ref
 
         try:
+            import uuid
             import httpx
             from a2a.client import (
                 ClientFactory,
@@ -112,6 +157,7 @@ async def _make_a2a_skill_callable(
             )
             from a2a.types import (
                 SendMessageRequest,
+                SendMessageConfiguration,
                 Message as A2AMessage,
                 Part,
                 Role,
@@ -164,37 +210,65 @@ async def _make_a2a_skill_callable(
 
             client = a2a_client_ref["client"]
 
-            # Build a SendMessageRequest
-            import uuid
+            # ---- Build the outgoing Part ---------------------------------
+            part = Part()
+            # If the skill declares JSON input and the query looks like JSON,
+            # send as a structured data part.
+            json_input_modes = {"application/json"}
+            if effective_input_modes and set(effective_input_modes) & json_input_modes:
+                try:
+                    parsed = json.loads(query)
+                    if isinstance(parsed, (dict, list)):
+                        from google.protobuf.struct_pb2 import Struct
+                        # Use protobuf Struct for JSON data
+                        s = Struct()
+                        s.update(parsed)
+                        part.data.CopyFrom(s)
+                        part.media_type = "application/json"
+                    else:
+                        part.text = query
+                except (json.JSONDecodeError, Exception):
+                    # Not valid JSON — fall back to text
+                    part.text = query
+            else:
+                part.text = query
+
+            # ---- Build the SendMessageRequest -----------------------------
             msg = A2AMessage()
             msg.message_id = str(uuid.uuid4())
             msg.role = Role.ROLE_USER
-            part = Part()
-            part.text = query
             msg.parts.append(part)
             request = SendMessageRequest()
             request.message.CopyFrom(msg)
 
-            # Send and collect response
-            result_text_parts = []
+            # ---- Media type negotiation -----------------------------------
+            if effective_output_modes:
+                config_block = SendMessageConfiguration()
+                config_block.accepted_output_modes.extend(effective_output_modes)
+                request.configuration.CopyFrom(config_block)
+
+            # ---- Send and collect ALL Part types --------------------------
+            result_parts: list[str] = []
             async for stream_response in client.send_message(request):
                 if stream_response.HasField("task"):
                     task = stream_response.task
                     if task.artifacts:
                         for artifact in task.artifacts:
-                            for part in artifact.parts:
-                                if part.text:
-                                    result_text_parts.append(part.text)
+                            for r_part in artifact.parts:
+                                formatted = _format_response_part(r_part)
+                                if formatted:
+                                    result_parts.append(formatted)
                 elif stream_response.HasField("message"):
                     msg_resp = stream_response.message
-                    for part in msg_resp.parts:
-                        if part.text:
-                            result_text_parts.append(part.text)
+                    for r_part in msg_resp.parts:
+                        formatted = _format_response_part(r_part)
+                        if formatted:
+                            result_parts.append(formatted)
 
-            if not result_text_parts:
-                return f"[A2A skill '{skill_name}' returned no text response]"
+            if not result_parts:
+                return f"[A2A skill '{skill_name}' returned no response]"
 
-            return "\n".join(result_text_parts)
+            return "\n".join(result_parts)
 
         except Exception as exc:
             logger.error(
@@ -207,8 +281,79 @@ async def _make_a2a_skill_callable(
 
     # Set metadata for the skill
     a2a_skill_callable.__name__ = f"a2a_{skill_id.replace('-', '_')}"
-    a2a_skill_callable.__doc__ = (
-        skill_description or f"Call the remote A2A agent skill: {skill_name}"
-    )
+    a2a_skill_callable.__doc__ = rich_docstring
 
     return a2a_skill_callable
+
+
+# ---------------------------------------------------------------------------
+# Response Part formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_response_part(r_part) -> str | None:
+    """Format a single A2A ``Part`` into a human-readable string.
+
+    Handles all four Part oneof types defined in A2A spec Section 4.1.6:
+    ``text``, ``data``, ``url``, and ``raw``.
+    """
+    # Check which oneof field is set.
+    # Prefer the protobuf-generated WhichOneof method when available and
+    # returning a real string (not a MagicMock fallback).
+    kind: str | None = None
+    if hasattr(r_part, "WhichOneof") and callable(r_part.WhichOneof):
+        try:
+            raw_kind = r_part.WhichOneof("content")
+            if isinstance(raw_kind, str) and raw_kind:
+                kind = raw_kind
+        except Exception:
+            pass
+
+    # Fallback: inspect content attributes directly
+    if not kind:
+        filename = getattr(r_part, "filename", "") or ""
+        media_type = getattr(r_part, "media_type", "") or ""
+        for candidate in ("text", "data", "url", "raw"):
+            val = getattr(r_part, candidate, None)
+            if val is not None and val != "" and val != b"":
+                kind = candidate
+                break
+
+    filename = getattr(r_part, "filename", "") or ""
+    media_type = getattr(r_part, "media_type", "") or ""
+
+    if kind == "text" or (kind is None and hasattr(r_part, "text") and r_part.text):
+        text_val = r_part.text
+        if text_val and isinstance(text_val, str):
+            return text_val
+
+    elif kind == "data" or (kind is None and hasattr(r_part, "data") and r_part.data is not None):
+        data_val = r_part.data
+        try:
+            # protobuf Struct / Value — use MessageToDict
+            from google.protobuf.json_format import MessageToDict
+            data_dict = MessageToDict(data_val)
+            data_str = json.dumps(data_dict, ensure_ascii=False, indent=2)
+        except Exception:
+            # Fallback: plain dict or other JSON-serializable
+            if isinstance(data_val, (dict, list)):
+                data_str = json.dumps(data_val, ensure_ascii=False, indent=2)
+            else:
+                data_str = str(data_val)
+        label = f"[data: {media_type}]" if media_type else "[data]"
+        return f"{label}\n{data_str}"
+
+    elif kind == "url" or (kind is None and hasattr(r_part, "url") and r_part.url):
+        url_val = r_part.url
+        if url_val and isinstance(url_val, str):
+            label = f"[file: {filename}]" if filename else "[url]"
+            return f"{label} {url_val}"
+
+    elif kind == "raw" or (kind is None and hasattr(r_part, "raw") and r_part.raw):
+        raw_bytes = r_part.raw
+        size = len(raw_bytes) if isinstance(raw_bytes, (bytes, bytearray)) else 0
+        label = f"[binary: {filename}]" if filename else "[binary]"
+        detail = f" ({media_type}, {size} bytes)" if media_type else f" ({size} bytes)"
+        return f"{label}{detail}"
+
+    return None

--- a/backend/tests/test_a2a_part_types.py
+++ b/backend/tests/test_a2a_part_types.py
@@ -1,0 +1,320 @@
+# =============================================================================
+# PH Agent Hub — A2A Part Type Tests (Issue #408)
+# =============================================================================
+# Tests the full Part type support (text, data, url, raw) in the A2A tool
+# wrapper and the A2A server-side Part parsing.
+# =============================================================================
+
+import json
+import pytest
+from unittest.mock import patch, AsyncMock, MagicMock
+
+from src.tools.a2a import _format_response_part
+
+
+# ---------------------------------------------------------------------------
+#  _format_response_part  unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatResponsePart:
+    """Unit tests for _format_response_part — all four A2A Part types."""
+
+    @staticmethod
+    def _make_part(which_oneof: str | None = None, **kwargs):
+        """Create a mock Part with only the specified oneof field set.
+
+        All other content fields are explicitly set to None so the
+        fallback attribute inspection doesn't pick up spurious Mock
+        values.
+        """
+        part = MagicMock()
+        # Default all content fields to None
+        part.text = None
+        part.data = None
+        part.url = None
+        part.raw = None
+
+        # Set the requested content field
+        for key, val in kwargs.items():
+            setattr(part, key, val)
+
+        # Configure WhichOneof if the mock needs it
+        if which_oneof:
+            part.WhichOneof = MagicMock(return_value=which_oneof)
+        else:
+            # No WhichOneof — forces the attribute fallback path
+            del part.WhichOneof
+
+        return part
+
+    def test_text_part(self):
+        """Should return the text content directly."""
+        part = self._make_part("text", text="Hello, world!")
+
+        result = _format_response_part(part)
+        assert result == "Hello, world!"
+
+    def test_text_part_no_whichoneof(self):
+        """Should detect text via attribute fallback."""
+        part = self._make_part(None, text="Plain text")
+
+        result = _format_response_part(part)
+        assert result == "Plain text"
+
+    def test_data_part_json(self):
+        """Should format structured data as JSON with [data] label."""
+        part = self._make_part(
+            "data",
+            data={"key": "value", "nested": {"a": 1}},
+            media_type="application/json",
+        )
+
+        result = _format_response_part(part)
+        assert result is not None
+        assert "[data: application/json]" in result
+        assert '"key"' in result
+        assert '"value"' in result
+
+    def test_url_part_with_filename(self):
+        """Should format URL part with filename label."""
+        part = self._make_part(
+            "url",
+            url="https://storage.example.com/file.pdf",
+            filename="report.pdf",
+        )
+
+        result = _format_response_part(part)
+        assert result == "[file: report.pdf] https://storage.example.com/file.pdf"
+
+    def test_url_part_without_filename(self):
+        """Should format URL part with generic [url] label."""
+        part = self._make_part(
+            "url",
+            url="https://example.com/data",
+            filename="",
+        )
+
+        result = _format_response_part(part)
+        assert result == "[url] https://example.com/data"
+
+    def test_raw_part_with_metadata(self):
+        """Should format raw/binary part with size and media type."""
+        part = self._make_part(
+            "raw",
+            raw=b"binary content here",  # 19 bytes
+            filename="image.png",
+            media_type="image/png",
+        )
+
+        result = _format_response_part(part)
+        assert result == "[binary: image.png] (image/png, 19 bytes)"
+
+    def test_raw_part_minimal(self):
+        """Should format raw part without filename."""
+        part = self._make_part(
+            "raw",
+            raw=b"x" * 100,
+            filename="",
+            media_type="",
+        )
+
+        result = _format_response_part(part)
+        assert result == "[binary] (100 bytes)"
+
+    def test_empty_part_returns_none(self):
+        """Should return None for a Part with no content set."""
+        part = self._make_part(None)
+
+        result = _format_response_part(part)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+#  A2A Server _extract_text_from_parts  tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTextFromParts:
+    """Tests for the server-side Part parser."""
+
+    def test_text_part(self):
+        """Should extract text from text parts."""
+        from src.api.a2a_server import _extract_text_from_parts
+
+        parts = [{"text": "Hello"}, {"text": " world"}]
+        result = _extract_text_from_parts(parts)
+        assert result == "Hello\n world"
+
+    def test_data_part_dict(self):
+        """Should serialize data dict to JSON string."""
+        from src.api.a2a_server import _extract_text_from_parts
+
+        parts = [{"data": {"key": "value"}}]
+        result = _extract_text_from_parts(parts)
+        assert '"key"' in result
+        assert '"value"' in result
+
+    def test_data_part_string(self):
+        """Should pass through data string directly."""
+        from src.api.a2a_server import _extract_text_from_parts
+
+        parts = [{"data": '{"a":1}'}]
+        result = _extract_text_from_parts(parts)
+        assert result == '{"a":1}'
+
+    def test_url_part_with_filename(self):
+        """Should label URL parts with filename."""
+        from src.api.a2a_server import _extract_text_from_parts
+
+        parts = [{"url": "https://example.com/file.pdf", "filename": "report.pdf"}]
+        result = _extract_text_from_parts(parts)
+        assert result == "[file: report.pdf] https://example.com/file.pdf"
+
+    def test_url_part_without_filename(self):
+        """Should label URL parts without filename."""
+        from src.api.a2a_server import _extract_text_from_parts
+
+        parts = [{"url": "https://example.com/data"}]
+        result = _extract_text_from_parts(parts)
+        assert result == "[url] https://example.com/data"
+
+    def test_raw_part(self):
+        """Should format raw parts with base64 size info."""
+        from src.api.a2a_server import _extract_text_from_parts
+
+        raw_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAUA"
+        parts = [{"raw": raw_b64, "filename": "img.png"}]
+        result = _extract_text_from_parts(parts)
+        assert "[binary: img.png]" in result
+        assert "base64" in result
+
+    def test_mixed_parts(self):
+        """Should combine text, data, and url parts."""
+        from src.api.a2a_server import _extract_text_from_parts
+
+        parts = [
+            {"text": "Here is the report:"},
+            {"data": {"total": 42}},
+            {"url": "https://example.com/chart.png", "filename": "chart.png"},
+        ]
+        result = _extract_text_from_parts(parts)
+        assert "Here is the report:" in result
+        assert '"total"' in result
+        assert "[file: chart.png]" in result
+
+    def test_empty_parts(self):
+        """Should return empty string for no parts."""
+        from src.api.a2a_server import _extract_text_from_parts
+
+        result = _extract_text_from_parts([])
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+#  Agent Card  a2a_metadata  integration test
+# ---------------------------------------------------------------------------
+
+
+class TestAgentCardA2aMetadata:
+    """Tests that the Agent Card reads a2a_metadata from skills."""
+
+    async def test_skill_with_a2a_metadata(self, monkeypatch):
+        """Agent Card should use a2a_metadata when present."""
+        from unittest.mock import MagicMock, AsyncMock
+        from src.api.a2a_server import get_agent_card
+
+        # Mock settings
+        monkeypatch.setattr(
+            "src.api.a2a_server.settings.A2A_PUBLIC_URL",
+            "https://api.example.com",
+        )
+        monkeypatch.setattr(
+            "src.api.a2a_server.settings.A2A_ORGANIZATION_NAME", "Test Hub"
+        )
+        monkeypatch.setattr(
+            "src.api.a2a_server.settings.A2A_ORGANIZATION_URL",
+            "https://example.com",
+        )
+        monkeypatch.setattr(
+            "src.api.a2a_server.settings.A2A_DOCS_URL", ""
+        )
+
+        # Build a mock request with a mock DB that returns a skill with a2a_metadata
+        request = MagicMock()
+        request.base_url = "https://api.example.com/"
+        request.state = MagicMock()
+
+        mock_skill = MagicMock()
+        mock_skill.id = "skill-uuid-1"
+        mock_skill.name = "JSON Analyzer"
+        mock_skill.description = "Analyzes JSON payloads"
+        mock_skill.a2a_metadata = {
+            "inputModes": ["application/json"],
+            "outputModes": ["application/json", "text/plain"],
+            "examples": ["Analyze this: {\"foo\":\"bar\"}"],
+            "tags": ["json", "analysis"],
+        }
+
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [mock_skill]
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=mock_result)
+        request.state.db = mock_db
+
+        data = await get_agent_card(request)
+
+        assert len(data["skills"]) == 1
+        skill = data["skills"][0]
+        assert skill["id"] == "skill-uuid-1"
+        assert skill["name"] == "JSON Analyzer"
+        assert skill["inputModes"] == ["application/json"]
+        assert skill["outputModes"] == ["application/json", "text/plain"]
+        assert skill["examples"] == ["Analyze this: {\"foo\":\"bar\"}"]
+        assert skill["tags"] == ["json", "analysis"]
+
+    async def test_skill_without_a2a_metadata_falls_back(self, monkeypatch):
+        """Agent Card should fall back to text/plain when a2a_metadata is None."""
+        from unittest.mock import MagicMock, AsyncMock
+        from src.api.a2a_server import get_agent_card
+
+        monkeypatch.setattr(
+            "src.api.a2a_server.settings.A2A_PUBLIC_URL",
+            "https://api.example.com",
+        )
+        monkeypatch.setattr(
+            "src.api.a2a_server.settings.A2A_ORGANIZATION_NAME", "Test Hub"
+        )
+        monkeypatch.setattr(
+            "src.api.a2a_server.settings.A2A_ORGANIZATION_URL",
+            "https://example.com",
+        )
+        monkeypatch.setattr(
+            "src.api.a2a_server.settings.A2A_DOCS_URL", ""
+        )
+
+        request = MagicMock()
+        request.base_url = "https://api.example.com/"
+        request.state = MagicMock()
+
+        mock_skill = MagicMock()
+        mock_skill.id = "skill-uuid-2"
+        mock_skill.name = "Basic Agent"
+        mock_skill.description = "A basic agent"
+        mock_skill.a2a_metadata = None  # No metadata
+
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [mock_skill]
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=mock_result)
+        request.state.db = mock_db
+
+        data = await get_agent_card(request)
+
+        skill = data["skills"][0]
+        assert skill["inputModes"] == ["text/plain"]
+        assert skill["outputModes"] == ["text/plain"]
+        assert skill["examples"] == []
+        assert skill["tags"] == []

--- a/backend/tests/test_a2a_service.py
+++ b/backend/tests/test_a2a_service.py
@@ -63,6 +63,10 @@ def _create_mock_agent_card(agent_name: str = "Test Agent", skill_list: list[dic
             self.id = data["id"]
             self.name = data.get("name", "")
             self.description = data.get("description", "")
+            self.input_modes = data.get("inputModes") or data.get("input_modes", [])
+            self.output_modes = data.get("outputModes") or data.get("output_modes", [])
+            self.examples = data.get("examples", [])
+            self.tags = data.get("tags", [])
 
     class MockAgentCard:
         def __init__(self):
@@ -468,8 +472,12 @@ class TestTestA2aConnection:
         mock_card = _create_mock_agent_card(
             agent_name="Remote Agent",
             skill_list=[
-                {"id": "s1", "name": "Skill One", "description": "First skill"},
-                {"id": "s2", "name": "Skill Two", "description": "Second skill"},
+                {"id": "s1", "name": "Skill One", "description": "First skill",
+                 "inputModes": ["text/plain"], "outputModes": ["text/plain"],
+                 "examples": ["ex1"], "tags": ["tag1"]},
+                {"id": "s2", "name": "Skill Two", "description": "Second skill",
+                 "inputModes": ["application/json"], "outputModes": ["application/json"],
+                 "examples": [], "tags": []},
             ],
         )
 
@@ -481,6 +489,11 @@ class TestTestA2aConnection:
         assert result["agent_description"] == "A test A2A agent"
         assert len(result["skills"]) == 2
         assert result["skills"][0]["id"] == "s1"
+        assert result["skills"][0]["inputModes"] == ["text/plain"]
+        assert result["skills"][0]["outputModes"] == ["text/plain"]
+        assert result["skills"][0]["examples"] == ["ex1"]
+        assert result["skills"][0]["tags"] == ["tag1"]
+        assert result["skills"][1]["inputModes"] == ["application/json"]
 
     async def test_failed_connection(self, db_session: AsyncSession, test_tenant):
         """Should return error info on failed connection."""
@@ -522,8 +535,12 @@ class TestSyncA2aTools:
         mock_card = _create_mock_agent_card(
             agent_name="Skillful",
             skill_list=[
-                {"id": "s1", "name": "Alpha", "description": "Alpha skill"},
-                {"id": "s2", "name": "Beta", "description": "Beta skill"},
+                {"id": "s1", "name": "Alpha", "description": "Alpha skill",
+                 "inputModes": ["text/plain"], "outputModes": ["text/plain"],
+                 "examples": ["try this"], "tags": ["alpha"]},
+                {"id": "s2", "name": "Beta", "description": "Beta skill",
+                 "inputModes": ["application/json"], "outputModes": ["application/json"],
+                 "examples": [], "tags": ["beta", "json"]},
             ],
         )
 
@@ -544,6 +561,25 @@ class TestSyncA2aTools:
         tools = db_result.scalars().all()
         assert len(tools) == 2
         assert all(t.config["a2a_server_id"] == server.id for t in tools)
+
+        # Verify enriched config fields (Issue #408)
+        s1_tool = next(t for t in tools if t.config["skill_id"] == "s1")
+        assert s1_tool.config["input_modes"] == ["text/plain"]
+        assert s1_tool.config["output_modes"] == ["text/plain"]
+        assert s1_tool.config["examples"] == ["try this"]
+        assert s1_tool.config["tags"] == ["alpha"]
+
+        s2_tool = next(t for t in tools if t.config["skill_id"] == "s2")
+        assert s2_tool.config["input_modes"] == ["application/json"]
+        assert s2_tool.config["output_modes"] == ["application/json"]
+        assert s2_tool.config["examples"] == []
+        assert s2_tool.config["tags"] == ["beta", "json"]
+
+        # Verify Agent Card cache was populated (Issue #408)
+        await db_session.refresh(server)
+        assert server.agent_card_cache is not None
+        assert server.agent_card_cache["name"] == "Skillful"
+        assert server.agent_card_cached_at is not None
 
     async def test_updates_existing_tools(self, db_session: AsyncSession, test_tenant):
         """Should update existing Tool records for known skills."""


### PR DESCRIPTION
This update introduces a nullable JSON column `a2a_metadata` to the `skills` table, allowing for the storage of A2A Agent Card metadata such as input/output modes, examples, and tags. This enhancement enables more accurate I/O mode declarations and improves the tool descriptions provided to agents. The implementation includes updates to the skill creation and response models, as well as the handling of various A2A Part types in message processing.
Closes #408

