### PR TITLE
Goal-Based Skills — define objectives, not prompts, and let the agent plan execution

### DIFF
--- a/backend/src/agents/registry.py
+++ b/backend/src/agents/registry.py
@@ -65,6 +65,8 @@ async def startup_scan(db: AsyncSession) -> None:
     db_keys = [row[0] for row in result.all()]
 
     for key in db_keys:
+        if key is None:
+            continue  # goal_based skills don't need a MAF target
         if key not in _registry:
             logger.warning(
                 "Skill '%s' exists in DB but has no registered MAF target.", key

--- a/backend/src/agents/runner.py
+++ b/backend/src/agents/runner.py
@@ -127,10 +127,10 @@ async def _resolve_session_config(
 
     # 5. Determine execution type and name
     execution_type = skill.execution_type if skill else "agent"
-    # Normalize: workflow_based → workflow, prompt_based → agent
+    # Normalize: workflow_based → workflow, prompt_based → agent, goal_based → agent
     if execution_type == "workflow_based":
         execution_type = "workflow"
-    if execution_type == "prompt_based":
+    if execution_type in ("prompt_based", "goal_based"):
         execution_type = "agent"
     agent_name = skill.title if skill else "assistant"
 
@@ -174,6 +174,37 @@ async def _resolve_session_config(
             tenant_name = tenant_row.name
     except Exception:
         logger.warning("Failed to resolve tenant name for tenant %s", tenant_id)
+
+    # ---- Constraint-aware tool filtering (Goal-Based Skills, Issue #448) --
+    # When a goal_based skill has a "read_only" constraint, strip tools
+    # that perform write operations so the agent cannot modify data.
+    if (
+        skill
+        and skill.execution_type == "goal_based"
+        and skill.constraints
+        and "read_only" in skill.constraints
+    ):
+        _WRITE_TOOL_PREFIXES = (
+            "create_", "update_", "delete_", "save_", "send_",
+            "insert_", "submit_", "write_", "upload_", "remove_",
+            "edit_", "modify_", "add_", "set_", "put_", "post_",
+        )
+        _EXEMPT_TOOLS = {"propose_schedule", "confirm_schedule", "save_memory",
+                         "delete_memory", "list_memory"}
+        before = len(active_tool_callables)
+        active_tool_callables = [
+            t for t in active_tool_callables
+            if not hasattr(t, "name")
+            or not t.name.lower().startswith(_WRITE_TOOL_PREFIXES)
+            or t.name in _EXEMPT_TOOLS
+        ]
+        removed = before - len(active_tool_callables)
+        if removed:
+            logger.info(
+                "read_only constraint removed %d write tool(s) "
+                "for goal_based skill '%s'",
+                removed, skill.title,
+            )
 
     return SessionConfig(
         model=model,
@@ -1413,6 +1444,47 @@ async def _build_system_prompt(
             "email depends on search"
         )
         parts.append(parallel_guidance)
+
+    # ---- Goal-Based Skill context (Issue #448) ----------------------------
+    # When the session has a goal_based skill selected, inject the goal,
+    # constraints, and success criteria so the agent knows what to achieve.
+    skill_id = session_data.get("selected_skill_id")
+    if skill_id:
+        try:
+            result = await db.execute(select(Skill).where(Skill.id == skill_id))
+            skill_row = result.scalar_one_or_none()
+            if skill_row and skill_row.execution_type == "goal_based" and skill_row.goal:
+                goal_lines: list[str] = [
+                    "## Goal",
+                    "",
+                    skill_row.goal,
+                    "",
+                ]
+                if skill_row.constraints:
+                    goal_lines.append("## Constraints")
+                    goal_lines.append("")
+                    if isinstance(skill_row.constraints, list):
+                        for c in skill_row.constraints:
+                            goal_lines.append(f"- {c}")
+                    else:
+                        goal_lines.append(str(skill_row.constraints))
+                    goal_lines.append("")
+                if skill_row.success_criteria:
+                    goal_lines.append("## Success Criteria")
+                    goal_lines.append("")
+                    goal_lines.append(skill_row.success_criteria)
+                    goal_lines.append("")
+
+                goal_lines.append(
+                    "Work autonomously toward this goal. "
+                    "Plan your approach step by step. "
+                    "Report progress as you go. "
+                    "When you have achieved the goal, call "
+                    "`task_complete(summary=...)` to signal completion."
+                )
+                parts.append("\n".join(goal_lines))
+        except Exception:
+            logger.warning("Failed to load goal-based skill context", exc_info=True)
 
     if parts:
         return "\n\n---\n\n".join(parts)

--- a/backend/src/api/admin.py
+++ b/backend/src/api/admin.py
@@ -2335,6 +2335,10 @@ class AdminSkillCreate(BaseModel):
     cross_session_max_snippets: int = 3
     cross_session_min_score: float = 0.30
     a2a_metadata: dict | None = None
+    goal: str | None = None
+    constraints: list[str] | None = None
+    success_criteria: str | None = None
+    agent_config: dict | None = None
 
 
 class AdminSkillUpdate(BaseModel):
@@ -2354,6 +2358,10 @@ class AdminSkillUpdate(BaseModel):
     cross_session_max_snippets: int | None = None
     cross_session_min_score: float | None = None
     a2a_metadata: dict | None = None
+    goal: str | None = None
+    constraints: list[str] | None = None
+    success_criteria: str | None = None
+    agent_config: dict | None = None
 
 
 class AdminSkillResponse(BaseModel):
@@ -2373,6 +2381,10 @@ class AdminSkillResponse(BaseModel):
     cross_session_max_snippets: int
     a2a_metadata: dict | None = None
     cross_session_min_score: float
+    goal: str | None = None
+    constraints: list[str] | None = None
+    success_criteria: str | None = None
+    agent_config: dict | None = None
     created_at: datetime
     updated_at: datetime
     tool_ids: list[str] = []
@@ -2457,6 +2469,10 @@ async def admin_create_skill(
         cross_session_max_snippets=body.cross_session_max_snippets,
         cross_session_min_score=body.cross_session_min_score,
         a2a_metadata=body.a2a_metadata,
+        goal=body.goal,
+        constraints=body.constraints,
+        success_criteria=body.success_criteria,
+        agent_config=body.agent_config,
     )
     tools = await _svc_list_skill_tools(db, skill.id)
     resp = AdminSkillResponse.model_validate(skill)

--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -1192,6 +1192,31 @@ async def send_message(
                 "Please wait for one to complete or cancel it before starting another."
             )
 
+    # ---- Goal-Based Skill implies autopilot (Issue #448) -----------------
+    _goal_based_goal: str | None = None
+    _goal_based_max_turns: int | None = None
+    skill_id = data.get("selected_skill_id")
+    if skill_id and not (body.autopilot is False and body.background is False):
+        try:
+            from ..db.orm.skills import Skill as SkillORM
+            from sqlalchemy import select as _sa_select
+            _skill_result = await db.execute(
+                _sa_select(SkillORM).where(SkillORM.id == skill_id)
+            )
+            _skill = _skill_result.scalar_one_or_none()
+            if _skill and _skill.execution_type == "goal_based" and _skill.goal:
+                # Auto-enable autopilot for goal-based skills
+                body.autopilot = True
+                _goal_based_goal = _skill.goal
+                if _skill.agent_config:
+                    _goal_based_max_turns = _skill.agent_config.get("max_turns")
+                logger.info(
+                    "Goal-based skill '%s' auto-enabled autopilot",
+                    _skill.title,
+                )
+        except Exception:
+            logger.warning("Failed to check goal-based skill", exc_info=True)
+
     # ---- Inject file content into user message --------------------------
     file_ids = body.file_ids or []
     modified_message, valid_file_ids = await _inject_file_content(
@@ -1220,6 +1245,8 @@ async def send_message(
                 db=db,
                 current_user=current_user,
                 modified_message=modified_message,
+                goal_override=_goal_based_goal,
+                max_turns_override=_goal_based_max_turns,
             )
 
         return await _handle_streaming_message(
@@ -1245,11 +1272,13 @@ async def send_message(
             )
         from ..agents.autopilot import run_autopilot
 
+        autopilot_goal = _goal_based_goal or modified_message
         response_text, assistant_msg_id = await run_autopilot(
             session_data=data,
-            goal=modified_message,
+            goal=autopilot_goal,
             db=db,
             current_user=current_user,
+            max_turns=_goal_based_max_turns,
         )
     else:
         response_text, assistant_msg_id = await run_agent(
@@ -1877,6 +1906,8 @@ async def _handle_streaming_autopilot(
     db: AsyncSession,
     current_user: UserORM,
     modified_message: str = "",
+    goal_override: str | None = None,
+    max_turns_override: int | None = None,
 ) -> EventSourceResponse:
     """Send a message in autopilot mode and run the meta-loop in the
     background, returning SSE.
@@ -1889,8 +1920,13 @@ async def _handle_streaming_autopilot(
     **Important**: The user's original message is persisted to the DB
     **before** the background task starts so it is immediately visible
     in the sidebar and survives page refresh / navigation away.
+
+    When *goal_override* is provided (from a Goal-Based Skill), the
+    autopilot goal is set to the skill's goal text while the user's
+    original message is preserved as-is in the conversation history.
     """
     _user_message = modified_message or body.content
+    _autopilot_goal = goal_override or _user_message
 
     # Persist the user's original message immediately so it's in the DB
     # before any autopilot turn starts.  This ensures the session title
@@ -1909,9 +1945,10 @@ async def _handle_streaming_autopilot(
     _spawn_autopilot_background(
         session_id=session_id,
         data=data,
-        user_message=_user_message,
+        user_message=_autopilot_goal,
         current_user=current_user,
         bridge=bridge,
+        max_turns=max_turns_override,
         background=body.background,
     )
 

--- a/backend/src/api/skills.py
+++ b/backend/src/api/skills.py
@@ -40,6 +40,10 @@ class SkillCreate(BaseModel):
     cross_session_max_snippets: int = 3
     cross_session_min_score: float = 0.30
     a2a_metadata: dict | None = None
+    goal: str | None = None
+    constraints: list[str] | None = None
+    success_criteria: str | None = None
+    agent_config: dict | None = None
 
 
 class SkillUpdate(BaseModel):
@@ -56,6 +60,10 @@ class SkillUpdate(BaseModel):
     cross_session_max_snippets: int | None = None
     cross_session_min_score: float | None = None
     a2a_metadata: dict | None = None
+    goal: str | None = None
+    constraints: list[str] | None = None
+    success_criteria: str | None = None
+    agent_config: dict | None = None
 
 
 class SkillResponse(BaseModel):
@@ -75,6 +83,10 @@ class SkillResponse(BaseModel):
     cross_session_max_snippets: int
     cross_session_min_score: float
     a2a_metadata: dict | None = None
+    goal: str | None = None
+    constraints: list[str] | None = None
+    success_criteria: str | None = None
+    agent_config: dict | None = None
     created_at: datetime
     updated_at: datetime
     tool_ids: list[str] = []
@@ -153,6 +165,10 @@ async def create_skill(
         cross_session_max_snippets=body.cross_session_max_snippets,
         cross_session_min_score=body.cross_session_min_score,
         a2a_metadata=body.a2a_metadata,
+        goal=body.goal,
+        constraints=body.constraints,
+        success_criteria=body.success_criteria,
+        agent_config=body.agent_config,
     )
     tools = await _svc_list_skill_tools(db, skill.id)
     resp = SkillResponse.model_validate(skill)

--- a/backend/src/db/migrations/versions/a5b6c7d8e9f0_add_goal_based_skill_type.py
+++ b/backend/src/db/migrations/versions/a5b6c7d8e9f0_add_goal_based_skill_type.py
@@ -1,0 +1,86 @@
+"""add_goal_based_skill_type
+
+Add ``goal_based`` to ``skill_execution_enum`` and add 4 new nullable
+columns to the ``skills`` table for Goal-Based Skills (Issue #448):
+
+- ``goal`` (Text) — the objective the agent should achieve
+- ``constraints`` (JSON) — behavioral constraints (e.g. read_only, max_cost)
+- ``success_criteria`` (Text) — how to determine the task is complete
+- ``agent_config`` (JSON) — per-skill agent overrides (max_turns, model)
+
+Revision ID: a5b6c7d8e9f0
+Revises: a1b2c3d4e5f8
+Create Date: 2026-07-23
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a5b6c7d8e9f0"
+down_revision: Union[str, None] = "a1b2c3d4e5f8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. Expand execution_type enum to include goal_based
+    op.execute(
+        "ALTER TABLE skills MODIFY COLUMN execution_type "
+        "ENUM('agent','workflow','prompt_based','workflow_based','goal_based') NOT NULL"
+    )
+
+    # 2. Add new nullable columns
+    op.add_column(
+        "skills",
+        sa.Column(
+            "goal",
+            sa.Text(),
+            nullable=True,
+            comment="The objective the agent should achieve (Goal-Based Skills)",
+        ),
+    )
+    op.add_column(
+        "skills",
+        sa.Column(
+            "constraints",
+            sa.JSON(),
+            nullable=True,
+            comment="Behavioral constraints as JSON array, e.g. [\"read_only\"]",
+        ),
+    )
+    op.add_column(
+        "skills",
+        sa.Column(
+            "success_criteria",
+            sa.Text(),
+            nullable=True,
+            comment="How to determine the task is complete",
+        ),
+    )
+    op.add_column(
+        "skills",
+        sa.Column(
+            "agent_config",
+            sa.JSON(),
+            nullable=True,
+            comment="Agent overrides: {max_turns, model}",
+        ),
+    )
+
+
+def downgrade() -> None:
+    # 1. Drop new columns
+    op.drop_column("skills", "agent_config")
+    op.drop_column("skills", "success_criteria")
+    op.drop_column("skills", "constraints")
+    op.drop_column("skills", "goal")
+
+    # 2. Revert execution_type enum to previous set
+    op.execute(
+        "ALTER TABLE skills MODIFY COLUMN execution_type "
+        "ENUM('agent','workflow','prompt_based','workflow_based') NOT NULL"
+    )

--- a/backend/src/db/orm/skills.py
+++ b/backend/src/db/orm/skills.py
@@ -33,7 +33,7 @@ class Skill(Base):
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str | None] = mapped_column(String(1024), nullable=True)
     execution_type: Mapped[str] = mapped_column(
-        Enum("agent", "workflow", "prompt_based", "workflow_based", name="skill_execution_enum"), nullable=False
+        Enum("agent", "workflow", "prompt_based", "workflow_based", "goal_based", name="skill_execution_enum"), nullable=False
     )
     maf_target_key: Mapped[str | None] = mapped_column(String(255), nullable=True)
     template_id: Mapped[str | None] = mapped_column(

--- a/backend/src/db/orm/skills.py
+++ b/backend/src/db/orm/skills.py
@@ -5,7 +5,7 @@
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import String, Boolean, Integer, Float, DateTime, Enum, ForeignKey, JSON, func
+from sqlalchemy import String, Boolean, Integer, Float, DateTime, Enum, ForeignKey, JSON, Text, func
 from sqlalchemy.dialects.mysql import CHAR
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -65,6 +65,24 @@ class Skill(Base):
     a2a_metadata: Mapped[dict | None] = mapped_column(
         JSON, nullable=True,
         comment="A2A Agent Card per-skill metadata: {inputModes, outputModes, examples, tags}",
+    )
+
+    # ---- Goal-Based Skill fields (Issue #448) ------------------------------
+    goal: Mapped[str | None] = mapped_column(
+        Text, nullable=True,
+        comment="The objective the agent should achieve",
+    )
+    constraints: Mapped[dict | None] = mapped_column(
+        JSON, nullable=True,
+        comment="Behavioral constraints, e.g. [\"read_only\"]",
+    )
+    success_criteria: Mapped[str | None] = mapped_column(
+        Text, nullable=True,
+        comment="How to determine the task is complete",
+    )
+    agent_config: Mapped[dict | None] = mapped_column(
+        JSON, nullable=True,
+        comment="Agent overrides: {max_turns, model}",
     )
 
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/src/services/skill_service.py
+++ b/backend/src/services/skill_service.py
@@ -141,6 +141,10 @@ async def create_skill(
     cross_session_max_snippets: int = 3,
     cross_session_min_score: float = 0.30,
     a2a_metadata: dict | None = None,
+    goal: str | None = None,
+    constraints: list[str] | None = None,
+    success_criteria: str | None = None,
+    agent_config: dict | None = None,
 ) -> Skill:
     """Create a new skill with optional tool associations.
 
@@ -166,6 +170,10 @@ async def create_skill(
         cross_session_max_snippets=cross_session_max_snippets,
         cross_session_min_score=cross_session_min_score,
         a2a_metadata=a2a_metadata,
+        goal=goal,
+        constraints=constraints,
+        success_criteria=success_criteria,
+        agent_config=agent_config,
     )
     db.add(skill)
     await db.flush()  # Get the skill ID before adding join rows

--- a/frontend/src/features/admin/resources/skills/SkillForm.tsx
+++ b/frontend/src/features/admin/resources/skills/SkillForm.tsx
@@ -212,6 +212,7 @@ export function SkillForm({ open, skill, duplicateFrom, onClose }: SkillFormProp
             options={[
               { label: "Prompt Based", value: "prompt_based" },
               { label: "Workflow Based", value: "workflow_based" },
+              { label: "Goal Based", value: "goal_based" },
             ]}
           />
         </Form.Item>
@@ -250,7 +251,7 @@ export function SkillForm({ open, skill, duplicateFrom, onClose }: SkillFormProp
             />
           </Form.Item>
         )}
-        {executionType !== "workflow_based" && (
+        {executionType !== "workflow_based" && executionType !== "goal_based" && (
           <Form.Item name="template_id" label="Template">
             <Select
               allowClear
@@ -262,6 +263,51 @@ export function SkillForm({ open, skill, duplicateFrom, onClose }: SkillFormProp
             />
           </Form.Item>
         )}
+
+        {executionType === "goal_based" && (
+          <>
+            <Form.Item
+              name="goal"
+              label="Goal"
+              rules={[{ required: true, message: "Please enter the goal" }]}
+              extra="The objective the agent should achieve"
+            >
+              <TextArea rows={4} placeholder="e.g., Diagnose why the supplier_rate report is showing incorrect values" />
+            </Form.Item>
+            <Form.Item
+              name="constraints"
+              label="Constraints"
+              extra="Behavioral constraints for the agent"
+            >
+              <Select
+                mode="multiple"
+                allowClear
+                placeholder="Select constraints"
+                options={[
+                  { label: "Read Only (no modifications)", value: "read_only" },
+                  { label: "Max Cost €0.50", value: "max_cost_€0.50" },
+                  { label: "Max Cost €1.00", value: "max_cost_€1.00" },
+                  { label: "Max Cost €5.00", value: "max_cost_€5.00" },
+                ]}
+              />
+            </Form.Item>
+            <Form.Item
+              name="success_criteria"
+              label="Success Criteria"
+              extra="How to determine the task is complete"
+            >
+              <TextArea rows={2} placeholder="e.g., Identify the root cause and propose a specific fix" />
+            </Form.Item>
+            <Form.Item
+              name={["agent_config", "max_turns"]}
+              label="Max Turns"
+              extra="Maximum agent turns before forced summarization (default: 20)"
+            >
+              <Input type="number" min={1} max={50} placeholder="20" />
+            </Form.Item>
+          </>
+        )}
+
         <Form.Item name="default_model_id" label="Default Model">
           <Select
             allowClear

--- a/frontend/src/features/admin/resources/skills/SkillList.tsx
+++ b/frontend/src/features/admin/resources/skills/SkillList.tsx
@@ -91,7 +91,23 @@ export function SkillList() {
       dataIndex: "execution_type",
       key: "execution_type",
       sorter: true,
-      render: (v: string) => <Tag color="blue">{v}</Tag>,
+      render: (v: string) => {
+        const colorMap: Record<string, string> = {
+          agent: "blue",
+          prompt_based: "blue",
+          workflow: "orange",
+          workflow_based: "orange",
+          goal_based: "green",
+        };
+        const labelMap: Record<string, string> = {
+          agent: "Agent",
+          prompt_based: "Prompt Based",
+          workflow: "Workflow",
+          workflow_based: "Workflow Based",
+          goal_based: "Goal Based",
+        };
+        return <Tag color={colorMap[v] || "default"}>{labelMap[v] || v}</Tag>;
+      },
     },
     {
       title: "MAF Key",
@@ -184,12 +200,13 @@ export function SkillList() {
         <Select
           placeholder="Type"
           allowClear
-          style={{ width: 140 }}
+          style={{ width: 150 }}
           value={params.execution_type as string | undefined}
           onChange={(value) => updateParams({ execution_type: value, page: 1 })}
           options={[
             { label: "Agent", value: "agent" },
             { label: "Workflow", value: "workflow" },
+            { label: "Goal Based", value: "goal_based" },
           ]}
         />
         <Select

--- a/frontend/src/features/admin/services/admin.ts
+++ b/frontend/src/features/admin/services/admin.ts
@@ -162,6 +162,10 @@ export interface SkillData {
   cross_session_retrieval_enabled?: boolean;
   cross_session_max_snippets?: number;
   cross_session_min_score?: number;
+  goal?: string;
+  constraints?: string[];
+  success_criteria?: string;
+  agent_config?: { max_turns?: number; model?: string };
 }
 
 export interface UsageData {

--- a/frontend/src/features/chat/components/PersonalSkillEditor.tsx
+++ b/frontend/src/features/chat/components/PersonalSkillEditor.tsx
@@ -243,6 +243,7 @@ export function PersonalSkillEditor({
                 options={[
                   { label: "Prompt Based", value: "prompt_based" },
                   { label: "Workflow Based", value: "workflow_based" },
+                  { label: "Goal Based", value: "goal_based" },
                 ]}
               />
             </Form.Item>
@@ -256,7 +257,7 @@ export function PersonalSkillEditor({
                 <Input placeholder="e.g., invoice_processing" />
               </Form.Item>
             )}
-            {executionType !== "workflow_based" && (
+            {executionType !== "workflow_based" && executionType !== "goal_based" && (
               <Form.Item name="template_id" label="Template">
                 <Select
                   allowClear
@@ -267,6 +268,49 @@ export function PersonalSkillEditor({
                   }))}
                 />
               </Form.Item>
+            )}
+            {executionType === "goal_based" && (
+              <>
+                <Form.Item
+                  name="goal"
+                  label="Goal"
+                  rules={[{ required: true, message: "Please enter the goal" }]}
+                  extra="The objective the agent should achieve"
+                >
+                  <TextArea rows={4} placeholder="e.g., Diagnose why the supplier_rate report is showing incorrect values" />
+                </Form.Item>
+                <Form.Item
+                  name="constraints"
+                  label="Constraints"
+                  extra="Behavioral constraints for the agent"
+                >
+                  <Select
+                    mode="multiple"
+                    allowClear
+                    placeholder="Select constraints"
+                    options={[
+                      { label: "Read Only (no modifications)", value: "read_only" },
+                      { label: "Max Cost €0.50", value: "max_cost_€0.50" },
+                      { label: "Max Cost €1.00", value: "max_cost_€1.00" },
+                      { label: "Max Cost €5.00", value: "max_cost_€5.00" },
+                    ]}
+                  />
+                </Form.Item>
+                <Form.Item
+                  name="success_criteria"
+                  label="Success Criteria"
+                  extra="How to determine the task is complete"
+                >
+                  <TextArea rows={2} placeholder="e.g., Identify the root cause and propose a specific fix" />
+                </Form.Item>
+                <Form.Item
+                  name={["agent_config", "max_turns"]}
+                  label="Max Turns"
+                  extra="Maximum agent turns before forced summarization (default: 20)"
+                >
+                  <Input type="number" min={1} max={50} placeholder="20" />
+                </Form.Item>
+              </>
             )}
             <Space>
               <Button onClick={() => setView("list")}>Cancel</Button>

--- a/frontend/src/features/chat/components/SkillSelector.tsx
+++ b/frontend/src/features/chat/components/SkillSelector.tsx
@@ -38,6 +38,10 @@ interface SkillData {
   created_at: string;
   updated_at: string;
   tool_ids: string[];
+  goal?: string;
+  constraints?: string[];
+  success_criteria?: string;
+  agent_config?: { max_turns?: number; model?: string };
 }
 
 interface SkillSelectorProps {
@@ -76,6 +80,11 @@ export function SkillSelector({
               label: (
                 <Space size={4}>
                   {s.title}
+                  {s.execution_type === "goal_based" && (
+                    <Tag color="green" style={{ fontSize: 11, lineHeight: "18px", margin: 0 }}>
+                      Goal
+                    </Tag>
+                  )}
                   {s.tool_ids && s.tool_ids.length > 0 && (
                     <Tag color="blue" style={{ fontSize: 11, lineHeight: "18px", margin: 0 }}>
                       {s.tool_ids.length} tool{s.tool_ids.length !== 1 ? "s" : ""}


### PR DESCRIPTION
## Description

Introduces a third skill type — Goal-Based Skills — that allows users to define an objective, constraints, and success criteria. The agent autonomously plans and executes to achieve the goal, rather than following a fixed prompt or predefined workflow. Includes database migration for new columns (goal, constraints, success_criteria, agent_config), backend logic to auto-enable autopilot, inject goal context into system prompts, and filter tools based on read_only constraint. Frontend updates add goal-based skill creation forms and display tags.

## Related Issue

Closes #448

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Testing

- [x] Tested locally with Docker Compose (dev)
- [x] Backend tests pass (pytest backend/tests/ -m "not e2e and not slow")
- [x] Frontend builds without errors (npm run build)
- [x] Manual testing completed (created goal-based skills, verified autopilot with goal injection, tool filtering)

## Checklist

- [x] My code follows the coding conventions of this project
- [x] I have self-reviewed my own code
- [x] I have commented complex code sections, particularly in hard-to-understand areas
- [x] I have updated the documentation (docs/) if my change affects user-facing behaviour or configuration
- [x] My changes generate no new warnings or errors
- [x] New and existing tests pass locally

## Additional Notes

The new execution_type "goal_based" is added to the skill enum. When a goal-based skill is selected, autopilot is automatically enabled, the goal, constraints, and success criteria are injected into the system prompt, and tools with write prefixes are removed if "read_only" constraint is set.

