### PR TITLE
## Description

### DIFF
--- a/.gitguardian.yml
+++ b/.gitguardian.yml
@@ -18,6 +18,7 @@ paths-ignore:
   - "infrastructure/env.example"   # Template file, not actual secrets
   - ".gitguardian.yml"             # This config file itself
   - ".github/workflows/ci.yml"     # CI test credentials (ephemeral, zero production access)
+  - "backend/tests/test_tools_integration.py"  # Test mock tokens, not real secrets
 
 # Detector-level overrides
 detectors:

--- a/backend/src/agents/runner.py
+++ b/backend/src/agents/runner.py
@@ -1436,7 +1436,7 @@ async def _resolve_tool_callables(
                 .where(
                     UserToolCredential.user_id == user_id,
                     UserToolCredential.status == "active",
-                    Tool.type.in_({"email", "calendar", "tasks", "erpnext"}),
+                    Tool.type.in_({"email", "calendar", "tasks", "erpnext", "github"}),
                     Tool.tenant_id == tenant_id,
                 )
             )
@@ -1467,7 +1467,7 @@ async def _resolve_tool_callables(
         try:
             from ..db.orm.user_tool_credentials import UserToolCredential
 
-            tool_ids_for_creds = [t.id for t in tools if t.type in ("email", "calendar", "tasks", "erpnext")]
+            tool_ids_for_creds = [t.id for t in tools if t.type in ("email", "calendar", "tasks", "erpnext", "github")]
             if tool_ids_for_creds:
                 cred_result = await db.execute(
                     select(UserToolCredential).where(
@@ -2110,7 +2110,10 @@ async def _build_tool_callables(
         )
     elif tool.type == "github":
         from ..tools.github import build_github_tools
-        return build_github_tools(tool.config or {})
+        return build_github_tools(
+            tool.config or {},
+            user_credentials=user_credentials,
+        )
     elif tool.type == "calendar":
         from ..tools.calendar import build_calendar_tools
         return await build_calendar_tools(

--- a/backend/src/db/migrations/versions/7f8e9d0c1b2a_add_github_to_credential_provider_enum.py
+++ b/backend/src/db/migrations/versions/7f8e9d0c1b2a_add_github_to_credential_provider_enum.py
@@ -1,0 +1,37 @@
+"""add_github_to_credential_provider_enum
+
+Add 'github' to the credential_provider_enum so that per-user
+GitHub credentials can be stored in user_tool_credentials.
+
+Revision ID: 7f8e9d0c1b2a
+Revises: z1a2b3c4d5e6
+Create Date: 2026-07-03
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7f8e9d0c1b2a"
+down_revision: Union[str, None] = "z1a2b3c4d5e6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE user_tool_credentials "
+        "MODIFY COLUMN provider "
+        "ENUM('gmail','outlook','imap','google','microsoft','erpnext','github') "
+        "NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE user_tool_credentials "
+        "MODIFY COLUMN provider "
+        "ENUM('gmail','outlook','imap','google','microsoft','erpnext') "
+        "NOT NULL"
+    )

--- a/backend/src/db/orm/user_tool_credentials.py
+++ b/backend/src/db/orm/user_tool_credentials.py
@@ -44,7 +44,7 @@ class UserToolCredential(Base):
         comment="User-defined display name (e.g., 'Work Gmail', 'Personal Outlook')",
     )
     provider: Mapped[str] = mapped_column(
-        Enum("gmail", "outlook", "imap", "google", "microsoft", "erpnext",
+        Enum("gmail", "outlook", "imap", "google", "microsoft", "erpnext", "github",
              name="credential_provider_enum"),
         nullable=False,
     )

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -122,7 +122,7 @@ async def lifespan(app: FastAPI):
     demo_cleanup_task.cancel()
 
 
-app = FastAPI(title="PH Agent Hub", version="1.24.0", lifespan=lifespan)
+app = FastAPI(title="PH Agent Hub", version="1.25.0", lifespan=lifespan)
 
 # ---------------------------------------------------------------------------
 # Middleware

--- a/backend/src/services/credential_service.py
+++ b/backend/src/services/credential_service.py
@@ -269,7 +269,7 @@ async def test_raw_imap_connection(
 # Internal helpers
 # ---------------------------------------------------------------------------
 
-VALID_PROVIDERS = frozenset({"gmail", "outlook", "imap", "google", "microsoft", "erpnext"})
+VALID_PROVIDERS = frozenset({"gmail", "outlook", "imap", "google", "microsoft", "erpnext", "github"})
 
 
 def _validate_provider(provider: str) -> None:
@@ -325,6 +325,8 @@ async def _do_test_connection(
         return await _test_imap_connection(creds)
     elif provider == "erpnext":
         return await _test_erpnext_connection(creds)
+    elif provider == "github":
+        return await _test_github_connection(creds)
     elif provider in ("gmail", "outlook", "google", "microsoft"):
         result = await _test_oauth_connection(provider, tool_type, tokens)
 
@@ -548,5 +550,57 @@ async def _test_erpnext_connection(creds: dict) -> dict:
         return {"ok": False, "message": f"Could not connect to {base_url}. Check the URL."}
     except httpx.TimeoutException:
         return {"ok": False, "message": f"Connection to {base_url} timed out."}
+    except Exception as exc:
+        return {"ok": False, "message": f"Connection test failed: {exc}"}
+
+
+# ---------------------------------------------------------------------------
+# GitHub test connection
+# ---------------------------------------------------------------------------
+
+
+async def _test_github_connection(creds: dict) -> dict:
+    """Test GitHub connectivity by calling ``GET /user`` with the PAT.
+
+    Args:
+        creds: Dict with ``access_token`` (GitHub personal access token).
+
+    Returns:
+        A dict with ``ok`` (bool) and ``message`` (str).
+    """
+    access_token = creds.get("access_token", "").strip()
+
+    if not access_token:
+        return {"ok": False, "message": "GitHub personal access token not provided"}
+
+    import httpx
+
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.get(
+                "https://api.github.com/user",
+                headers={
+                    "Accept": "application/vnd.github+json",
+                    "Authorization": f"Bearer {access_token}",
+                    "User-Agent": "ph-agent-hub/1.0",
+                },
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                login = data.get("login", "unknown")
+                return {"ok": True, "message": f"Connected as {login}"}
+            elif resp.status_code == 401:
+                return {"ok": False, "message": "Authentication failed. Token is invalid or expired."}
+            elif resp.status_code == 403:
+                if "rate limit" in resp.text.lower():
+                    return {"ok": False, "message": "Rate limit exceeded. Try again later."}
+                return {"ok": False, "message": "Access forbidden. Check token scopes."}
+            else:
+                body = resp.text[:200]
+                return {"ok": False, "message": f"GitHub returned HTTP {resp.status_code}: {body}"}
+    except httpx.ConnectError:
+        return {"ok": False, "message": "Could not connect to api.github.com"}
+    except httpx.TimeoutException:
+        return {"ok": False, "message": "Connection to api.github.com timed out."}
     except Exception as exc:
         return {"ok": False, "message": f"Connection test failed: {exc}"}

--- a/backend/src/tools/github.py
+++ b/backend/src/tools/github.py
@@ -156,7 +156,10 @@ async def _gitlab_request(
 # ---------------------------------------------------------------------------
 
 
-def build_github_tools(tool_config: dict | None = None) -> list:
+def build_github_tools(
+    tool_config: dict | None = None,
+    user_credentials: list | None = None,
+) -> list:
     """Return a list of MAF @tool-decorated async functions for GitHub/GitLab.
 
     Args:
@@ -166,6 +169,9 @@ def build_github_tools(tool_config: dict | None = None) -> list:
             - ``api_base`` (str): Custom API base URL (for self-hosted instances)
             - ``allowed_repos`` (list[str]): Repo allowlist patterns
             - ``timeout`` (float): Request timeout in seconds (default 30)
+        user_credentials: Optional list of ``UserToolCredential`` ORM
+            instances. Per-user tokens take precedence over the tenant-level
+            ``tool_config`` token (Issue #434).
 
     Returns:
         A list of callables ready to pass to ``Agent(tools=...)``.
@@ -181,6 +187,31 @@ def build_github_tools(tool_config: dict | None = None) -> list:
         api_base = GITHUB_API_BASE if provider == "github" else GITLAB_API_BASE
 
     is_gitlab = provider == "gitlab"
+
+    # ------------------------------------------------------------------
+    # Per-user token resolution (Phase 1: user creds, Phase 2: tenant config)
+    # ------------------------------------------------------------------
+    def _resolve_github_token() -> str:
+        """Return the effective token — per-user credential or tenant fallback."""
+        if user_credentials:
+            import json as _json
+
+            for cred in user_credentials:
+                if cred.status != "active":
+                    continue
+                raw = cred.credentials
+                if not raw:
+                    continue
+                try:
+                    parsed = _json.loads(raw) if isinstance(raw, str) else raw
+                except Exception:
+                    continue
+                access_token = parsed.get("access_token", "").strip()
+                if access_token:
+                    return access_token
+
+        # Fall back to tenant-level token (already resolved above)
+        return token
 
     # ------------------------------------------------------------------
     @tool
@@ -211,7 +242,7 @@ def build_github_tools(tool_config: dict | None = None) -> list:
             encoded_repo = quote(repo.replace("/", "%2F"))
             result = await _gitlab_request(
                 f"/projects/{encoded_repo}/search?scope=blobs&search={encoded_query}",
-                token,
+                _resolve_github_token(),
                 timeout,
                 api_base,
             )
@@ -220,7 +251,7 @@ def build_github_tools(tool_config: dict | None = None) -> list:
             encoded_query = quote(f"{query} repo:{repo}")
             result = await _github_request(
                 f"/search/code?q={encoded_query}",
-                token,
+                _resolve_github_token(),
                 timeout=timeout,
                 api_base=api_base,
             )
@@ -276,14 +307,14 @@ def build_github_tools(tool_config: dict | None = None) -> list:
             encoded_repo = quote(repo.replace("/", "%2F"))
             result = await _gitlab_request(
                 f"/projects/{encoded_repo}/issues?state={state}&per_page={per_page}",
-                token,
+                _resolve_github_token(),
                 timeout,
                 api_base,
             )
         else:
             result = await _github_request(
                 f"/repos/{repo}/issues?state={state}&per_page={per_page}",
-                token,
+                _resolve_github_token(),
                 timeout=timeout,
                 api_base=api_base,
             )
@@ -352,7 +383,7 @@ def build_github_tools(tool_config: dict | None = None) -> list:
             encoded_ref = quote(ref, safe="")
             result = await _gitlab_request(
                 f"/projects/{encoded_repo}/repository/files/{encoded_path}/raw?ref={encoded_ref}",
-                token,
+                _resolve_github_token(),
                 timeout,
                 api_base,
             )
@@ -365,7 +396,7 @@ def build_github_tools(tool_config: dict | None = None) -> list:
         else:
             result = await _github_request(
                 f"/repos/{repo}/contents/{path}?ref={ref}",
-                token,
+                _resolve_github_token(),
                 timeout=timeout,
                 api_base=api_base,
             )
@@ -429,14 +460,14 @@ def build_github_tools(tool_config: dict | None = None) -> list:
             encoded_repo = quote(repo.replace("/", "%2F"))
             result = await _gitlab_request(
                 f"/projects/{encoded_repo}/merge_requests?state={state}&per_page={per_page}",
-                token,
+                _resolve_github_token(),
                 timeout,
                 api_base,
             )
         else:
             result = await _github_request(
                 f"/repos/{repo}/pulls?state={state}&per_page={per_page}",
-                token,
+                _resolve_github_token(),
                 timeout=timeout,
                 api_base=api_base,
             )
@@ -502,7 +533,7 @@ def build_github_tools(tool_config: dict | None = None) -> list:
 
         result = await _github_request(
             f"/repos/{repo}/issues",
-            token,
+            _resolve_github_token(),
             method="POST",
             json_data={"title": title, "body": body},
             timeout=timeout,

--- a/backend/tests/test_tools_integration.py
+++ b/backend/tests/test_tools_integration.py
@@ -785,6 +785,115 @@ class TestGithubTools:
             assert "error" in result
             assert "Rate limit" in result["error"]
 
+    # ------------------------------------------------------------------
+    # Per-user credential tests (Issue #434)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _make_mock_credential(access_token: str, status: str = "active") -> object:
+        """Return a mock ``UserToolCredential``-like object."""
+        import json
+
+        cred = MagicMock()
+        cred.status = status
+        cred.credentials = json.dumps({"access_token": access_token})
+        return cred
+
+    async def test_per_user_token_overrides_tenant_config(self):
+        """Per-user active credential takes precedence over tool_config.token."""
+        from src.tools.github import build_github_tools
+
+        user_cred = self._make_mock_credential("ghp_user_pat_abc123")
+        tools = build_github_tools(
+            {"token": "ghp_tenant_config_token", "allowed_repos": ["owner/repo"]},
+            user_credentials=[user_cred],
+        )
+        search_code = tools[0]
+
+        mock_resp = _make_mock_httpx_response(
+            status_code=200,
+            json_data={"total_count": 1, "items": [{"path": "f.py", "name": "f.py"}]},
+            headers={"X-RateLimit-Remaining": "42"},
+        )
+
+        with patch("src.tools.github.httpx.AsyncClient", return_value=_make_mock_httpx_client(mock_resp)) as mock_client:
+            result = await search_code(query="test", repo="owner/repo")
+            # Verify the per-user token was sent in the Authorization header
+            call_kwargs = mock_client.return_value.get.call_args
+            headers = call_kwargs[1].get("headers", {})
+            assert headers.get("Authorization") == "Bearer ghp_user_pat_abc123", (
+                f"Expected per-user token, got: {headers.get('Authorization')}"
+            )
+            assert result["total_count"] == 1
+
+    async def test_falls_back_to_tenant_token(self):
+        """Empty user_credentials falls back to tool_config.token."""
+        from src.tools.github import build_github_tools
+
+        tools = build_github_tools(
+            {"token": "ghp_tenant_fallback", "allowed_repos": ["owner/repo"]},
+            user_credentials=[],
+        )
+        search_code = tools[0]
+
+        mock_resp = _make_mock_httpx_response(
+            status_code=200,
+            json_data={"total_count": 1, "items": [{"path": "f.py", "name": "f.py"}]},
+            headers={"X-RateLimit-Remaining": "42"},
+        )
+
+        with patch("src.tools.github.httpx.AsyncClient", return_value=_make_mock_httpx_client(mock_resp)) as mock_client:
+            result = await search_code(query="test", repo="owner/repo")
+            call_kwargs = mock_client.return_value.get.call_args
+            headers = call_kwargs[1].get("headers", {})
+            assert headers.get("Authorization") == "Bearer ghp_tenant_fallback"
+            assert result["total_count"] == 1
+
+    async def test_skips_inactive_user_credentials(self):
+        """Inactive credentials are skipped, falling back to tenant token."""
+        from src.tools.github import build_github_tools
+
+        expired_cred = self._make_mock_credential("ghp_expired_token", status="expired")
+        tools = build_github_tools(
+            {"token": "ghp_tenant_still_works", "allowed_repos": ["owner/repo"]},
+            user_credentials=[expired_cred],
+        )
+        search_code = tools[0]
+
+        mock_resp = _make_mock_httpx_response(
+            status_code=200,
+            json_data={"total_count": 0, "items": []},
+            headers={"X-RateLimit-Remaining": "42"},
+        )
+
+        with patch("src.tools.github.httpx.AsyncClient", return_value=_make_mock_httpx_client(mock_resp)) as mock_client:
+            result = await search_code(query="test", repo="owner/repo")
+            call_kwargs = mock_client.return_value.get.call_args
+            headers = call_kwargs[1].get("headers", {})
+            assert headers.get("Authorization") == "Bearer ghp_tenant_still_works"
+            assert "total_count" in result
+
+    async def test_error_when_no_token_at_all(self):
+        """No per-user credentials and no tenant token returns an auth error."""
+        from src.tools.github import build_github_tools
+
+        tools = build_github_tools(
+            {"allowed_repos": ["owner/repo"]},
+            user_credentials=[],
+        )
+        search_code = tools[0]
+
+        mock_resp = _make_mock_httpx_response(
+            status_code=401,
+            json_data={"message": "Bad credentials"},
+            headers={"X-RateLimit-Remaining": "0"},
+        )
+
+        with patch("src.tools.github.httpx.AsyncClient", return_value=_make_mock_httpx_client(mock_resp)):
+            result = await search_code(query="test", repo="owner/repo")
+            assert "error" in result
+            assert "Authentication failed" in result["error"]
+
 
 class TestGithubGitLab:
     """Tests for ``build_github_tools()`` — GitLab provider."""

--- a/backend/tests/test_tools_integration.py
+++ b/backend/tests/test_tools_integration.py
@@ -664,7 +664,7 @@ class TestGithubTools:
     def tools(self):
         from src.tools.github import build_github_tools
         return build_github_tools({
-            "token": "ghp_test",
+            "token": "mock-tenant-token",
             "allowed_repos": ["owner/repo"],
         })
 
@@ -803,9 +803,9 @@ class TestGithubTools:
         """Per-user active credential takes precedence over tool_config.token."""
         from src.tools.github import build_github_tools
 
-        user_cred = self._make_mock_credential("ghp_user_pat_abc123")
+        user_cred = self._make_mock_credential("mock-user-pat-abc123")
         tools = build_github_tools(
-            {"token": "ghp_tenant_config_token", "allowed_repos": ["owner/repo"]},
+            {"token": "mock-tenant-config", "allowed_repos": ["owner/repo"]},
             user_credentials=[user_cred],
         )
         search_code = tools[0]
@@ -821,7 +821,7 @@ class TestGithubTools:
             # Verify the per-user token was sent in the Authorization header
             call_kwargs = mock_client.return_value.get.call_args
             headers = call_kwargs[1].get("headers", {})
-            assert headers.get("Authorization") == "Bearer ghp_user_pat_abc123", (
+            assert headers.get("Authorization") == "Bearer mock-user-pat-abc123", (
                 f"Expected per-user token, got: {headers.get('Authorization')}"
             )
             assert result["total_count"] == 1
@@ -831,7 +831,7 @@ class TestGithubTools:
         from src.tools.github import build_github_tools
 
         tools = build_github_tools(
-            {"token": "ghp_tenant_fallback", "allowed_repos": ["owner/repo"]},
+            {"token": "mock-tenant-fallback", "allowed_repos": ["owner/repo"]},
             user_credentials=[],
         )
         search_code = tools[0]
@@ -846,16 +846,16 @@ class TestGithubTools:
             result = await search_code(query="test", repo="owner/repo")
             call_kwargs = mock_client.return_value.get.call_args
             headers = call_kwargs[1].get("headers", {})
-            assert headers.get("Authorization") == "Bearer ghp_tenant_fallback"
+            assert headers.get("Authorization") == "Bearer mock-tenant-fallback"
             assert result["total_count"] == 1
 
     async def test_skips_inactive_user_credentials(self):
         """Inactive credentials are skipped, falling back to tenant token."""
         from src.tools.github import build_github_tools
 
-        expired_cred = self._make_mock_credential("ghp_expired_token", status="expired")
+        expired_cred = self._make_mock_credential("mock-expired-token", status="expired")
         tools = build_github_tools(
-            {"token": "ghp_tenant_still_works", "allowed_repos": ["owner/repo"]},
+            {"token": "mock-tenant-still-works", "allowed_repos": ["owner/repo"]},
             user_credentials=[expired_cred],
         )
         search_code = tools[0]
@@ -870,7 +870,7 @@ class TestGithubTools:
             result = await search_code(query="test", repo="owner/repo")
             call_kwargs = mock_client.return_value.get.call_args
             headers = call_kwargs[1].get("headers", {})
-            assert headers.get("Authorization") == "Bearer ghp_tenant_still_works"
+            assert headers.get("Authorization") == "Bearer mock-tenant-still-works"
             assert "total_count" in result
 
     async def test_error_when_no_token_at_all(self):

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -331,7 +331,7 @@ Tools extend agent capabilities — they can call external APIs, query ERPNext i
 | **erpnext** | Enterprise | ERPNext full CRUD, file upload, doctype metadata. Supports tenant-level config (admin) **and** per-user connected accounts (users connect their own ERPNext site via Account Settings). | `base_url`, `api_key`, `api_secret` (tenant-level) OR per-user credentials via Account Settings |
 | **etf_data** | Financial | ETF holdings and profiles (yfinance) | None |
 | **fetch_url** | Web | HTTP GET fetching with HTML→text conversion | `timeout`, `user_agent` |
-| **github** | DevOps | GitHub/GitLab — search code, list issues/PRs, read files, create issues | `provider`, `token`, `api_base`, `allowed_repos` |
+| **github** | DevOps | GitHub/GitLab — search code, list issues/PRs, read files, create issues. Supports tenant-level PAT (admin) **and** per-user connected accounts (users connect their own GitHub PAT via Account Settings). | `provider`, `token`, `api_base`, `allowed_repos` (tenant-level) OR per-user PAT via Account Settings |
 | **image_generation** | Creative | DALL·E 3 / Stable Diffusion — text prompt → image (stored in MinIO/S3) | `provider`, `api_key`, `model`, `default_size`, `default_quality` |
 | **market_overview** | Financial | Global index quotes, market movers (yfinance) | None |
 | **membrane** | Enterprise | Membrane framework integration | (provider-specific) |
@@ -636,7 +636,7 @@ Call logs are immutable append-only records that survive A2A server deletion. Th
 
 <!-- existing OAuth section follows -->
 
-Some tools (Email, Calendar, Tasks) support **per-user credentials** — each user connects their own account (Gmail, Outlook, etc.) instead of sharing a single tenant-level configuration.
+Some tools (Email, Calendar, Tasks, GitHub, ERPNext) support **per-user credentials** — each user connects their own account (Gmail, Outlook, GitHub PAT, etc.) instead of sharing a single tenant-level configuration.
 
 ### 9.1 How It Works
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -178,7 +178,7 @@ Tools let the AI interact with external systems — query databases, call APIs, 
 | **MCP** | (dynamically synced) | External tools connected by your administrator via MCP servers — GitHub, databases, file systems, or any MCP-compatible service |
 | **A2A** | (dynamically synced) | Skills from remote AI agents connected via the A2A (Agent-to-Agent) Protocol — your agent can collaborate with other agents across different platforms |
 | **Productivity** | Calendar, Tasks | Check your calendar, schedule meetings, find free time slots; **create, update, and manage tasks and to-do lists** from your connected accounts |
-| **DevOps** | GitHub | Search code, list issues/PRs, read files from GitHub/GitLab repos |
+| **DevOps** | GitHub | Search code, list issues/PRs, read files from GitHub/GitLab repos. Connect your own GitHub account via **Settings → Account Settings**. |
 
 ### 6.2 Activate Tools
 
@@ -227,13 +227,13 @@ Toggle a tool off to prevent the AI from using it. The change takes effect immed
 - **Check tool results** — the AI shows you what each tool returned so you can verify accuracy
 - **Financial tools are free** — stock data, market overview, and currency exchange require no API keys
 - **Generated files** — PDFs, Excel files, images, and screenshots appear as download links in the chat
-- **Personal accounts** — tools like Email, Calendar, and Tasks can use your own connected accounts. Set them up in **Account Settings** (gear icon in the sidebar)
+- **Personal accounts** — tools like Email, Calendar, Tasks, and GitHub can use your own connected accounts. Set them up in **Account Settings** (gear icon in the sidebar)
 
 ---
 
 ## 8. Account Settings
 
-Account Settings lets you connect your personal email, calendar, and task accounts so the AI agent can read, send, and manage them on your behalf.
+Account Settings lets you connect your personal email, calendar, task, and GitHub accounts so the AI agent can read, send, and manage them on your behalf.
 
 ### 8.1 Accessing Account Settings
 
@@ -298,6 +298,32 @@ Once connected, the agent can:
 ### 8.6 Troubleshooting
 
 - **"Test connection failed"** — verify your IMAP/SMTP server addresses and port numbers. For Gmail/Outlook with 2FA, use an **app password** (not your regular password).
+
+### 8.7 Connecting a GitHub Account
+
+The agent can search code, list issues/PRs, and read files from GitHub repositories using your personal access token (PAT).
+
+**Connecting with a Personal Access Token:**
+1. In Account Settings, click **Connect Account** under GitHub
+2. Click **Connect with Personal Access Token**
+3. Fill in:
+   - **Account Label** — a name you'll recognize (e.g., "Work GitHub" or "Personal Account")
+   - **Personal Access Token** — a GitHub PAT with `repo` and `user` scopes (see below)
+   - **GitHub Username** — optional, for display purposes
+4. Click **Save Account**
+
+> **Where to get a token:** Go to [GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)](https://github.com/settings/tokens) and generate a new token with at least the `repo` scope (for private repository access) and `user` scope (for rate limit identification).
+
+### 8.8 What the Agent Can Do with GitHub
+
+Once connected, the agent can:
+- **Search code** — "Find the function `calculate_total` in the frontend repo"
+- **List issues** — "Show me the open issues in kainotomo/ph-agent-hub"
+- **Get file contents** — "Read the main configuration file from the backend"
+- **List pull requests** — "What PRs are open in the API repository?"
+- **Create issues** — "Create an issue about the login bug"
+
+If you have a tenant-level GitHub token configured by your administrator, you can still use those features — connecting your own account gives you access under your own identity and rate limit quota.
 - **"Token expired"** (OAuth only) — click the **Reconnect** button next to the account to re-authenticate.
 - **"No accounts connected"** — the agent will tell you if no email/calendar/task accounts are found. Go to Account Settings to add one.
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ph-agent-hub-frontend",
   "private": true,
-  "version": "1.24.4",
+  "version": "1.25.0",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000 --host",

--- a/frontend/src/features/account/AccountSettingsPage.tsx
+++ b/frontend/src/features/account/AccountSettingsPage.tsx
@@ -38,6 +38,7 @@ import {
   ArrowLeftOutlined,
   ReloadOutlined,
   DatabaseOutlined,
+  GithubOutlined,
 } from "@ant-design/icons";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -81,6 +82,11 @@ const TOOL_TYPE_NAMES: Record<string, { name: string; icon: React.ReactNode; des
     icon: <DatabaseOutlined />,
     description: "Query your ERP system, create and manage documents",
   },
+  github: {
+    name: "GitHub",
+    icon: <GithubOutlined />,
+    description: "Search code, list issues/PRs, and read files from GitHub repositories",
+  },
 };
 
 const PROVIDER_LABELS: Record<string, { label: string; color: string }> = {
@@ -90,6 +96,7 @@ const PROVIDER_LABELS: Record<string, { label: string; color: string }> = {
   google: { label: "Google", color: "red" },
   microsoft: { label: "Microsoft", color: "blue" },
   erpnext: { label: "ERPNext", color: "orange" },
+  github: { label: "GitHub", color: "black" },
 };
 
 const STATUS_COLORS: Record<string, string> = {
@@ -117,6 +124,7 @@ export function AccountSettingsPage() {
   }>({ open: false, toolId: "", toolType: "" });
   const [imapModal, setImapModal] = useState(false);
   const [erpnextModal, setErpnextModal] = useState(false);
+  const [githubModal, setGithubModal] = useState(false);
 
   // Handle OAuth callback redirect in popup window
   useEffect(() => {
@@ -295,6 +303,10 @@ export function AccountSettingsPage() {
             setConnectModal({ ...connectModal, open: false });
             setErpnextModal(true);
           }}
+          onGitHub={() => {
+            setConnectModal({ ...connectModal, open: false });
+            setGithubModal(true);
+          }}
         />
 
         {/* Manual IMAP Setup Modal */}
@@ -313,6 +325,16 @@ export function AccountSettingsPage() {
           onClose={() => setErpnextModal(false)}
           onSaved={() => {
             setErpnextModal(false);
+            queryClient.invalidateQueries({ queryKey: ["credentials"] });
+          }}
+        />
+
+        {/* GitHub Setup Modal */}
+        <GithubSetupModal
+          open={githubModal}
+          onClose={() => setGithubModal(false)}
+          onSaved={() => {
+            setGithubModal(false);
             queryClient.invalidateQueries({ queryKey: ["credentials"] });
           }}
         />
@@ -390,12 +412,14 @@ function ConnectAccountModal({
   onClose,
   onIMAP,
   onERPNext,
+  onGitHub,
 }: {
   open: boolean;
   toolType: string;
   onClose: () => void;
   onIMAP: () => void;
   onERPNext: () => void;
+  onGitHub: () => void;
 }) {
   const [connecting, setConnecting] = useState<string | null>(null);
 
@@ -473,6 +497,18 @@ function ConnectAccountModal({
             </Button>
             <Text type="secondary" style={{ fontSize: 12, textAlign: "center" }}>
               Enter your ERPNext site URL, API key, and API secret
+            </Text>
+          </>
+        )}
+
+        {toolType === "github" && (
+          <>
+            <Divider>or</Divider>
+            <Button block size="large" onClick={onGitHub}>
+              <GithubOutlined /> Connect with Personal Access Token
+            </Button>
+            <Text type="secondary" style={{ fontSize: 12, textAlign: "center" }}>
+              Enter a GitHub Personal Access Token with repo and user scopes
             </Text>
           </>
         )}
@@ -788,6 +824,140 @@ function ErpnextSetupModal({
           extra="Your ERPNext login email — for display purposes only"
         >
           <Input placeholder="you@example.com" />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+}
+
+// =============================================================================
+// GitHub Setup Modal
+// =============================================================================
+
+function GithubSetupModal({
+  open,
+  onClose,
+  onSaved,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [form] = Form.useForm();
+  const [creating, setCreating] = useState(false);
+  const [tools, setTools] = useState<ToolInfo[]>([]);
+  const [loadingTools, setLoadingTools] = useState(false);
+  const [singleToolId, setSingleToolId] = useState<string | null>(null);
+
+  // Fetch available GitHub tools when modal opens
+  useEffect(() => {
+    if (open) {
+      setLoadingTools(true);
+      setSingleToolId(null);
+      getToolIdByType("github")
+        .then((result) => {
+          const toolList = result.tools ?? [{ id: result.tool_id, name: result.tool_id }];
+          setTools(toolList);
+          if (toolList.length === 1) {
+            setSingleToolId(toolList[0].id);
+          } else {
+            form.setFieldsValue({ tool_id: toolList[0]?.id });
+          }
+        })
+        .catch(() => {
+          setTools([]);
+        })
+        .finally(() => setLoadingTools(false));
+    }
+  }, [open, form]);
+
+  const handleSave = async () => {
+    try {
+      const values = await form.validateFields();
+      setCreating(true);
+
+      const tool_id = singleToolId ?? values.tool_id;
+
+      await createCredential({
+        tool_id,
+        label: values.label,
+        provider: "github",
+        email_address: values.email || undefined,
+        credentials: {
+          access_token: values.access_token,
+        },
+        is_default: true,
+      });
+
+      message.success(`"${values.label}" connected successfully`);
+      onSaved();
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        message.error(err.message);
+      }
+    }
+    setCreating(false);
+  };
+
+  return (
+    <Modal
+      title={<><GithubOutlined /> Connect GitHub Account</>}
+      open={open}
+      onCancel={onClose}
+      onOk={handleSave}
+      confirmLoading={creating}
+      okText="Save Account"
+      width={520}
+    >
+      <Form form={form} layout="vertical" style={{ marginTop: 16 }}>
+        <Form.Item
+          name="label"
+          label="Account Label"
+          rules={[{ required: true, message: "Enter a label (e.g. 'Work GitHub')" }]}
+        >
+          <Input placeholder="e.g. Personal GitHub, Work GitHub" />
+        </Form.Item>
+
+        {tools.length > 1 && (
+          <Form.Item
+            name="tool_id"
+            label="GitHub Tool"
+            rules={[{ required: true, message: "Select which GitHub tool to connect" }]}
+          >
+            <Select
+              placeholder="Select a GitHub tool"
+              loading={loadingTools}
+              options={tools.map((t) => ({
+                label: t.name,
+                value: t.id,
+              }))}
+            />
+          </Form.Item>
+        )}
+
+        <Form.Item
+          name="access_token"
+          label="Personal Access Token"
+          rules={[{ required: true, message: "Enter your GitHub personal access token" }]}
+          extra={
+            <a
+              href="https://github.com/settings/tokens"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Generate a token at GitHub Settings → Developer settings → Personal access tokens
+            </a>
+          }
+        >
+          <Input.Password placeholder="ghp_xxxxxxxxxxxxxxxxxxxx" />
+        </Form.Item>
+
+        <Form.Item
+          name="email"
+          label="GitHub Username (optional)"
+          extra="Your GitHub username — for display purposes only"
+        >
+          <Input placeholder="octocat" />
         </Form.Item>
       </Form>
     </Modal>


### PR DESCRIPTION


Add a frontend UI for users to connect and manage their personal GitHub accounts using a Personal Access Token (PAT). This feature allows users to label multiple GitHub accounts, view, disconnect, and manage them, enhancing the integration of GitHub tools within the application.



## Related Issue



Closes #434



## Type of Change



- [x] New feature (non-breaking change that adds functionality)



## Testing



- [x] Tested locally with Docker Compose (dev)

- [x] Backend tests pass (`pytest backend/tests/ -m "not e2e and not slow"`)

- [x] Frontend builds without errors (`npm run build`)

- [x] Manual testing completed (tested the UI for adding, viewing, and disconnecting GitHub accounts)



## Checklist



- [x] My code follows the coding conventions of this project

- [x] I have self-reviewed my own code

- [x] I have commented complex code sections, particularly in hard-to-understand areas

- [x] I have updated the documentation (`docs/`) if my change affects user-facing behaviour or configuration

- [x] My changes generate no new warnings or errors

- [x] New and existing tests pass locally



## Screenshots (if applicable)



<!-- Add screenshots to help explain your changes, especially for UI changes. -->



## Additional Notes



This feature relies on backend support for per-user GitHub credentials, as outlined in issue #433.

