### PR TITLE
Fix MIME type fallback and flaky OAuth test

### DIFF
--- a/backend/src/services/upload_service.py
+++ b/backend/src/services/upload_service.py
@@ -162,17 +162,10 @@ def _resolve_content_type(content_type: str, filename: str) -> str:
     if guessed:
         return guessed
 
-    # Nothing worked — fall back to text/plain instead of returning
-    # the opaque generic type (which would fail validation).
-    # This matches user expectation: most files users try to upload
-    # are text-like, and security is maintained by the 100 MiB size
-    # cap and filename sanitization.
-    logger.info(
-        "Could not resolve MIME type for '%s' (reported: %s). "
-        "Falling back to text/plain.",
-        filename, content_type,
-    )
-    return "text/plain"
+    # Nothing worked — return the original (the caller may apply its
+    # own text/plain fallback for generic browser-reported types;
+    # see Issue #473).
+    return content_type
 
 
 # ---------------------------------------------------------------------------
@@ -287,6 +280,22 @@ async def create_upload(
     allowed_types = [
         t.strip() for t in settings.UPLOAD_ALLOWED_TYPES.split(",") if t.strip()
     ]
+    if resolved_type not in allowed_types:
+        # 1a. Final safety net (Issue #473): if the browser reported a
+        #     generic / opaque type (e.g. application/octet-stream) and
+        #     the resolved type is still not in the allowlist, fall back
+        #     to text/plain.  This lets users upload files with unknown
+        #     extensions (e.g. notes.xyz) while still blocking files
+        #     whose browser-reported type is already specific and
+        #     disallowed (e.g. application/x-msdownload for .exe).
+        if content_type in _GENERIC_MIME_TYPES:
+            logger.info(
+                "Content type '%s' for '%s' not allowed; "
+                "original browser type was generic. Falling back to text/plain.",
+                resolved_type, original_filename,
+            )
+            resolved_type = "text/plain"
+
     if resolved_type not in allowed_types:
         raise ValidationError(
             f"File type '{resolved_type}' is not allowed. "

--- a/backend/tests/test_filename_sanitization.py
+++ b/backend/tests/test_filename_sanitization.py
@@ -226,25 +226,39 @@ class TestResolveContentType:
         """.toml files resolve to text/plain."""
         assert _resolve_content_type("application/octet-stream", "pyproject.toml") == "text/plain"
 
-    def test_env_extension_resolves_to_text_plain(self):
-        """.env files resolve to text/plain."""
-        assert _resolve_content_type("application/octet-stream", ".env") == "text/plain"
+    def test_env_extension_not_overridden_to_text_plain_directly(self):
+        """`_resolve_content_type` does not map .env (os.path.splitext
+        treats it as an extension-less filename; fallback is in create_upload).
+        """
+        result = _resolve_content_type("application/octet-stream", ".env")
+        # .env is treated as extension-less by splitext → not in overrides.
+        # The text/plain fallback happens in create_upload(), not here.
+        assert result != "text/plain"
 
     def test_tf_extension_resolves_to_text_plain(self):
         """.tf files resolve to text/plain."""
         assert _resolve_content_type("application/octet-stream", "main.tf") == "text/plain"
 
-    def test_unknown_extension_falls_back_to_text_plain(self):
-        """A truly unknown extension falls back to text/plain."""
-        assert _resolve_content_type("application/octet-stream", "notes.xyz") == "text/plain"
+    def test_unknown_extension_not_overridden_to_text_plain(self):
+        """`_resolve_content_type` no longer applies a text/plain fallback.
+        The safety net is now in ``create_upload()``, not here.
+        """
+        result = _resolve_content_type("application/octet-stream", "notes.xyz")
+        # The result depends on the system's mimetypes DB:
+        # - Docker (Debian): None → returns application/octet-stream
+        # - CI (Ubuntu): maps .xyz → chemical/x-xyz
+        # Either way, it should NOT be text/plain (that's in create_upload).
+        assert result != "text/plain"
 
-    def test_no_extension_falls_back_to_text_plain(self):
-        """A filename without extension falls back to text/plain."""
-        assert _resolve_content_type("application/octet-stream", "README") == "text/plain"
+    def test_no_extension_returns_original_type(self):
+        """A filename without extension returns the original generic type."""
+        result = _resolve_content_type("application/octet-stream", "README")
+        assert result == "application/octet-stream"
 
-    def test_empty_filename_falls_back_to_text_plain(self):
-        """An empty filename falls back to text/plain."""
-        assert _resolve_content_type("application/octet-stream", "") == "text/plain"
+    def test_empty_filename_returns_original_type(self):
+        """An empty filename returns the original generic type."""
+        result = _resolve_content_type("application/octet-stream", "")
+        assert result == "application/octet-stream"
 
     def test_office_extensions_still_resolve_correctly(self):
         """Office extensions still resolve to their proper MIME types."""

--- a/backend/tests/test_oauth_state_security.py
+++ b/backend/tests/test_oauth_state_security.py
@@ -107,19 +107,27 @@ class TestOAuthStateStoreEdgeCases:
         assert isinstance(payload3, str)  # returned as-is, not validated
 
     async def test_expiry_boundary_precision(self):
-        """Verify state is retrievable just before TTL and gone after."""
-        # Key A — store with 2-second TTL, read at ~1.5s (should exist)
+        """Verify state is retrievable before TTL and gone after expiry.
+
+        Uses generous timing margins to avoid flakiness on loaded CI runners.
+        The key insight: ``asyncio.sleep()`` is imprecise under load, so we
+        give ourselves 4x the TTL margin on each side.
+        """
+        r = await get_redis()
+
+        # Key A — store with 5-second TTL, read at ~1s (should easily exist)
         nonce_a = f"boundary-a-{uuid.uuid4().hex}"
-        await store_oauth_state(nonce_a, "user-1", "email_tool", ttl=2)
-        await asyncio.sleep(1.5)
+        await store_oauth_state(nonce_a, "user-1", "email_tool", ttl=5)
+        await asyncio.sleep(1)
 
         payload = await get_oauth_state(nonce_a)
         assert payload is not None, "State should still exist before TTL expiry"
+        assert payload["user_id"] == "user-1"
 
-        # Key B — store with 1-second TTL, read at ~2.5s (should be gone)
+        # Key B — store with 1-second TTL, read at ~3s (should be gone)
         nonce_b = f"boundary-b-{uuid.uuid4().hex}"
         await store_oauth_state(nonce_b, "user-2", "email_tool", ttl=1)
-        await asyncio.sleep(1.5)
+        await asyncio.sleep(2)
 
         payload = await get_oauth_state(nonce_b)
         assert payload is None, "State should have expired after TTL"


### PR DESCRIPTION
## Description

Move the text/plain MIME type fallback from the resolver (`_resolve_content_type`) to the caller (`create_upload()`). This ensures the fallback only applies when the browser-reported type is generic (e.g., `application/octet-stream`), allowing specific but disallowed types to be properly rejected. Also increase timing margins in the OAuth state expiry test to eliminate flakiness on loaded CI runners.

## Related Issue

Closes #473

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring / Code style cleanup
- [ ] Infrastructure / CI / Build
- [ ] Other (please describe):

## Testing

- [x] Tested locally with Docker Compose (dev)
- [x] Backend tests pass (`pytest backend/tests/ -m "not e2e and not slow"`)
- [ ] Frontend builds without errors (`npm run build`)
- [ ] Manual testing completed (describe what you tested)

## Checklist

- [x] My code follows the coding conventions of this project
- [x] I have self-reviewed my own code
- [x] I have commented complex code sections, particularly in hard-to-understand areas
- [ ] I have updated the documentation (`docs/`) if my change affects user-facing behaviour or configuration
- [x] My changes generate no new warnings or errors
- [x] New and existing tests pass locally

## Screenshots (if applicable)

N/A

## Additional Notes

The flaky test fix uses a 5-second TTL and a 1-second wait for the “alive” check, and a 1-second TTL with a 2-second wait for the “expired” check, giving a generous margin under load.

