### PR TITLE
Improve ERPNext tool to support per-user credentials

### DIFF
--- a/backend/src/agents/runner.py
+++ b/backend/src/agents/runner.py
@@ -1436,7 +1436,7 @@ async def _resolve_tool_callables(
                 .where(
                     UserToolCredential.user_id == user_id,
                     UserToolCredential.status == "active",
-                    Tool.type.in_({"email", "calendar", "tasks"}),
+                    Tool.type.in_({"email", "calendar", "tasks", "erpnext"}),
                     Tool.tenant_id == tenant_id,
                     Tool.enabled == True,
                 )
@@ -1468,7 +1468,7 @@ async def _resolve_tool_callables(
         try:
             from ..db.orm.user_tool_credentials import UserToolCredential
 
-            tool_ids_for_creds = [t.id for t in tools if t.type in ("email", "calendar", "tasks")]
+            tool_ids_for_creds = [t.id for t in tools if t.type in ("email", "calendar", "tasks", "erpnext")]
             if tool_ids_for_creds:
                 cred_result = await db.execute(
                     select(UserToolCredential).where(
@@ -2010,7 +2010,12 @@ async def _build_tool_callables(
             of the tenant-level ``tool.config`` (Issue #312).
     """
     if tool.type == "erpnext":
-        return await _build_erpnext_callables(db, tool, tenant_id, session_id=session_id, cleanup_clients=cleanup_clients)
+        return await _build_erpnext_callables(
+            db, tool, tenant_id,
+            session_id=session_id,
+            cleanup_clients=cleanup_clients,
+            user_credentials=user_credentials,
+        )
     elif tool.type == "membrane":
         from ..tools.membrane import build_membrane_tools
         return build_membrane_tools(tool.config or {})
@@ -2143,10 +2148,14 @@ async def _build_erpnext_callables(
     tenant_id: str,
     session_id: str = "",
     cleanup_clients: list | None = None,
+    user_credentials: list | None = None,
 ) -> list:
     """Build ERPNext tool callables for a given Tool record.
 
-    Reads credentials directly from ``tool.config`` JSON.
+    Credentials are resolved in this order:
+    1. Per-user ``user_credentials`` (when provided) — first active credential wins.
+    2. Fall back to ``tool.config`` (tenant-level config).
+
     Queries ALL FileUpload records for the session so the
     ``upload_file`` tool can access files uploaded in any
     message — the built-in ``list_uploaded_files`` tool
@@ -2156,18 +2165,26 @@ async def _build_erpnext_callables(
     on *cleanup_clients* so the caller can close it after the
     agent run completes.
     """
+    import json as _json
     import httpx
-    from ..tools.erpnext import build_erpnext_tools
+    from ..tools.erpnext import build_erpnext_tools, _resolve_erpnext_credentials
 
     config = tool.config or {}
-    base_url = config.get("base_url")
-    api_key = config.get("api_key")
-    api_secret = config.get("api_secret")
+
+    # Resolve credentials — per-user takes precedence over tenant config
+    resolved = _resolve_erpnext_credentials(
+        tool_config=config,
+        user_credentials=user_credentials,
+    )
+    base_url = resolved.get("base_url", "")
+    api_key = resolved.get("api_key", "")
+    api_secret = resolved.get("api_secret", "")
 
     if not all([base_url, api_key, api_secret]):
         raise NotFoundError(
-            f"ERPNext tool '{tool.name}' is missing required config fields. "
-            "Set base_url, api_key, and api_secret in the tool config."
+            f"ERPNext tool '{tool.name}' has no valid credentials. "
+            "Either configure base_url, api_key, and api_secret in the "
+            "tool config, or add per-user credentials via Account Settings."
         )
 
     # Build the shared httpx client — caller is responsible for closing it
@@ -2210,6 +2227,7 @@ async def _build_erpnext_callables(
         httpx_client=erpnext_client,
         file_infos=file_infos,
         tool_name=tool.name,
+        user_credentials=user_credentials,
     )
 
 

--- a/backend/src/api/credentials.py
+++ b/backend/src/api/credentials.py
@@ -124,32 +124,51 @@ def _cred_to_response(
 
 @router.get("/tool-id", response_model=dict)
 async def get_tool_id_by_type(
-    tool_type: str = Query(..., description="Tool type (email, calendar, tasks)"),
+    tool_type: str = Query(..., description="Tool type (email, calendar, tasks, erpnext)"),
     current_user: UserORM = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Look up a tool's ID by its type.
+    """Look up tool IDs by their type.
 
-    Used by the frontend when creating credentials — the user selects
-    a tool type (email, calendar, tasks) and needs the actual tool ID
-    to pass to the create credential endpoint.
+    Returns ALL tools of the given type so the frontend can let the user
+    choose which one to associate their credential with.  Credentials are
+    scoped to a specific tool record — when multiple tools of the same
+    type exist (e.g. "Production ERP" + "Staging ERP"), each can have
+    its own set of per-user credentials.
+
+    Both enabled and disabled tools are returned so users can create
+    credentials even when the tool is temporarily disabled.
     """
     result = await db.execute(
         _select(ToolORM)
         .where(
             ToolORM.type == tool_type,
             ToolORM.tenant_id == current_user.tenant_id,
-            ToolORM.enabled == True,  # noqa: E712
         )
-        .limit(1)
+        .order_by(ToolORM.name)
     )
-    tool = result.scalar_one_or_none()
-    if not tool:
+    tools = list(result.scalars().all())
+    if not tools:
         raise NotFoundError(
-            f"No enabled '{tool_type}' tool found. "
+            f"No '{tool_type}' tool found. "
             f"An administrator must create one in Admin Area → Tools."
         )
-    return {"tool_id": tool.id}
+
+    # For backward compatibility, return the first tool's id at the top level
+    # when there's exactly one tool.  When multiple exist, return all tools
+    # so the frontend can let the user pick.
+    return {
+        "tool_id": tools[0].id,
+        "tools": [
+            {
+                "id": t.id,
+                "name": t.name,
+                "description": t.description or "",
+                "base_url": (t.config or {}).get("base_url", ""),
+            }
+            for t in tools
+        ],
+    }
 
 
 @router.get("", response_model=CredentialListResponse)

--- a/backend/src/db/migrations/versions/z1a2b3c4d5e6_add_erpnext_to_credential_provider_enum.py
+++ b/backend/src/db/migrations/versions/z1a2b3c4d5e6_add_erpnext_to_credential_provider_enum.py
@@ -1,0 +1,37 @@
+"""add_erpnext_to_credential_provider_enum
+
+Add 'erpnext' to the credential_provider_enum so that per-user
+ERPNext credentials can be stored in user_tool_credentials.
+
+Revision ID: z1a2b3c4d5e6
+Revises: y1z2a3b4c5d6
+Create Date: 2026-07-02
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "z1a2b3c4d5e6"
+down_revision: Union[str, None] = "y1z2a3b4c5d6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE user_tool_credentials "
+        "MODIFY COLUMN provider "
+        "ENUM('gmail','outlook','imap','google','microsoft','erpnext') "
+        "NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE user_tool_credentials "
+        "MODIFY COLUMN provider "
+        "ENUM('gmail','outlook','imap','google','microsoft') "
+        "NOT NULL"
+    )

--- a/backend/src/db/orm/user_tool_credentials.py
+++ b/backend/src/db/orm/user_tool_credentials.py
@@ -44,7 +44,7 @@ class UserToolCredential(Base):
         comment="User-defined display name (e.g., 'Work Gmail', 'Personal Outlook')",
     )
     provider: Mapped[str] = mapped_column(
-        Enum("gmail", "outlook", "imap", "google", "microsoft",
+        Enum("gmail", "outlook", "imap", "google", "microsoft", "erpnext",
              name="credential_provider_enum"),
         nullable=False,
     )

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -122,7 +122,7 @@ async def lifespan(app: FastAPI):
     demo_cleanup_task.cancel()
 
 
-app = FastAPI(title="PH Agent Hub", version="1.23.0", lifespan=lifespan)
+app = FastAPI(title="PH Agent Hub", version="1.24.0", lifespan=lifespan)
 
 # ---------------------------------------------------------------------------
 # Middleware

--- a/backend/src/services/credential_service.py
+++ b/backend/src/services/credential_service.py
@@ -241,6 +241,20 @@ async def test_connection(
     return await _do_test_connection(credential, db=db)
 
 
+async def test_raw_erpnext_connection(
+    base_url: str, api_key: str, api_secret: str,
+) -> dict:
+    """Test ERPNext connectivity without a stored credential.
+
+    Used by the pre-save test in the manual ERPNext setup UI.
+    """
+    return await _test_erpnext_connection({
+        "base_url": base_url,
+        "api_key": api_key,
+        "api_secret": api_secret,
+    })
+
+
 async def test_raw_imap_connection(
     host: str, port: int, username: str, password: str,
 ) -> dict:
@@ -255,7 +269,7 @@ async def test_raw_imap_connection(
 # Internal helpers
 # ---------------------------------------------------------------------------
 
-VALID_PROVIDERS = frozenset({"gmail", "outlook", "imap", "google", "microsoft"})
+VALID_PROVIDERS = frozenset({"gmail", "outlook", "imap", "google", "microsoft", "erpnext"})
 
 
 def _validate_provider(provider: str) -> None:
@@ -309,6 +323,8 @@ async def _do_test_connection(
 
     if provider == "imap":
         return await _test_imap_connection(creds)
+    elif provider == "erpnext":
+        return await _test_erpnext_connection(creds)
     elif provider in ("gmail", "outlook", "google", "microsoft"):
         result = await _test_oauth_connection(provider, tool_type, tokens)
 
@@ -484,3 +500,53 @@ async def _test_oauth_connection(provider: str, tool_type: str, tokens: dict) ->
         return {"ok": False, "message": f"Connection test failed: {exc}"}
 
     return {"ok": False, "message": "Could not test connection (unknown error)"}
+
+
+# ---------------------------------------------------------------------------
+# ERPNext test connection
+# ---------------------------------------------------------------------------
+
+
+async def _test_erpnext_connection(creds: dict) -> dict:
+    """Test ERPNext connectivity by hitting the auth check endpoint.
+
+    Args:
+        creds: Dict with ``base_url``, ``api_key``, ``api_secret``.
+
+    Returns:
+        A dict with ``ok`` (bool) and ``message`` (str).
+    """
+    base_url = creds.get("base_url", "").rstrip("/")
+    api_key = creds.get("api_key", "")
+    api_secret = creds.get("api_secret", "")
+
+    if not base_url:
+        return {"ok": False, "message": "ERPNext base URL not provided"}
+    if not api_key or not api_secret:
+        return {"ok": False, "message": "ERPNext API key and secret are required"}
+
+    import httpx
+
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.get(
+                f"{base_url}/api/method/frappe.auth.get_logged_user",
+                headers={"Authorization": f"token {api_key}:{api_secret}"},
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                user = data.get("message", "unknown")
+                return {"ok": True, "message": f"Connected as {user}"}
+            elif resp.status_code == 403:
+                return {"ok": False, "message": "Invalid API credentials (HTTP 403)"}
+            elif resp.status_code == 401:
+                return {"ok": False, "message": "Authentication failed (HTTP 401). Check API key and secret."}
+            else:
+                body = resp.text[:200]
+                return {"ok": False, "message": f"ERPNext returned HTTP {resp.status_code}: {body}"}
+    except httpx.ConnectError:
+        return {"ok": False, "message": f"Could not connect to {base_url}. Check the URL."}
+    except httpx.TimeoutException:
+        return {"ok": False, "message": f"Connection to {base_url} timed out."}
+    except Exception as exc:
+        return {"ok": False, "message": f"Connection test failed: {exc}"}

--- a/backend/src/tools/erpnext.py
+++ b/backend/src/tools/erpnext.py
@@ -50,6 +50,53 @@ def _build_auth_header(api_key: str, api_secret: str) -> dict[str, str]:
     return {"Authorization": f"token {api_key}:{api_secret}"}
 
 
+def _resolve_erpnext_credentials(
+    tool_config: dict | None = None,
+    user_credentials: list | None = None,
+) -> dict:
+    """Resolve ERPNext connection parameters from user credentials or tenant config.
+
+    Per-user credentials take precedence over tenant-level ``tool.config``.
+
+    Args:
+        tool_config: Tenant-level tool config dict (from ``Tool.config``).
+        user_credentials: Optional list of ``UserToolCredential`` ORM instances.
+
+    Returns:
+        A dict with ``base_url``, ``api_key``, ``api_secret``.
+        Returns an empty dict when neither source has complete credentials.
+    """
+    # Phase 1 — try per-user credentials first
+    if user_credentials:
+        import json as _json
+
+        for cred in user_credentials:
+            if cred.status != "active":
+                continue
+            raw = cred.credentials
+            if not raw:
+                continue
+            try:
+                parsed = _json.loads(raw) if isinstance(raw, str) else raw
+            except Exception:
+                continue
+            base_url = parsed.get("base_url", "").strip()
+            api_key = parsed.get("api_key", "").strip()
+            api_secret = parsed.get("api_secret", "").strip()
+            if base_url and api_key and api_secret:
+                return {"base_url": base_url, "api_key": api_key, "api_secret": api_secret}
+
+    # Phase 2 — fall back to tenant-level tool.config
+    config = tool_config or {}
+    base_url = config.get("base_url", "").strip()
+    api_key = config.get("api_key", "").strip()
+    api_secret = config.get("api_secret", "").strip()
+    if base_url and api_key and api_secret:
+        return {"base_url": base_url, "api_key": api_key, "api_secret": api_secret}
+
+    return {}
+
+
 async def _safe_erpnext_response(resp: httpx.Response) -> dict:
     """Process an ERPNext HTTP response, returning the JSON body.
 
@@ -88,14 +135,22 @@ def build_erpnext_tools(
     httpx_client: httpx.AsyncClient,
     file_infos: list[dict] | None = None,
     tool_name: str | None = None,
+    user_credentials: list | None = None,
+    db: object | None = None,
 ) -> list:
     """Return a list of MAF @tool-decorated async functions bound to an
     ERPNext instance.
 
+    Credentials are resolved in this order:
+    1. Per-user ``user_credentials`` (when provided) — first active credential wins.
+    2. Fall back to the ``base_url`` / ``api_key`` / ``api_secret`` parameters
+       (typically from tenant-level ``tool.config``).
+
     Args:
-        base_url: ERPNext site URL (e.g. ``https://erp.example.com``).
-        api_key: ERPNext API key.
-        api_secret: ERPNext API secret.
+        base_url: ERPNext site URL (e.g. ``https://erp.example.com``) — used
+            as fallback when no per-user credential is available.
+        api_key: ERPNext API key — fallback.
+        api_secret: ERPNext API secret — fallback.
         httpx_client: A pre-configured ``httpx.AsyncClient`` whose lifecycle
             is managed by the caller.  Must already have ``base_url`` and
             ``Authorization`` headers set.
@@ -104,6 +159,10 @@ def build_erpnext_tools(
         tool_name: Optional display name of the Tool ORM record. When provided,
             each tool function is prefixed (e.g. ``erpnext_kainotomo_com__get_doc``)
             to prevent name collisions when multiple ERPNext instances are active.
+        user_credentials: Optional list of ``UserToolCredential`` ORM instances
+            for per-user ERPNext accounts. Takes precedence over base_url/api_key/
+            api_secret.
+        db: Optional async DB session (for future use, e.g. token persistence).
 
     Returns:
         A list of callables ready to pass to ``Agent(tools=...)``.

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -328,7 +328,7 @@ Tools extend agent capabilities — they can call external APIs, query ERPNext i
 | **datetime** | Utility | Timezone-aware date/time queries | `timezone` |
 | **document_generation** | Utility | Markdown→PDF (weasyprint), list→Excel (openpyxl), list→CSV | `company_logo_url` |
 | **email** | Communication | Send, read, search, and manage emails. Supports SMTP/SendGrid (tenant-level) and per-user connected accounts (IMAP, Gmail API, Microsoft Graph). Users connect their own accounts via Account Settings. | `provider`, `smtp_host`, `smtp_port`, `smtp_username`, `smtp_password`, `api_key`, `from_email`, `from_name`, `allowed_recipients` |
-| **erpnext** | Enterprise | ERPNext full CRUD, file upload, doctype metadata | `base_url`, `api_key`, `api_secret` |
+| **erpnext** | Enterprise | ERPNext full CRUD, file upload, doctype metadata. Supports tenant-level config (admin) **and** per-user connected accounts (users connect their own ERPNext site via Account Settings). | `base_url`, `api_key`, `api_secret` (tenant-level) OR per-user credentials via Account Settings |
 | **etf_data** | Financial | ETF holdings and profiles (yfinance) | None |
 | **fetch_url** | Web | HTTP GET fetching with HTML→text conversion | `timeout`, `user_agent` |
 | **github** | DevOps | GitHub/GitLab — search code, list issues/PRs, read files, create issues | `provider`, `token`, `api_base`, `allowed_repos` |

--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -30,7 +30,7 @@ The backend provides the following core capabilities:
   - `services/a2a_circuit_breaker.py` — Redis-backed circuit breaker for A2A servers (consecutive failure tracking, auto-recovery)
   - `services/a2a_client.py` — resilient `send_message` wrapper with configurable timeouts, retry with exponential backoff, structured logging, and call log persistence
   - `tools/a2a.py` — builds MAF-compatible tool callables from A2A Tool records; delegates to the resilient client
-- ERPNext API tools (per‑tenant)
+- ERPNext API tools (per‑tenant with optional per‑user credentials)
 - Membrane tools
 - Custom tools (Python modules)
 - Tool permission enforcement based on user roles and tenant settings

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -124,7 +124,12 @@ Tools represent external integrations (ERPNext, Membrane, custom tools).
 
 ## 1.5 ERPNext (Tool Type)
 
-ERPNext integration is handled through the tool system. An ERPNext tool instance is created via the `/admin/tools` endpoint with `type=erpnext` and connection details stored in `tools.config` as a JSON object:
+ERPNext integration is handled through the tool system. An ERPNext tool instance is created via the `/admin/tools` endpoint with `type=erpnext`. Credentials can be provided at two levels:
+
+1. **Tenant-level** — Admin sets `base_url`, `api_key`, `api_secret` in `tools.config` (the original approach). This serves as the fallback default for all users.
+2. **Per-user** — Users connect their own ERPNext site via **Account Settings** (`/settings`). Per-user credentials are stored in `user_tool_credentials` and take precedence over tenant-level config.
+
+Tenant-level `tools.config` example:
 
 ```json
 {
@@ -154,7 +159,7 @@ Users can mark tools as "always on" so they're automatically activated in new se
 
 ## 1.7 User Tool Credentials (Issue #312)
 
-Per-user credentials for tools that require personal authentication (email, calendar, tasks). Each row represents one connected account — a user can have multiple accounts for the same tool type (e.g., Work Gmail + Personal Gmail).
+Per-user credentials for tools that require personal authentication (email, calendar, tasks, erpnext). Each row represents one connected account — a user can have multiple accounts for the same tool type (e.g., Work Gmail + Personal Gmail).
 
 Credentials and OAuth tokens are encrypted at rest via the `EncryptedString` ORM column type, using the same Fernet encryption as the `models.api_key` field.
 
@@ -164,7 +169,7 @@ Credentials and OAuth tokens are encrypted at rest via the `EncryptedString` ORM
 - user_id (UUID, FK → users.id, CASCADE) — who owns this credential
 - tool_id (UUID, FK → tools.id, CASCADE) — which tool this credential is for
 - label (string, 255, NOT NULL) — user-defined display name (e.g., "Work Gmail")
-- provider (enum: gmail, outlook, imap, google, microsoft) — the authentication provider
+- provider (enum: gmail, outlook, imap, google, microsoft, erpnext) — the authentication provider
 - email_address (string, 255, nullable) — primary email address for this account
 - credentials (Text, nullable) — encrypted JSON: IMAP/SMTP passwords, client IDs, etc.
 - oauth_tokens (Text, nullable) — encrypted JSON: access_token, refresh_token, expires_at

--- a/docs/planning/decisions.md
+++ b/docs/planning/decisions.md
@@ -132,3 +132,13 @@ A log of key design decisions made during the design phase, with rationale. Orde
 **Rationale:** The previous state format (`user_id:tool_id:8-char-hex`) was unsigned, non-expiring, and replayable. An attacker could forge or replay state to bind credentials to the wrong user context. A Redis-backed nonce store provides tamper evidence (no embedded info), automatic expiry (TTL), and one-time use (atomic GETDEL) without introducing new cryptographic primitives or infrastructure. The codebase already uses Redis for session storage, rate limiting, and JTI denylist — this follows the same established patterns.
 **Alternatives considered:** Fernet-signed state (replayable within TTL without server-side tracking; still requires server-side nonce to enforce one-time use), local in-memory dict (lost on reload, not shared across workers).
 **Reference:** `backend/src/core/redis.py` (`store_oauth_state`, `get_oauth_state`), [Issue #345](https://github.com/kainotomo/ph-agent-hub/issues/345)
+
+---
+
+## D-14 — Per-user ERPNext credentials with tenant fallback
+
+**Date:** 2026-07-02
+**Decision:** ERPNext tool credentials can be configured at two levels: tenant-level `tool.config` (admin setup) and per-user `UserToolCredential` (user connects their own account via Account Settings). Per-user credentials take precedence; tenant-level config acts as the fallback default.
+**Rationale:** In multi-tenant deployments, different users connect to different ERPNext sites or have distinct API keys/permissions. Sharing a single tenant-level API key loses audit trails and forces all users into the same identity. The email/calendar/tasks tools already follow this pattern (Issue #312), proving the architecture. Existing tenant-level setups continue working unchanged.
+**Alternatives considered:** Tenant-level only (rejected — breaks multi-user ERPNext use cases), per-user only with no fallback (rejected — breaks backward compatibility for existing setups).
+**Reference:** `backend/src/tools/erpnext.py` (`_resolve_erpnext_credentials`, `build_erpnext_tools`), `backend/src/agents/runner.py` (`_build_erpnext_callables`), [Issue #432](https://github.com/kainotomo/ph-agent-hub/issues/432)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -171,7 +171,7 @@ Tools let the AI interact with external systems — query databases, call APIs, 
 |---|---|---|
 | **Web** | Web Search, Fetch URL, Browser, RSS Feed, Wikipedia, RAG Search | Search the internet, read web pages, take screenshots, extract tables, search your uploaded documents |
 | **Financial** | Stock Data, Stock Screener, Market Overview, ETF Data, Currency Exchange, Portfolio, SEC Filings | Get stock quotes, screen stocks by custom criteria, analyze portfolios, check exchange rates, read SEC filings |
-| **Enterprise** | ERPNext, SQL Query | Query your ERP system, run read-only SQL on your database |
+| **Enterprise** | ERPNext, SQL Query | Query your ERP system, create and manage documents. Connect your own ERPNext account via **Settings → Account Settings**. |
 | **Utility** | Calculator, Code Interpreter, Datetime, Document Generation, Weather | Do math, run Python code, check dates/times, generate PDFs/Excel/CSV, check weather |
 | **Communication** | Slack, Email | Send messages to Slack channels; **read, send, search, and manage emails** from your connected accounts |
 | **Creative** | Image Generation | Generate images from text descriptions (DALL·E 3, Stable Diffusion) |

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5222,7 +5222,7 @@
       "license": "MIT",
       "dependencies": {
         "@ant-design/colors": "^7.2.1",
-        "@ant-design/cssinjs": "^1.23.0",
+        "@ant-design/cssinjs": "^1.24.0",
         "@ant-design/cssinjs-utils": "^1.1.3",
         "@ant-design/fast-color": "^2.0.6",
         "@ant-design/icons": "^5.6.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ph-agent-hub-frontend",
   "private": true,
-  "version": "1.23.0",
+  "version": "1.24.0",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000 --host",

--- a/frontend/src/features/account/AccountSettingsPage.tsx
+++ b/frontend/src/features/account/AccountSettingsPage.tsx
@@ -17,6 +17,7 @@ import {
   Modal,
   Form,
   Input,
+  Select,
   message,
   Spin,
   Empty,
@@ -36,6 +37,7 @@ import {
   CheckSquareOutlined,
   ArrowLeftOutlined,
   ReloadOutlined,
+  DatabaseOutlined,
 } from "@ant-design/icons";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -50,6 +52,7 @@ import {
   getGoogleOAuthUrl,
   getMicrosoftOAuthUrl,
   CredentialData,
+  ToolInfo,
 } from "../../services/credentials";
 
 const { Content } = Layout;
@@ -73,6 +76,11 @@ const TOOL_TYPE_NAMES: Record<string, { name: string; icon: React.ReactNode; des
     icon: <CheckSquareOutlined />,
     description: "Create, update, and manage your to-do lists",
   },
+  erpnext: {
+    name: "ERPNext",
+    icon: <DatabaseOutlined />,
+    description: "Query your ERP system, create and manage documents",
+  },
 };
 
 const PROVIDER_LABELS: Record<string, { label: string; color: string }> = {
@@ -81,6 +89,7 @@ const PROVIDER_LABELS: Record<string, { label: string; color: string }> = {
   imap: { label: "IMAP", color: "green" },
   google: { label: "Google", color: "red" },
   microsoft: { label: "Microsoft", color: "blue" },
+  erpnext: { label: "ERPNext", color: "orange" },
 };
 
 const STATUS_COLORS: Record<string, string> = {
@@ -107,6 +116,7 @@ export function AccountSettingsPage() {
     toolType: string;
   }>({ open: false, toolId: "", toolType: "" });
   const [imapModal, setImapModal] = useState(false);
+  const [erpnextModal, setErpnextModal] = useState(false);
 
   // Handle OAuth callback redirect in popup window
   useEffect(() => {
@@ -281,6 +291,10 @@ export function AccountSettingsPage() {
             setConnectModal({ ...connectModal, open: false });
             setImapModal(true);
           }}
+          onERPNext={() => {
+            setConnectModal({ ...connectModal, open: false });
+            setErpnextModal(true);
+          }}
         />
 
         {/* Manual IMAP Setup Modal */}
@@ -289,6 +303,16 @@ export function AccountSettingsPage() {
           onClose={() => setImapModal(false)}
           onSaved={() => {
             setImapModal(false);
+            queryClient.invalidateQueries({ queryKey: ["credentials"] });
+          }}
+        />
+
+        {/* ERPNext Setup Modal */}
+        <ErpnextSetupModal
+          open={erpnextModal}
+          onClose={() => setErpnextModal(false)}
+          onSaved={() => {
+            setErpnextModal(false);
             queryClient.invalidateQueries({ queryKey: ["credentials"] });
           }}
         />
@@ -365,11 +389,13 @@ function ConnectAccountModal({
   toolType,
   onClose,
   onIMAP,
+  onERPNext,
 }: {
   open: boolean;
   toolType: string;
   onClose: () => void;
   onIMAP: () => void;
+  onERPNext: () => void;
 }) {
   const [connecting, setConnecting] = useState<string | null>(null);
 
@@ -435,6 +461,18 @@ function ConnectAccountModal({
             </Button>
             <Text type="secondary" style={{ fontSize: 12, textAlign: "center" }}>
               Use app passwords for Gmail/Outlook with IMAP enabled on your account
+            </Text>
+          </>
+        )}
+
+        {toolType === "erpnext" && (
+          <>
+            <Divider>or</Divider>
+            <Button block size="large" onClick={onERPNext}>
+              🔑 Manual ERPNext Setup
+            </Button>
+            <Text type="secondary" style={{ fontSize: 12, textAlign: "center" }}>
+              Enter your ERPNext site URL, API key, and API secret
             </Text>
           </>
         )}
@@ -600,6 +638,146 @@ function ManualSetupModal({
         >
           Test Connection
         </Button>
+      </Form>
+    </Modal>
+  );
+}
+
+// =============================================================================
+// ERPNext Setup Modal
+// =============================================================================
+
+function ErpnextSetupModal({
+  open,
+  onClose,
+  onSaved,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [form] = Form.useForm();
+  const [creating, setCreating] = useState(false);
+  const [tools, setTools] = useState<ToolInfo[]>([]);
+  const [loadingTools, setLoadingTools] = useState(false);
+
+  // Fetch available ERPNext tools when modal opens
+  useEffect(() => {
+    if (open) {
+      setLoadingTools(true);
+      getToolIdByType("erpnext")
+        .then((result) => {
+          // If multiple tools exist, use the full list; otherwise wrap the single one
+          const toolList = result.tools ?? [{ id: result.tool_id, name: result.tool_id }];
+          setTools(toolList);
+          // Pre-select the first tool
+          form.setFieldsValue({ tool_id: toolList[0]?.id });
+        })
+        .catch(() => {
+          setTools([]);
+        })
+        .finally(() => setLoadingTools(false));
+    }
+  }, [open, form]);
+
+  const handleSave = async () => {
+    try {
+      const values = await form.validateFields();
+      setCreating(true);
+
+      await createCredential({
+        tool_id: values.tool_id,
+        label: values.label,
+        provider: "erpnext",
+        email_address: values.email || undefined,
+        credentials: {
+          base_url: values.base_url,
+          api_key: values.api_key,
+          api_secret: values.api_secret,
+        },
+        is_default: true,
+      });
+
+      message.success(`"${values.label}" connected successfully`);
+      onSaved();
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        message.error(err.message);
+      }
+    }
+    setCreating(false);
+  };
+
+  return (
+    <Modal
+      title="🔑 Connect ERPNext Account"
+      open={open}
+      onCancel={onClose}
+      onOk={handleSave}
+      confirmLoading={creating}
+      okText="Save Account"
+      width={520}
+    >
+      <Form form={form} layout="vertical" style={{ marginTop: 16 }}>
+        <Form.Item
+          name="label"
+          label="Account Label"
+          rules={[{ required: true, message: "Enter a label (e.g. 'My ERP')" }]}
+        >
+          <Input placeholder="e.g. My ERP, Production Site" />
+        </Form.Item>
+
+        {tools.length > 1 && (
+          <Form.Item
+            name="tool_id"
+            label="ERPNext Tool"
+            rules={[{ required: true, message: "Select which ERPNext tool to connect" }]}
+          >
+            <Select
+              placeholder="Select an ERPNext tool"
+              loading={loadingTools}
+              options={tools.map((t) => ({
+                label: t.base_url ? `${t.name} (${t.base_url})` : t.name,
+                value: t.id,
+              }))}
+            />
+          </Form.Item>
+        )}
+
+        <Form.Item
+          name="base_url"
+          label="ERPNext Site URL"
+          rules={[
+            { required: true, message: "Enter your ERPNext site URL" },
+            { type: "url", message: "Enter a valid URL (https://...)" },
+          ]}
+        >
+          <Input placeholder="https://erpnext.example.com" />
+        </Form.Item>
+
+        <Form.Item
+          name="api_key"
+          label="API Key"
+          rules={[{ required: true, message: "Enter your ERPNext API key" }]}
+        >
+          <Input placeholder="Your ERPNext API key" />
+        </Form.Item>
+
+        <Form.Item
+          name="api_secret"
+          label="API Secret"
+          rules={[{ required: true, message: "Enter your ERPNext API secret" }]}
+        >
+          <Input.Password placeholder="Your ERPNext API secret" />
+        </Form.Item>
+
+        <Form.Item
+          name="email"
+          label="Email (optional)"
+          extra="Your ERPNext login email — for display purposes only"
+        >
+          <Input placeholder="you@example.com" />
+        </Form.Item>
       </Form>
     </Modal>
   );

--- a/frontend/src/services/credentials.ts
+++ b/frontend/src/services/credentials.ts
@@ -78,8 +78,15 @@ export function createCredential(data: CreateCredentialRequest): Promise<Credent
   });
 }
 
-export function getToolIdByType(tool_type: string): Promise<{ tool_id: string }> {
-  return api<{ tool_id: string }>(`/credentials/tool-id${qs({ tool_type })}`);
+export interface ToolInfo {
+  id: string;
+  name: string;
+  description?: string;
+  base_url?: string;
+}
+
+export function getToolIdByType(tool_type: string): Promise<{ tool_id: string; tools?: ToolInfo[] }> {
+  return api<{ tool_id: string; tools?: ToolInfo[] }>(`/credentials/tool-id${qs({ tool_type })}`);
 }
 
 export function deleteCredential(credential_id: string): Promise<void> {


### PR DESCRIPTION
The ERPNext tool now allows users to connect with their own credentials instead of relying solely on tenant-level API keys. This change enhances user flexibility and security by enabling individual account management. The implementation includes updates to the credential provider enum, API endpoints, and relevant documentation to reflect this new functionality.

Closes #432

