### PR TITLE
## Description

### DIFF
--- a/backend/src/agents/runner.py
+++ b/backend/src/agents/runner.py
@@ -1842,19 +1842,37 @@ async def _auto_select_tools(
     # ── Step 5c: Forcibly include session-active tools (always-on) ──────
     # Tools that the user manually activated or set as always-on must
     # never be dropped by the Top-K filter.  These are non-negotiable.
+    #
+    # Use session_data["active_tool_ids"] when available (already loaded
+    # by _load_session) instead of re-querying the DB — avoids a fragile
+    # second query that could fail transiently (Issue #439).
     active_ids: set[str] = set()
     if is_temporary:
         active_ids.update(session_data.get("active_tool_ids", []))
     else:
-        try:
-            sa_result = await db.execute(
-                select(SessionActiveTool.tool_id).where(
-                    SessionActiveTool.session_id == session_id
-                )
+        # Prefer the already-loaded list from _load_session
+        loaded_ids = session_data.get("active_tool_ids")
+        if loaded_ids is not None:
+            active_ids.update(loaded_ids)
+        else:
+            # Fallback: re-query DB (should not happen under normal flow)
+            logger.warning(
+                "Step 5c: active_tool_ids not in session_data — querying DB for session %s",
+                session_id,
             )
-            active_ids.update(row[0] for row in sa_result.all())
-        except Exception:
-            logger.debug("Failed to query session active tools", exc_info=True)
+            try:
+                sa_result = await db.execute(
+                    select(SessionActiveTool.tool_id).where(
+                        SessionActiveTool.session_id == session_id
+                    )
+                )
+                active_ids.update(row[0] for row in sa_result.all())
+            except Exception:
+                logger.warning(
+                    "Step 5c: Failed to query session active tools for session %s",
+                    session_id,
+                    exc_info=True,
+                )
 
     if active_ids:
         seen_ids = {t.id for t in shortlisted_tools}

--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -20,6 +20,7 @@ from fastapi import APIRouter, Depends, File, Request, Response, UploadFile
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import delete, select, update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sse_starlette.sse import EventSourceResponse
 
@@ -227,7 +228,9 @@ async def _lazy_create_session(
     """
     # Resolve active tool IDs (mirrors create_session endpoint logic)
     active_tool_ids = session_data.active_tool_ids
-    if active_tool_ids is None:
+    if not active_tool_ids:
+        # Auto-activate: user's always-on tools + skill tools
+        # Treat None and [] the same — both mean "no explicit tools selected"
         always_on_ids: set[str] = set()
         try:
             pref_result = await db.execute(
@@ -487,8 +490,9 @@ async def create_session(
     """
     # Resolve active tool IDs: explicit list > always-on + skill tools > empty
     active_tool_ids = body.active_tool_ids
-    if active_tool_ids is None:
+    if not active_tool_ids:
         # Auto-activate: user's always-on tools + skill tools
+        # Treat None and [] the same — both mean "no explicit tools selected"
         always_on_ids: set[str] = set()
         try:
             pref_result = await db.execute(
@@ -971,15 +975,26 @@ async def send_message(
             "Promoting temp session %s to permanent on first message",
             session_id,
         )
-        data = await _lazy_create_session(
-            db, session_id, body.session_data, current_user,
-        )
-        # Re-link any files uploaded during the pending phase
-        await upload_service.link_pending_uploads_to_session(
-            db, session_id, current_user.id,
-        )
-        # Clean up the stale Redis temp entry
-        await delete_temp_session(session_id)
+        try:
+            data = await _lazy_create_session(
+                db, session_id, body.session_data, current_user,
+            )
+        except IntegrityError:
+            # Race: upload_file already created the permanent session.
+            # Re-fetch the existing session data.
+            logger.info(
+                "Session %s already promoted to permanent by concurrent request — re-fetching",
+                session_id,
+            )
+            await db.rollback()
+            data = await _load_session(db, session_id)
+        else:
+            # Re-link any files uploaded during the pending phase
+            await upload_service.link_pending_uploads_to_session(
+                db, session_id, current_user.id,
+            )
+            # Clean up the stale Redis temp entry
+            await delete_temp_session(session_id)
 
     # ---- Auto-title: if session still has the default title, use the
     #      first user message as the title.  Set a raw truncated title
@@ -2264,7 +2279,7 @@ async def upload_file(
             "auto_select_tools": True,
             "thinking_enabled": None,
             "temperature": None,
-            "active_tool_ids": [],
+            "active_tool_ids": None,
             "created_at": now,
             "updated_at": now,
         }

--- a/backend/src/api/demo.py
+++ b/backend/src/api/demo.py
@@ -205,7 +205,7 @@ async def create_demo_session(
         "selected_model_id": None,
         "thinking_enabled": False,
         "temperature": None,
-        "active_tool_ids": [],
+        "active_tool_ids": None,
         "created_at": now.isoformat(),
         "updated_at": now.isoformat(),
     }

--- a/backend/src/api/widget.py
+++ b/backend/src/api/widget.py
@@ -132,7 +132,7 @@ async def get_widget_config(
         "selected_model_id": config.default_model_id,
         "thinking_enabled": False,
         "temperature": None,
-        "active_tool_ids": [],
+        "active_tool_ids": None,
         "created_at": now.isoformat(),
         "updated_at": now.isoformat(),
     }

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -85,8 +85,8 @@ class Settings(BaseSettings):
     # --- Logging ---
     LOG_LEVEL: str = "INFO"
 
-    # --- Auto tool selection (Issue #287) ---
-    AUTO_SELECT_TOOLS_TOP_K: int = 3
+    # --- Auto tool selection (Issue #287, #439) ---
+    AUTO_SELECT_TOOLS_TOP_K: int = 8
 
     # --- Agent execution (Issue #317) ---
     AGENT_MAX_STEPS: int = 15

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -1603,6 +1603,92 @@ class TestAutoSelectTools:
         )
         assert isinstance(result, list)
 
+    async def test_step_5c_uses_session_data_active_tool_ids(
+        self, db_session, test_tenant, test_tool, test_session, test_user
+    ):
+        """Verify Step 5c uses session_data['active_tool_ids'] instead of re-querying DB.
+
+        When active_tool_ids is present in session_data (loaded by _load_session),
+        Step 5c must use it regardless of DB state (Issue #439 fix).
+        """
+        from src.db.orm.sessions import SessionActiveTool
+
+        # Create a session with an active tool in the DB
+        sat = SessionActiveTool(
+            session_id=test_session.id,
+            tool_id=test_tool.id,
+        )
+        db_session.add(sat)
+        await db_session.flush()
+
+        # Provide active_tool_ids in session_data (simulates _load_session having populated it)
+        session_data = {
+            "id": test_session.id,
+            "is_temporary": False,
+            "tenant_id": test_tenant.id,
+            "user_id": test_user.id,
+            "auto_select_tools": True,
+            "active_tool_ids": [test_tool.id],
+        }
+
+        result = await self.fn(
+            db_session,
+            session_data,
+            test_tenant.id,
+            "test message about nothing in particular",
+            [],
+            [],
+            None,
+            "user1",
+        )
+        assert isinstance(result, list)
+
+        # Verify the session-active tool is in the shortlist (Step 5c retained it)
+        # We check that callables were returned — the tool should be present
+        # since Step 5c forcibly retains session-active tools.
+        # The exact callable count depends on other tenant tools, but at least
+        # one callable (the session-active test_tool) must be present.
+        assert len(result) >= 1, (
+            "Step 5c should retain the session-active tool even when "
+            "the message doesn't match the tool's keywords"
+        )
+
+    async def test_step_5c_falls_back_to_db_when_session_data_missing(
+        self, db_session, test_tenant, test_tool, test_session
+    ):
+        """Verify Step 5c falls back to DB query when session_data lacks active_tool_ids."""
+        from src.db.orm.sessions import SessionActiveTool
+
+        # Create a session with an active tool
+        sat = SessionActiveTool(
+            session_id=test_session.id,
+            tool_id=test_tool.id,
+        )
+        db_session.add(sat)
+        await db_session.flush()
+
+        # session_data without active_tool_ids key — should trigger DB fallback
+        session_data = {
+            "id": test_session.id,
+            "is_temporary": False,
+            "tenant_id": test_tenant.id,
+            "auto_select_tools": True,
+        }
+
+        result = await self.fn(
+            db_session,
+            session_data,
+            test_tenant.id,
+            "unrelated message with no keyword match",
+            [],
+            [],
+            None,
+            None,
+        )
+        assert isinstance(result, list)
+        # Should still have callables (session-active tool retained via DB fallback)
+        assert len(result) >= 1
+
 
 # =============================================================================
 # Phase 5: Summarization tests

--- a/backend/tests/test_chat_api.py
+++ b/backend/tests/test_chat_api.py
@@ -149,6 +149,46 @@ class TestCreateSession:
         data = resp.json()
         assert data["title"] == "Tooled Chat"
 
+    async def test_create_session_with_empty_tool_ids_auto_activates(
+        self, async_client, auth_headers, test_user, test_model, test_tool, db_session
+    ):
+        """Verify active_tool_ids=[] triggers auto-activation (Issue #439 fix).
+
+        An empty list should behave the same as None — both mean "no explicit
+        tools selected", so always-on + skill tools should be auto-activated.
+        """
+        from src.db.orm.user_tool_preferences import UserToolPreference
+
+        # Set the test tool as always-on for this user
+        pref = UserToolPreference(
+            user_id=test_user.id,
+            tool_id=test_tool.id,
+            always_on=True,
+        )
+        db_session.add(pref)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        payload = {
+            "title": "Empty IDs Chat",
+            "selected_model_id": test_model.id,
+            "active_tool_ids": [],  # empty list — should auto-activate
+        }
+        resp = await async_client.post("/api/chat/session", json=payload, headers=headers)
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["title"] == "Empty IDs Chat"
+
+        # Verify the always-on tool was auto-activated
+        tools_resp = await async_client.get(
+            f"/api/chat/session/{data['id']}/tools", headers=headers
+        )
+        assert tools_resp.status_code == 200
+        tool_ids = [t["id"] for t in tools_resp.json()]
+        assert test_tool.id in tool_ids, (
+            "Always-on tool should be auto-activated when active_tool_ids=[]"
+        )
+
     async def test_create_session_with_auto_route_enabled(
         self, async_client, auth_headers, test_user
     ):
@@ -2277,6 +2317,67 @@ class TestLazyCreateSession:
             headers=headers,
         )
         assert resp.status_code == 200, resp.text
+
+    @patch("src.api.chat.run_agent")
+    async def test_lazy_create_after_file_upload_activates_tools(
+        self, mock_run_agent, async_client, auth_headers, test_user, test_model, test_tool, db_session
+    ):
+        """Verify uploading a file before the first message doesn't lose tools (Issue #439 fix).
+
+        Previously, upload_file() created a temp session with active_tool_ids=[],
+        and _lazy_create_session() checked "if active_tool_ids is None" — but []
+        is not None, so auto-activation was skipped and zero tools were activated.
+        """
+        from src.db.orm.user_tool_preferences import UserToolPreference
+
+        mock_run_agent.return_value = ("Fixed response!", str(uuid.uuid4()))
+
+        # Set the test tool as always-on
+        pref = UserToolPreference(
+            user_id=test_user.id,
+            tool_id=test_tool.id,
+            always_on=True,
+        )
+        db_session.add(pref)
+        await db_session.flush()
+
+        headers = auth_headers(test_user)
+        session_id = str(uuid.uuid4())
+
+        # Step 1: Upload a file (this used to create a session with zero tools)
+        files = {"file": ("hello.txt", b"Hello world", "text/plain")}
+        upload_resp = await async_client.post(
+            f"/api/chat/session/{session_id}/upload",
+            files=files,
+            headers=headers,
+        )
+        # Upload should succeed (may be 201 if MinIO available, or error if not)
+        # The important thing is the session was created
+
+        # Step 2: Send first message
+        payload = {
+            "content": "Check tools are active",
+            "session_data": {
+                "title": "Post-Upload Chat",
+                "selected_model_id": test_model.id,
+            },
+        }
+        resp = await async_client.post(
+            f"/api/chat/session/{session_id}/message",
+            json=payload,
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+
+        # Step 3: Verify the always-on tool is active in the session
+        tools_resp = await async_client.get(
+            f"/api/chat/session/{session_id}/tools", headers=headers
+        )
+        assert tools_resp.status_code == 200, tools_resp.text
+        tool_ids = [t["id"] for t in tools_resp.json()]
+        assert test_tool.id in tool_ids, (
+            "Always-on tool should be active after file upload + first message"
+        )
 
 
 class TestFinalizeSession:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ph-agent-hub-frontend",
   "private": true,
-  "version": "1.24.3",
+  "version": "1.24.4",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000 --host",


### PR DESCRIPTION


Auto-activate tools now correctly utilize session data to prevent loss during conversations. This change addresses the issue of tools being randomly disabled by ensuring that active tool IDs are properly managed.



## Related Issue



Fixes #439



## Type of Change



- [x] Bug fix (non-breaking change that fixes an issue)



## Testing



- [x] Tested locally with Docker Compose (dev)

- [x] Backend tests pass (`pytest backend/tests/ -m "not e2e and not slow"`)

- [ ] Frontend builds without errors (`npm run build`)

- [x] Manual testing completed (verified tool activation during sessions)



## Checklist



- [x] My code follows the coding conventions of this project

- [x] I have self-reviewed my own code

- [x] I have commented complex code sections, particularly in hard-to-understand areas

- [x] I have updated the documentation (`docs/`) if my change affects user-facing behaviour or configuration

- [x] My changes generate no new warnings or errors

- [x] New and existing tests pass locally



## Screenshots (if applicable)



## Additional Notes



No additional notes.

