### PR TITLE
Fix goal field not persisting for goal-based skills

### DIFF
--- a/backend/src/api/admin.py
+++ b/backend/src/api/admin.py
@@ -2512,6 +2512,7 @@ async def admin_update_skill(
         "enabled",
         "cross_session_retrieval_enabled", "cross_session_max_snippets",
         "cross_session_min_score", "a2a_metadata",
+        "goal", "constraints", "success_criteria", "agent_config",
     ):
         val = getattr(body, field, None)
         if val is not None:

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -260,7 +260,7 @@ async def lifespan(app: FastAPI):
         _scheduler_task.cancel()
 
 
-app = FastAPI(title="PH Agent Hub", version="2.1.0", lifespan=lifespan)
+app = FastAPI(title="PH Agent Hub", version="2.1.1", lifespan=lifespan)
 
 # ---------------------------------------------------------------------------
 # Middleware

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ph-agent-hub-frontend",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000 --host",

--- a/frontend/src/features/admin/resources/skills/SkillForm.tsx
+++ b/frontend/src/features/admin/resources/skills/SkillForm.tsx
@@ -94,6 +94,10 @@ export function SkillForm({ open, skill, duplicateFrom, onClose }: SkillFormProp
           cross_session_retrieval_enabled: duplicateFrom.cross_session_retrieval_enabled ?? false,
           cross_session_max_snippets: duplicateFrom.cross_session_max_snippets ?? 3,
           cross_session_min_score: duplicateFrom.cross_session_min_score ?? 0.30,
+          goal: duplicateFrom.goal,
+          constraints: duplicateFrom.constraints,
+          success_criteria: duplicateFrom.success_criteria,
+          agent_config: duplicateFrom.agent_config ? { max_turns: duplicateFrom.agent_config.max_turns } : undefined,
         });
       } else if (skill) {
         form.setFieldsValue({
@@ -111,6 +115,10 @@ export function SkillForm({ open, skill, duplicateFrom, onClose }: SkillFormProp
           cross_session_retrieval_enabled: skill.cross_session_retrieval_enabled ?? false,
           cross_session_max_snippets: skill.cross_session_max_snippets ?? 3,
           cross_session_min_score: skill.cross_session_min_score ?? 0.30,
+          goal: skill.goal,
+          constraints: skill.constraints,
+          success_criteria: skill.success_criteria,
+          agent_config: skill.agent_config ? { max_turns: skill.agent_config.max_turns } : undefined,
         });
       } else {
         form.resetFields();

--- a/frontend/src/features/chat/components/PersonalSkillEditor.tsx
+++ b/frontend/src/features/chat/components/PersonalSkillEditor.tsx
@@ -54,6 +54,10 @@ interface SkillData {
   created_at: string;
   updated_at: string;
   tool_ids: string[];
+  goal?: string;
+  constraints?: string[];
+  success_criteria?: string;
+  agent_config?: { max_turns?: number };
 }
 
 interface PersonalSkillEditorProps {


### PR DESCRIPTION


## Description



The goal, constraints, success_criteria, and agent_config fields were not being included when updating a skill via the admin API or when duplicating/editing a skill in the frontend. This caused the goal to appear empty after creation. Added the missing fields to the backend update handler and to the frontend form initialization and interface type.



## Related Issue



Closes #493



## Type of Change



- [x] Bug fix (non-breaking change that fixes an issue)

- [ ] New feature (non-breaking change that adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

- [ ] Documentation update

- [ ] Refactoring / Code style cleanup

- [ ] Infrastructure / CI / Build

- [ ] Other (please describe):



## Testing



- [x] Tested locally with Docker Compose (dev)

- [x] Backend tests pass (`pytest backend/tests/ -m "not e2e and not slow"`)

- [x] Frontend builds without errors (`npm run build`)

- [x] Manual testing completed (verified goal field now persists after save)



## Checklist



- [x] My code follows the coding conventions of this project

- [x] I have self-reviewed my own code

- [ ] I have commented complex code sections, particularly in hard-to-understand areas

- [ ] I have updated the documentation (`docs/`) if my change affects user-facing behaviour or configuration

- [x] My changes generate no new warnings or errors

- [x] New and existing tests pass locally

- [ ] **Migration safety** (if adding/modifying a migration): N/A

- [ ] **Screenshots (if applicable)**: N/A



## Additional Notes



Also bumped version numbers to 2.1.1 to reflect the fix.

