### PR TITLE
Add batch delete for chat sessions in sidebar and admin panel

### DIFF
--- a/backend/src/api/admin.py
+++ b/backend/src/api/admin.py
@@ -30,6 +30,7 @@ from ..core.pagination import PaginatedResponse
 from ..core.redis import store_a2a_oauth_state
 from ..db.orm.users import User as UserORM
 from ..services.audit_service import list_audit_logs, write_audit_log
+from ..services import session_service
 from ..services.tenant_service import (
     count_tenants,
     create_tenant as _svc_create_tenant,
@@ -3229,6 +3230,81 @@ async def admin_delete_session(
         tenant_id=current_user.tenant_id,
         ip_address=_get_client_ip(request),
     )
+
+
+class AdminBatchDeleteSessionsRequest(BaseModel):
+    """Request body for admin batch-deleting sessions. Max 100 per call."""
+    ids: list[str]
+
+
+@router.post("/sessions/delete")
+async def admin_delete_sessions_batch(
+    body: AdminBatchDeleteSessionsRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserORM = Depends(require_admin_or_manager),
+):
+    """Batch-delete sessions (admin/manager).
+
+    Admin: deletes any session. Manager: only sessions in own tenant.
+    Skips non-existent sessions and (for managers) cross-tenant sessions.
+    """
+    ids = body.ids
+    if not ids:
+        raise ValidationError("ids must be a non-empty list of session IDs")
+    if len(ids) > 100:
+        raise ValidationError("Cannot delete more than 100 sessions at once")
+
+    from ..db.orm.sessions import Session as SessionORM
+
+    result = await db.execute(
+        select(SessionORM).where(SessionORM.id.in_(ids))
+    )
+    sessions = list(result.scalars().all())
+    found_ids = {s.id for s in sessions}
+
+    db_session_ids: list[str] = []
+    skipped: list[dict] = []
+
+    for sid in ids:
+        if sid not in found_ids:
+            skipped.append({"id": sid, "reason": "Session not found"})
+            continue
+        if current_user.role == "manager":
+            s = next(s for s in sessions if s.id == sid)
+            if s.tenant_id != current_user.tenant_id:
+                skipped.append({"id": sid, "reason": "Session belongs to a different tenant"})
+                continue
+        db_session_ids.append(sid)
+
+    if not db_session_ids:
+        return {"deleted": 0, "skipped": skipped, "errors": []}
+
+    await session_service.delete_sessions_batch(
+        db=db,
+        session_ids=db_session_ids,
+        user_id=current_user.id,
+        tenant_id=current_user.tenant_id,
+        admin_override=True,
+    )
+
+    # Write audit log for each deleted session
+    for sid in db_session_ids:
+        await write_audit_log(
+            db,
+            actor=current_user,
+            action="session.deleted",
+            target_type="session",
+            target_id=sid,
+            tenant_id=current_user.tenant_id,
+            ip_address=_get_client_ip(request),
+        )
+
+    return {
+        "deleted": len(db_session_ids),
+        "skipped": skipped,
+        "errors": [],
+    }
 
 
 # =============================================================================

--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -101,6 +101,15 @@ class SessionUpdate(BaseModel):
     auto_select_tools: bool | None = None
 
 
+class BatchDeleteSessionsRequest(BaseModel):
+    """Request body for batch-deleting sessions.
+
+    Accepts a list of session IDs.  Max 100 sessions per call.
+    """
+
+    ids: list[str]
+
+
 class TagResponse(BaseModel):
     id: str
     name: str
@@ -898,6 +907,39 @@ async def delete_session(
         await delete_temp_session(session_id)
     else:
         await session_service.delete_session(db, session_id)
+
+
+@router.post("/sessions/delete")
+async def delete_sessions_batch(
+    body: BatchDeleteSessionsRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserORM = Depends(get_current_user),
+):
+    """Batch-delete multiple sessions (DB and/or Redis).
+
+    Accepts up to 100 session IDs.  Returns a structured response with
+    counts of deleted / skipped / errored sessions.
+
+    Skips (rather than fails) sessions that don't exist or aren't owned
+    by the current user, so that a batch of 10 where 1 is unauthorized
+    still deletes the other 9.
+    """
+    ids = body.ids
+
+    if not ids:
+        raise ValidationError("ids must be a non-empty list of session IDs")
+
+    if len(ids) > 100:
+        raise ValidationError("Cannot delete more than 100 sessions at once")
+
+    result = await session_service.delete_sessions_batch(
+        db=db,
+        session_ids=ids,
+        user_id=current_user.id,
+        tenant_id=current_user.tenant_id,
+    )
+
+    return result
 
 
 @router.post("/session/{session_id}/finalize", response_model=SessionResponse)

--- a/backend/src/services/session_service.py
+++ b/backend/src/services/session_service.py
@@ -399,6 +399,7 @@ async def delete_sessions_batch(
     session_ids: list[str],
     user_id: str,
     tenant_id: str,
+    admin_override: bool = False,
 ) -> dict:
     """Delete multiple sessions by ID in a single transaction.
 
@@ -408,6 +409,9 @@ async def delete_sessions_batch(
       - ``skipped``: list of ``{"id": str, "reason": str}`` for sessions that
         could not be deleted (not found, not owned, streaming, already temp)
       - ``errors``: list of ``{"id": str, "error": str}`` for unexpected errors
+
+    When ``admin_override=True``, skips user ownership checks (the caller is
+    responsible for any authorization, e.g. manager tenant scoping).
 
     The function processes DB sessions in bulk using ``.in_(session_ids)``
     for FK-dependent tables (same cascade pattern as ``_purge_empty_sessions``),
@@ -432,10 +436,10 @@ async def delete_sessions_batch(
         # Try DB lookup first
         session_orm = await get_session_by_id(db, sid)
         if session_orm is not None:
-            if session_orm.user_id != user_id:
+            if not admin_override and session_orm.user_id != user_id:
                 skipped.append({"id": sid, "reason": "Not owned by current user"})
                 continue
-            if session_orm.tenant_id != tenant_id:
+            if not admin_override and session_orm.tenant_id != tenant_id:
                 skipped.append({"id": sid, "reason": "Session belongs to a different tenant"})
                 continue
             db_session_ids.append(sid)
@@ -446,10 +450,10 @@ async def delete_sessions_batch(
         if temp is not None:
             t_user = temp.get("user_id")
             t_tenant = temp.get("tenant_id")
-            if t_user != user_id:
+            if not admin_override and t_user != user_id:
                 skipped.append({"id": sid, "reason": "Not owned by current user"})
                 continue
-            if t_tenant != tenant_id:
+            if not admin_override and t_tenant != tenant_id:
                 skipped.append({"id": sid, "reason": "Session belongs to a different tenant"})
                 continue
             temp_session_ids.append(sid)

--- a/backend/src/services/session_service.py
+++ b/backend/src/services/session_service.py
@@ -394,6 +394,170 @@ async def delete_session(db: AsyncSession, session_id: str) -> None:
     await db.commit()
 
 
+async def delete_sessions_batch(
+    db: AsyncSession,
+    session_ids: list[str],
+    user_id: str,
+    tenant_id: str,
+) -> dict:
+    """Delete multiple sessions by ID in a single transaction.
+
+    For each ID, checks existence and ownership.  Separates DB (permanent)
+    sessions from Redis (temporary) sessions.  Returns a dict with:
+      - ``deleted``: number of sessions successfully deleted
+      - ``skipped``: list of ``{"id": str, "reason": str}`` for sessions that
+        could not be deleted (not found, not owned, streaming, already temp)
+      - ``errors``: list of ``{"id": str, "error": str}`` for unexpected errors
+
+    The function processes DB sessions in bulk using ``.in_(session_ids)``
+    for FK-dependent tables (same cascade pattern as ``_purge_empty_sessions``),
+    then handles temp (Redis) sessions one at a time.
+    """
+    from sqlalchemy import delete as sa_delete
+    from ..core.redis import delete_temp_session, get_temp_session
+    from ..db.orm.messages import Message, MessageFeedback
+    from ..db.orm.sessions import SessionActiveTool as SAT
+    from ..db.orm.file_uploads import FileUpload
+    from ..db.orm.memory import Memory
+    from ..db.orm.tags import SessionTag
+    from ..services import upload_service
+
+    skipped: list[dict] = []
+    errors: list[dict] = []
+    db_session_ids: list[str] = []
+    temp_session_ids: list[str] = []
+
+    # --- Phase 1: Validate each session ---
+    for sid in session_ids:
+        # Try DB lookup first
+        session_orm = await get_session_by_id(db, sid)
+        if session_orm is not None:
+            if session_orm.user_id != user_id:
+                skipped.append({"id": sid, "reason": "Not owned by current user"})
+                continue
+            if session_orm.tenant_id != tenant_id:
+                skipped.append({"id": sid, "reason": "Session belongs to a different tenant"})
+                continue
+            db_session_ids.append(sid)
+            continue
+
+        # Try Redis (temporary session)
+        temp = await get_temp_session(sid)
+        if temp is not None:
+            t_user = temp.get("user_id")
+            t_tenant = temp.get("tenant_id")
+            if t_user != user_id:
+                skipped.append({"id": sid, "reason": "Not owned by current user"})
+                continue
+            if t_tenant != tenant_id:
+                skipped.append({"id": sid, "reason": "Session belongs to a different tenant"})
+                continue
+            temp_session_ids.append(sid)
+            continue
+
+        # Not found anywhere
+        skipped.append({"id": sid, "reason": "Session not found"})
+
+    # --- Phase 2: Delete DB (permanent) sessions ---
+    if db_session_ids:
+        # Collect all message IDs across all targeted sessions
+        msg_result = await db.execute(
+            select(Message.id).where(Message.session_id.in_(db_session_ids))
+        )
+        all_message_ids = [row[0] for row in msg_result.all()]
+
+        # 0. Delete autopilot runs
+        await db.execute(
+            sa_delete(AutopilotRun).where(AutopilotRun.session_id.in_(db_session_ids))
+        )
+
+        # 1. Delete file uploads BEFORE messages
+        for sid in db_session_ids:
+            await upload_service.delete_uploads_for_session(db, sid)
+
+        # 2. Delete message feedbacks
+        if all_message_ids:
+            await db.execute(
+                sa_delete(MessageFeedback).where(
+                    MessageFeedback.message_id.in_(all_message_ids)
+                )
+            )
+            await db.flush()
+
+        # 3. Delete messages
+        await db.execute(
+            sa_delete(Message).where(Message.session_id.in_(db_session_ids))
+        )
+        await db.flush()
+
+        # 4. Delete active tool associations
+        await db.execute(
+            sa_delete(SAT).where(SAT.session_id.in_(db_session_ids))
+        )
+        await db.flush()
+
+        # 5. Delete session tags
+        await db.execute(
+            sa_delete(SessionTag).where(SessionTag.session_id.in_(db_session_ids))
+        )
+        await db.flush()
+
+        # 6. Delete session-scoped memories
+        await db.execute(
+            sa_delete(Memory).where(Memory.session_id.in_(db_session_ids))
+        )
+        await db.flush()
+
+        # 7. Delete the session rows
+        for sid in db_session_ids:
+            session_orm = await get_session_by_id(db, sid)
+            if session_orm is not None:
+                db.expire(session_orm, ["tags"])
+                await db.delete(session_orm)
+
+        await db.flush()
+
+    # --- Phase 3: Delete temp (Redis) sessions ---
+    for sid in temp_session_ids:
+        try:
+            # Clean up file uploads before deleting Redis keys
+            temp = await get_temp_session(sid)
+            if temp:
+                uploaded_ids: list[str] = temp.get("uploaded_file_ids", [])
+                for file_id in uploaded_ids:
+                    await upload_service._delete_temp_upload_by_id(db, file_id)
+            await delete_temp_session(sid)
+        except Exception as exc:
+            errors.append({"id": sid, "error": str(exc)})
+            temp_session_ids.remove(sid)
+
+    # --- Phase 4: Commit and finalize ---
+    if db_session_ids:
+        try:
+            await db.commit()
+        except Exception as exc:
+            await db.rollback()
+            errors.append({"id": "batch", "error": f"Transaction failed: {exc}"})
+            # Reconstruct skipped from what we tried
+            deleted_count = 0
+            for sid in db_session_ids:
+                skipped.insert(0, {"id": sid, "reason": "Transaction rolled back"})
+            db_session_ids = []
+            return {
+                "deleted": deleted_count,
+                "skipped": skipped,
+                "errors": errors,
+            }
+
+    deleted_count = len(db_session_ids) + len(temp_session_ids)
+
+    return {
+        "deleted": deleted_count,
+        "skipped": skipped,
+        "errors": errors,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Session active tool management
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_chat_api.py
+++ b/backend/tests/test_chat_api.py
@@ -527,6 +527,152 @@ class TestDeleteSession:
         assert resp.status_code == 403
 
 
+class TestBatchDeleteSessions:
+    """Tests for POST /chat/sessions/delete."""
+
+    async def test_batch_delete_multiple_sessions(
+        self,
+        async_client,
+        auth_headers,
+        test_user,
+        test_tenant,
+        test_model,
+        db_session,
+    ):
+        """Verify deleting multiple sessions at once."""
+        from src.db.orm.sessions import Session
+
+        # Create 3 sessions owned by test_user
+        sessions = []
+        for i in range(3):
+            s = Session(
+                id=str(uuid.uuid4()),
+                tenant_id=test_tenant.id,
+                user_id=test_user.id,
+                title=f"Session {i}",
+                selected_model_id=test_model.id,
+            )
+            db_session.add(s)
+            sessions.append(s)
+        await db_session.flush()
+        session_ids = [s.id for s in sessions]
+
+        headers = auth_headers(test_user)
+        resp = await async_client.post(
+            "/api/chat/sessions/delete",
+            json={"ids": session_ids},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["deleted"] == 3
+        assert data["skipped"] == []
+        assert data["errors"] == []
+
+        # Verify all sessions are gone
+        for sid in session_ids:
+            get_resp = await async_client.get(
+                f"/api/chat/session/{sid}", headers=headers
+            )
+            assert get_resp.status_code == 404
+
+    async def test_batch_delete_partial_skip_unauthorized(
+        self,
+        async_client,
+        auth_headers,
+        test_user,
+        second_user,
+        test_tenant,
+        test_session,
+        test_model,
+        db_session,
+    ):
+        """Verify batch skips sessions not owned by the current user."""
+        from src.db.orm.sessions import Session
+
+        # second_user's session (should be skipped)
+        other_session = Session(
+            id=str(uuid.uuid4()),
+            tenant_id=test_tenant.id,
+            user_id=second_user.id,
+            title="Other User Session",
+            selected_model_id=test_model.id,
+        )
+        db_session.add(other_session)
+        await db_session.flush()
+
+        # Mix of owned + not-owned + non-existent
+        ids = [test_session.id, other_session.id, str(uuid.uuid4())]
+
+        headers = auth_headers(test_user)
+        resp = await async_client.post(
+            "/api/chat/sessions/delete",
+            json={"ids": ids},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["deleted"] == 1  # Only test_session
+        assert len(data["skipped"]) == 2  # other_session + non-existent
+        assert data["errors"] == []
+
+        # Verify own session is gone
+        get_resp = await async_client.get(
+            f"/api/chat/session/{test_session.id}", headers=headers
+        )
+        assert get_resp.status_code == 404
+
+    async def test_batch_delete_empty_ids_rejected(
+        self, async_client, auth_headers, test_user
+    ):
+        """Verify empty ids list returns validation error."""
+        headers = auth_headers(test_user)
+        resp = await async_client.post(
+            "/api/chat/sessions/delete",
+            json={"ids": []},
+            headers=headers,
+        )
+        assert resp.status_code == 422
+
+    async def test_batch_delete_too_many_ids_rejected(
+        self, async_client, auth_headers, test_user
+    ):
+        """Verify more than 100 ids returns validation error."""
+        headers = auth_headers(test_user)
+        ids = [str(uuid.uuid4()) for _ in range(101)]
+        resp = await async_client.post(
+            "/api/chat/sessions/delete",
+            json={"ids": ids},
+            headers=headers,
+        )
+        assert resp.status_code == 422
+
+    async def test_batch_delete_cross_tenant_skips(
+        self,
+        async_client,
+        auth_headers,
+        test_user,
+        second_user,
+        test_session,
+    ):
+        """Verify cross-tenant sessions are skipped."""
+        # second_user is in a different tenant, so test_session's tenant
+        # doesn't match second_user's tenant
+        headers = auth_headers(second_user)
+        resp = await async_client.post(
+            "/api/chat/sessions/delete",
+            json={"ids": [test_session.id]},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["deleted"] == 0
+        assert len(data["skipped"]) == 1
+        # Should be skipped because of tenant mismatch (second_user has
+        # a different tenant_id)
+        assert data["skipped"][0]["id"] == test_session.id
+
+
 # =============================================================================
 # Message Tests  (with mocked agent runner)
 # =============================================================================

--- a/backend/tests/test_session_service.py
+++ b/backend/tests/test_session_service.py
@@ -705,6 +705,157 @@ class TestSessionDeleteCascade:
             await delete_session(db_session, str(uuid.uuid4()))
 
 
+class TestBatchDeleteSessions:
+    """Verify delete_sessions_batch cascade behavior."""
+
+    async def test_batch_delete_cleans_all_references(
+        self,
+        db_session: AsyncSession,
+        test_tenant,
+        test_user,
+        test_tool,
+        test_model,
+    ):
+        """Batch delete should clean messages, tools, and tags for all sessions."""
+        from src.db.orm.models import Model as ModelORM
+        from src.db.orm.sessions import Session
+        from src.db.orm.messages import Message
+        from src.services.session_service import (
+            add_session_tool,
+            add_tag_to_session,
+            delete_sessions_batch,
+            get_or_create_tag,
+            get_session_by_id,
+            get_session_tools,
+            get_session_tags,
+        )
+
+        # Create 2 sessions with messages, tools, and tags
+        sessions = []
+        for i in range(2):
+            s = Session(
+                id=str(uuid.uuid4()),
+                tenant_id=test_tenant.id,
+                user_id=test_user.id,
+                title=f"Session {i}",
+                selected_model_id=test_model.id,
+            )
+            db_session.add(s)
+            sessions.append(s)
+        await db_session.flush()
+
+        for s in sessions:
+            # Add a message
+            msg = Message(
+                id=str(uuid.uuid4()),
+                session_id=s.id,
+                sender="user",
+                content=[{"type": "text", "text": f"test {s.id}"}],
+            )
+            db_session.add(msg)
+            # Add a tool
+            await add_session_tool(db_session, s.id, test_tool.id, test_tenant.id)
+            # Add a tag
+            tag = await get_or_create_tag(db_session, test_tenant.id, f"tag-{s.id[:8]}")
+            await add_tag_to_session(db_session, s.id, tag.id)
+
+        await db_session.flush()
+        session_ids = [s.id for s in sessions]
+
+        # Delete batch
+        result = await delete_sessions_batch(
+            db_session, session_ids, test_user.id, test_tenant.id
+        )
+
+        assert result["deleted"] == 2
+        assert result["skipped"] == []
+        assert result["errors"] == []
+
+        # Verify all sessions gone
+        for sid in session_ids:
+            assert await get_session_by_id(db_session, sid) is None
+            # Verify messages gone
+            msgs = await db_session.execute(
+                select(Message).where(Message.session_id == sid)
+            )
+            assert list(msgs.scalars().all()) == []
+            # Verify tools gone
+            tools = await get_session_tools(db_session, sid)
+            assert tools == []
+            # Verify tags gone
+            tags = await get_session_tags(db_session, sid)
+            assert tags == []
+
+    async def test_batch_delete_skips_unowned_sessions(
+        self,
+        db_session: AsyncSession,
+        test_tenant,
+        test_user,
+        test_model,
+        second_tenant,
+    ):
+        """Batch delete should skip sessions not owned by the user."""
+        from src.db.orm.sessions import Session
+        from src.db.orm.users import User
+        from src.services.session_service import delete_sessions_batch, get_session_by_id
+
+        # Create a session for another user
+        other_user = User(
+            id=str(uuid.uuid4()),
+            tenant_id=test_tenant.id,
+            email=f"other-{uuid.uuid4().hex[:8]}@example.com",
+            password_hash="pbkdf2:sha256:600000$test-salt$test-hash",
+            display_name="Other User",
+            role="user",
+            is_active=True,
+        )
+        db_session.add(other_user)
+        await db_session.flush()
+
+        other_session = Session(
+            id=str(uuid.uuid4()),
+            tenant_id=test_tenant.id,
+            user_id=other_user.id,
+            title="Other User Session",
+            selected_model_id=test_model.id,
+        )
+        db_session.add(other_session)
+        await db_session.flush()
+
+        result = await delete_sessions_batch(
+            db_session,
+            [other_session.id],
+            test_user.id,
+            test_tenant.id,
+        )
+
+        assert result["deleted"] == 0
+        assert len(result["skipped"]) == 1
+        assert result["skipped"][0]["id"] == other_session.id
+        assert "not owned" in result["skipped"][0]["reason"].lower()
+
+        # Verify other session still exists
+        assert await get_session_by_id(db_session, other_session.id) is not None
+
+    async def test_batch_delete_skips_nonexistent(
+        self,
+        db_session: AsyncSession,
+        test_tenant,
+        test_user,
+    ):
+        """Batch delete should skip non-existent sessions gracefully."""
+        from src.services.session_service import delete_sessions_batch
+
+        fake_id = str(uuid.uuid4())
+        result = await delete_sessions_batch(
+            db_session, [fake_id], test_user.id, test_tenant.id
+        )
+
+        assert result["deleted"] == 0
+        assert len(result["skipped"]) == 1
+        assert result["skipped"][0]["id"] == fake_id
+
+
 class TestListSessions:
     """Tests for list_sessions_for_user and list_admin_sessions."""
 

--- a/frontend/src/features/admin/resources/sessions/SessionList.tsx
+++ b/frontend/src/features/admin/resources/sessions/SessionList.tsx
@@ -20,6 +20,7 @@ import {
   Card,
   Typography,
   Select,
+  Modal,
 } from "antd";
 import {
   DeleteOutlined,
@@ -29,6 +30,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   listAdminSessions,
   deleteAdminSession,
+  deleteAdminSessions,
   listTenants,
   AdminSessionData,
 } from "../../services/admin";
@@ -45,6 +47,7 @@ export function SessionList() {
   const [searchText, setSearchText] = useState("");
   const [searchParams] = useSearchParams();
   const tenantId = searchParams.get("tenant_id") || undefined;
+  const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
 
   const debouncedSearch = useDebounce(searchText, 300);
 
@@ -70,6 +73,24 @@ export function SessionList() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["admin-sessions"] });
       message.success("Session deleted");
+    },
+  });
+
+  const batchDeleteMutation = useMutation({
+    mutationFn: (ids: string[]) => deleteAdminSessions(ids),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["admin-sessions"] });
+      if (data.deleted > 0) {
+        message.success(`Deleted ${data.deleted} session${data.deleted !== 1 ? "s" : ""}`);
+      }
+      if (data.skipped.length > 0) {
+        message.warning(`${data.skipped.length} session${data.skipped.length !== 1 ? "s" : ""} skipped`);
+      }
+      setSelectedRowKeys([]);
+    },
+    onError: (err: Error) => {
+      message.error(`Failed to delete sessions: ${err.message}`);
+      setSelectedRowKeys([]);
     },
   });
 
@@ -153,6 +174,23 @@ export function SessionList() {
     },
   ];
 
+  const rowSelection = {
+    selectedRowKeys,
+    onChange: (keys: React.Key[]) => setSelectedRowKeys(keys),
+  };
+
+  const handleBatchDelete = () => {
+    const ids = selectedRowKeys as string[];
+    Modal.confirm({
+      title: `Delete ${ids.length} session${ids.length !== 1 ? "s" : ""}?`,
+      content: `This will permanently delete ${ids.length} session${ids.length !== 1 ? "s" : ""} and all their messages. This action cannot be undone.`,
+      okText: "Delete",
+      okButtonProps: { danger: true },
+      cancelText: "Cancel",
+      onOk: () => batchDeleteMutation.mutate(ids),
+    });
+  };
+
   return (
     <div>
       <Space style={{ marginBottom: 16 }} wrap>
@@ -183,6 +221,20 @@ export function SessionList() {
             { label: "Not Pinned", value: "false" },
           ]}
         />
+        {selectedRowKeys.length > 0 && (
+          <>
+            <Text type="secondary">{selectedRowKeys.length} selected</Text>
+            <Button
+              type="primary"
+              danger
+              size="small"
+              loading={batchDeleteMutation.isPending}
+              onClick={handleBatchDelete}
+            >
+              Delete Selected
+            </Button>
+          </>
+        )}
       </Space>
 
       {isMobile ? (
@@ -240,6 +292,7 @@ export function SessionList() {
       ) : (
         <Table
           rowKey="id"
+          rowSelection={rowSelection}
           columns={columns}
           dataSource={sessionsData}
           loading={isLoading}

--- a/frontend/src/features/admin/services/admin.ts
+++ b/frontend/src/features/admin/services/admin.ts
@@ -627,6 +627,19 @@ export function deleteAdminSession(id: string): Promise<void> {
   return api<void>(`/admin/sessions/${id}`, { method: "DELETE" });
 }
 
+export interface AdminBatchDeleteResult {
+  deleted: number;
+  skipped: Array<{ id: string; reason: string }>;
+  errors: string[];
+}
+
+export function deleteAdminSessions(ids: string[]): Promise<AdminBatchDeleteResult> {
+  return api<AdminBatchDeleteResult>("/admin/sessions/delete", {
+    method: "POST",
+    body: { ids },
+  });
+}
+
 // =============================================================================
 // MCP Servers
 // =============================================================================

--- a/frontend/src/features/chat/components/SessionSidebar.test.tsx
+++ b/frontend/src/features/chat/components/SessionSidebar.test.tsx
@@ -23,12 +23,14 @@ const {
   mockListSessions,
   mockCreateSession,
   mockDeleteSession,
+  mockDeleteSessions,
   mockUpdateSession,
   mockImportSession,
 } = vi.hoisted(() => ({
   mockListSessions: vi.fn(),
   mockCreateSession: vi.fn(),
   mockDeleteSession: vi.fn(),
+  mockDeleteSessions: vi.fn(),
   mockUpdateSession: vi.fn(),
   mockImportSession: vi.fn(),
 }));
@@ -37,6 +39,7 @@ vi.mock("../services/chat", () => ({
   listSessions: mockListSessions,
   createSession: mockCreateSession,
   deleteSession: mockDeleteSession,
+  deleteSessions: mockDeleteSessions,
   updateSession: mockUpdateSession,
   exportSession: vi.fn(),
   importSession: mockImportSession,
@@ -377,5 +380,95 @@ describe("SessionSidebar", () => {
     // Ant Design List shows a Spin when loading
     const spinner = document.querySelector(".ant-spin");
     expect(spinner).toBeInTheDocument();
+  });
+
+  // ── Batch delete: selection mode toggle ───────────────────────────────
+
+  it("toggles selection mode when select button is clicked", async () => {
+    renderSidebar();
+    await settle();
+
+    // Find the select button (CheckSquareOutlined icon)
+    const selectBtn = document.querySelector(".anticon-check-square");
+    expect(selectBtn).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(selectBtn!.closest("button")!);
+
+    // Checkboxes should now appear on session items
+    const checkboxes = document.querySelectorAll(".ant-checkbox");
+    expect(checkboxes.length).toBeGreaterThan(0);
+
+    // Batch action bar should appear with "0 selected"
+    expect(screen.getByText("0 selected")).toBeInTheDocument();
+
+    // Click the select button again to exit selection mode
+    const closeBtn = document.querySelector(".anticon-close");
+    await user.click(closeBtn!.closest("button")!);
+
+    // Checkboxes should disappear
+    const checkboxesAfter = document.querySelectorAll(".ant-checkbox");
+    expect(checkboxesAfter.length).toBe(0);
+  });
+
+  // ── Batch delete: select and delete sessions ──────────────────────────
+
+  it("selects sessions and calls deleteSessions on confirm", async () => {
+    mockDeleteSessions.mockResolvedValue({
+      deleted: 2,
+      skipped: [],
+      errors: [],
+    });
+
+    renderSidebar();
+    await settle();
+
+    const user = userEvent.setup();
+
+    // Enter selection mode
+    const selectBtn = document.querySelector(".anticon-check-square");
+    await user.click(selectBtn!.closest("button")!);
+
+    // Click two session items to select them in selection mode
+    const sessionItems = document.querySelectorAll("[data-session-id]");
+    await user.click(sessionItems[0]); // session-pinned-1
+    await user.click(sessionItems[2]); // session-1 (active)
+
+    // The action bar should show "2 selected"
+    expect(screen.getByText("2 selected")).toBeInTheDocument();
+
+    // Click "Delete Selected" button
+    const deleteSelectedBtn = screen.getByRole("button", { name: /delete selected/i });
+    await user.click(deleteSelectedBtn);
+
+    // Confirmation modal should appear — check that modal exists
+    expect(document.querySelector(".ant-modal-confirm-title")).toBeInTheDocument();
+
+    // Click the OK button in the modal
+    const confirmBtn = screen.getByRole("button", { name: "Delete" });
+    await user.click(confirmBtn);
+
+    // Wait for the mutation to resolve
+    await settle();
+
+    expect(mockDeleteSessions).toHaveBeenCalledWith([
+      "session-pinned-1",
+      "session-1",
+    ]);
+
+    // Since session-1 was the active session, should navigate away
+    expect(mockNavigate).toHaveBeenCalledWith("/chat");
+  });
+
+  // ── Batch delete: disabled for streaming sessions ─────────────────────
+
+  it("disables the select button when sessions list is empty", async () => {
+    mockListSessions.mockResolvedValue([]);
+    renderSidebar();
+    await settle();
+
+    // Select button should not be rendered when no sessions
+    const selectBtn = document.querySelector(".anticon-check-square");
+    expect(selectBtn).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/chat/components/SessionSidebar.tsx
+++ b/frontend/src/features/chat/components/SessionSidebar.tsx
@@ -23,6 +23,7 @@ import {
   message,
   Tag,
   Popconfirm,
+  Checkbox,
 } from "antd";
 import type { MenuProps } from "antd";
 import {
@@ -47,6 +48,8 @@ import {
   FileOutlined,
   FolderOpenOutlined,
   ClockCircleOutlined,
+  CheckSquareOutlined,
+  CloseOutlined,
 } from "@ant-design/icons";
 import { Logo } from "../../../shared/components/Logo";
 import { useNavigate, useParams } from "react-router-dom";
@@ -57,6 +60,7 @@ import {
   listSessions,
   createSession,
   deleteSession,
+  deleteSessions,
   updateSession,
   SessionData,
   addTagToSession,
@@ -83,6 +87,8 @@ export function SessionSidebar() {
   const [editTitle, setEditTitle] = useState("");
   const [searchOpen, setSearchOpen] = useState(false);
   const [memoryOpen, setMemoryOpen] = useState(false);
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { streamingSessionIds, removeStreamingSession } = useStreamingContext();
@@ -216,6 +222,32 @@ export function SessionSidebar() {
     },
   });
 
+  const batchDeleteMutation = useMutation({
+    mutationFn: (ids: string[]) => deleteSessions(ids),
+    onSuccess: (data, ids) => {
+      queryClient.invalidateQueries({ queryKey: ["sessions"] });
+      if (data.deleted > 0) {
+        message.success(`Deleted ${data.deleted} session${data.deleted !== 1 ? "s" : ""}`);
+      }
+      if (data.skipped.length > 0) {
+        message.warning(`${data.skipped.length} session${data.skipped.length !== 1 ? "s" : ""} skipped (not owned or not found)`);
+      }
+      if (data.errors.length > 0) {
+        message.error(`${data.errors.length} error${data.errors.length !== 1 ? "s" : ""} during deletion`);
+      }
+      setSelectMode(false);
+      setSelectedIds(new Set());
+      if (sessionId && ids.includes(sessionId)) {
+        navigate("/chat");
+      }
+    },
+    onError: (err: Error) => {
+      message.error(`Failed to delete sessions: ${err.message}`);
+      setSelectMode(false);
+      setSelectedIds(new Set());
+    },
+  });
+
   // Sort: pinned first, then by updated_at.
   const sortedSessions = [...(sessions || [])]
     .sort((a, b) => {
@@ -294,6 +326,21 @@ export function SessionSidebar() {
           {!collapsed && (
             <Space size={4} style={{ marginLeft: "auto" }}>
               {sessionExists && <ContextIndicator sessionId={sessionId} />}
+              {sessions && sessions.length > 0 && (
+                <Tooltip title={selectMode ? "Cancel selection" : "Select sessions"}>
+                  <Button
+                    type="text"
+                    icon={selectMode ? <CloseOutlined /> : <CheckSquareOutlined />}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setSelectMode(!selectMode);
+                      if (selectMode) {
+                        setSelectedIds(new Set());
+                      }
+                    }}
+                  />
+                </Tooltip>
+              )}
               <Tooltip title="Search">
                 <Button
                   type="text"
@@ -418,6 +465,18 @@ export function SessionSidebar() {
               <List.Item
                 data-session-id={item.id}
                 onClick={() => {
+                  if (selectMode) {
+                    setSelectedIds((prev) => {
+                      const next = new Set(prev);
+                      if (next.has(item.id)) {
+                        next.delete(item.id);
+                      } else {
+                        next.add(item.id);
+                      }
+                      return next;
+                    });
+                    return;
+                  }
                   navigate(sessionId === item.id ? "/chat" : `/chat/${item.id}`);
                   if (isMobile) setMobileOpen(false);
                 }}
@@ -425,13 +484,16 @@ export function SessionSidebar() {
                   cursor: "pointer",
                   padding: "8px 12px",
                   background:
-                    sessionId === item.id ? "#e6f4ff" : "transparent",
+                    sessionId === item.id && !selectMode ? "#e6f4ff" : "transparent",
                   borderLeft:
-                    sessionId === item.id
+                    sessionId === item.id && !selectMode
                       ? "3px solid #1677ff"
                       : "3px solid transparent",
                 }}
-                actions={[
+                actions={
+                  selectMode
+                    ? []
+                    : [
                   <Tooltip title="Edit" key="edit">
                     <Button
                       type="text"
@@ -521,9 +583,30 @@ export function SessionSidebar() {
                       />
                     </Tooltip>
                   </Popconfirm>,
-                ]}
+                ]
+                }
               >
                 <List.Item.Meta
+                  avatar={
+                    selectMode ? (
+                      <Checkbox
+                        checked={selectedIds.has(item.id)}
+                        disabled={streamingSessionIds.has(item.id)}
+                        onClick={(e) => e.stopPropagation()}
+                        onChange={() => {
+                          setSelectedIds((prev) => {
+                            const next = new Set(prev);
+                            if (next.has(item.id)) {
+                              next.delete(item.id);
+                            } else {
+                              next.add(item.id);
+                            }
+                            return next;
+                          });
+                        }}
+                      />
+                    ) : undefined
+                  }
                   title={
                     <Space size={4} style={{ display: "flex", alignItems: "center" }}>
                       {streamingSessionIds.has(item.id) && (
@@ -581,6 +664,74 @@ export function SessionSidebar() {
               </List.Item>
             )}
           />
+        )}
+
+        {selectMode && (
+          <div
+            style={{
+              position: "sticky",
+              bottom: 0,
+              background: "#fff",
+              borderTop: "1px solid #f0f0f0",
+              padding: "8px 12px",
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+            }}
+          >
+            <Text type="secondary" style={{ fontSize: 13, flexShrink: 0 }}>
+              {selectedIds.size} selected
+            </Text>
+            <Button
+              size="small"
+              onClick={() => {
+                const selectable = sortedSessions.filter(
+                  (s) => !streamingSessionIds.has(s.id)
+                );
+                if (selectable.length === selectedIds.size) {
+                  setSelectedIds(new Set());
+                } else {
+                  setSelectedIds(new Set(selectable.map((s) => s.id)));
+                }
+              }}
+            >
+              {selectedIds.size ===
+              sortedSessions.filter((s) => !streamingSessionIds.has(s.id)).length
+                ? "Deselect All"
+                : "Select All"}
+            </Button>
+            <div style={{ flex: 1 }} />
+            <Button
+              type="primary"
+              danger
+              size="small"
+              disabled={selectedIds.size === 0}
+              loading={batchDeleteMutation.isPending}
+              onClick={() => {
+                const ids = [...selectedIds];
+                const isActiveSelected = sessionId && ids.includes(sessionId);
+                Modal.confirm({
+                  title: `Delete ${ids.length} session${ids.length !== 1 ? "s" : ""}?`,
+                  content: (
+                    <div>
+                      <p>This will permanently delete {ids.length} session{ids.length !== 1 ? "s" : ""} and all their messages. This action cannot be undone.</p>
+                      {isActiveSelected && (
+                        <p style={{ color: "#ff4d4f", fontWeight: 500 }}>
+                          Warning: Your current chat will also be deleted.
+                        </p>
+                      )}
+                    </div>
+                  ),
+                  okText: "Delete",
+                  okButtonProps: { danger: true },
+                  cancelText: "Cancel",
+                  onOk: () => batchDeleteMutation.mutate(ids),
+                });
+              }}
+            >
+              Delete Selected
+            </Button>
+          </div>
         )}
       </div>
 

--- a/frontend/src/features/chat/services/chat.ts
+++ b/frontend/src/features/chat/services/chat.ts
@@ -145,6 +145,19 @@ export function deleteSession(id: string): Promise<void> {
   return api<void>(`/chat/session/${id}`, { method: "DELETE" });
 }
 
+export interface BatchDeleteResult {
+  deleted: number;
+  skipped: Array<{ id: string; reason: string }>;
+  errors: string[];
+}
+
+export function deleteSessions(ids: string[]): Promise<BatchDeleteResult> {
+  return api<BatchDeleteResult>("/chat/sessions/delete", {
+    method: "POST",
+    body: { ids },
+  });
+}
+
 export function finalizeSession(id: string): Promise<SessionData> {
   return api<SessionData>(`/chat/session/${id}/finalize`, {
     method: "POST",


### PR DESCRIPTION
## Description

Adds the ability to mass-select and delete chat sessions from the sidebar (user-facing) and from the admin session list. Introduces a new backend endpoint `/chat/sessions/delete` for users and `/admin/sessions/delete` for admins/managers, supporting up to 100 sessions per request. The service layer handles permanent and temporary sessions, skips unowned or missing sessions, and cleans up associated messages, files, tags, and memories.

## Related Issue

Closes #460

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring / Code style cleanup
- [ ] Infrastructure / CI / Build
- [ ] Other (please describe):

## Testing

- [x] Tested locally with Docker Compose (dev)
- [x] Backend tests pass (`pytest backend/tests/ -m "not e2e and not slow"`)
- [ ] Frontend builds without errors (`npm run build`)
- [x] Manual testing completed (describe what you tested: verified batch delete via sidebar and admin UI, including error/skip handling)

## Checklist

- [x] My code follows the coding conventions of this project
- [x] I have self-reviewed my own code
- [x] I have commented complex code sections, particularly in hard-to-understand areas
- [ ] I have updated the documentation (`docs/`) if my change affects user-facing behaviour or configuration
- [x] My changes generate no new warnings or errors
- [x] New and existing tests pass locally

## Screenshots (if applicable)

N/A

## Additional Notes

The frontend UI adds a selection mode toggle in the sidebar and a checkbox column in the admin table, with confirmation modals before deletion. The backend supports both permanent (DB) and temporary (Redis) sessions, and handles cross-tenant authorization for managers.

