### PR TITLE
Add message preview and expand/collapse functionality in MessageBubble component

### DIFF
--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -1676,6 +1676,16 @@ export const ChatWindow = React.memo(function ChatWindow({
     toolEvents,
   ]);
 
+  const latestUserMessageId = useMemo(() => {
+    const userMessages = (displayMessages || []).filter((m: any) => m.sender === "user" && !m.is_deleted);
+    return userMessages[userMessages.length - 1]?.id ?? null;
+  }, [displayMessages]);
+
+  const latestAssistantMessageId = useMemo(() => {
+    const assistantMessages = (displayMessages || []).filter((m: any) => m.sender === "assistant" && !m.is_deleted);
+    return assistantMessages[assistantMessages.length - 1]?.id ?? null;
+  }, [displayMessages]);
+
   return (
     <div
       style={{
@@ -1945,6 +1955,8 @@ export const ChatWindow = React.memo(function ChatWindow({
                 key={msg.id}
                 message={msg}
                 sessionId={sessionId}
+                isLatestUserMessage={msg.sender === "user" && msg.id === latestUserMessageId}
+                isLatestAssistantMessage={msg.sender === "assistant" && msg.id === latestAssistantMessageId}
                 showFeedback={!embedded && !demo}
                 onEdit={
                   msg.sender === "user" && !isTemporary

--- a/frontend/src/features/chat/components/MessageBubble.test.tsx
+++ b/frontend/src/features/chat/components/MessageBubble.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MessageBubble } from "./MessageBubble";
+
+function renderBubble(props: Partial<React.ComponentProps<typeof MessageBubble>> = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MessageBubble
+        message={{
+          id: "msg-1",
+          session_id: "session-1",
+          sender: "user",
+          content: [{ type: "text", text: "short" }],
+          model_id: null,
+          tool_calls: [],
+          tokens_in: null,
+          tokens_out: null,
+          is_deleted: false,
+          created_at: "2024-01-01T00:00:00Z",
+          updated_at: "2024-01-01T00:00:00Z",
+        }}
+        sessionId="session-1"
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("MessageBubble", () => {
+  it("keeps the newest user message fully visible", () => {
+    const longText = "A".repeat(2000);
+
+    renderBubble({
+      message: {
+        id: "msg-latest",
+        session_id: "session-1",
+        sender: "user",
+        content: [{ type: "text", text: longText }],
+        model_id: null,
+        tool_calls: [],
+        tokens_in: null,
+        tokens_out: null,
+        is_deleted: false,
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+      },
+      isLatestUserMessage: true,
+    });
+
+    expect(screen.getByText(longText)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /show more/i })).not.toBeInTheDocument();
+  });
+
+  it("collapses older long user messages and expands them on demand", async () => {
+    const longText = "This is a long user message. " + "B".repeat(2400);
+    const user = userEvent.setup();
+
+    renderBubble({
+      message: {
+        id: "msg-old",
+        session_id: "session-1",
+        sender: "user",
+        content: [{ type: "text", text: longText }],
+        model_id: null,
+        tool_calls: [],
+        tokens_in: null,
+        tokens_out: null,
+        is_deleted: false,
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+      },
+      isLatestUserMessage: false,
+    });
+
+    const toggle = screen.getByRole("button", { name: /show more/i });
+    expect(toggle).toBeInTheDocument();
+
+    await user.click(toggle);
+    expect(screen.getByRole("button", { name: /show less/i })).toBeInTheDocument();
+    expect(screen.getByText(longText)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/chat/components/MessageBubble.tsx
+++ b/frontend/src/features/chat/components/MessageBubble.tsx
@@ -33,6 +33,17 @@ import { getToken } from "../../../services/api";
 
 const { Text, Paragraph } = Typography;
 
+function textUtilsToString(items: ContentItem[]): string {
+  return items.map((item) => item.text || "").join("\n").trim();
+}
+
+function truncateMessagePreview(text: string): string {
+  const compact = text.replace(/\s+/g, " ").trim();
+  const maxChars = 700;
+  if (compact.length <= maxChars) return compact;
+  return `${compact.slice(0, maxChars).trimEnd()}…`;
+}
+
 // ---------------------------------------------------------------------------
 // Internal: parse content into displayable items
 // ---------------------------------------------------------------------------
@@ -79,6 +90,8 @@ interface MessageBubbleProps {
   disabled?: boolean;
   regenerating?: boolean;
   streaming?: boolean;
+  isLatestUserMessage?: boolean;
+  isLatestAssistantMessage?: boolean;
   /** Live elapsed duration for the currently streaming assistant message (ms since start). */
   streamingDuration?: number | null;
 }
@@ -137,14 +150,29 @@ function MessageBubbleInner({
   disabled,
   regenerating,
   streaming,
+  isLatestUserMessage = false,
+  isLatestAssistantMessage = false,
   streamingDuration,
 }: MessageBubbleProps) {
   const isUser = message.sender === "user";
   const isSystem = message.sender === "system";
   const contentItems = parseContent(message.content);
 
+  // Separate text, reasoning, and tool events
+  const textItems = contentItems.filter((c) => c.type === "text");
+  const reasoningItems = contentItems.filter((c) => c.type === "reasoning");
+  const toolItems = contentItems.filter(
+    (c) => c.type === "function_call" || c.type === "function_result",
+  );
+
+  const rawText = textUtilsToString(textItems);
+  const previewText = truncateMessagePreview(rawText);
+  const isLatestVisibleMessage = isUser ? isLatestUserMessage : !isSystem && isLatestAssistantMessage;
+  const shouldCollapseText = !isSystem && !isLatestVisibleMessage && rawText.length > 0 && (rawText.length > 700 || rawText.split(/\r?\n/).length > 8);
+
   // Inline editing state for assistant messages
   const [isEditingAssistant, setIsEditingAssistant] = useState(false);
+  const [isExpandedText, setIsExpandedText] = useState(false);
   const [editContent, setEditContent] = useState("");
   const [savingEdit, setSavingEdit] = useState(false);
 
@@ -156,12 +184,9 @@ function MessageBubbleInner({
     }
   }, [message.id]);
 
-  // Separate text, reasoning, and tool events
-  const textItems = contentItems.filter((c) => c.type === "text");
-  const reasoningItems = contentItems.filter((c) => c.type === "reasoning");
-  const toolItems = contentItems.filter(
-    (c) => c.type === "function_call" || c.type === "function_result",
-  );
+  useEffect(() => {
+    setIsExpandedText(false);
+  }, [message.id]);
 
   const bubbleStyle: React.CSSProperties = {
     padding: "12px 16px",
@@ -328,49 +353,69 @@ function MessageBubbleInner({
             </Space>
           </div>
         ) : (
-          textItems.map((item, i) => (
-            <div key={i} style={isUser ? undefined : { maxWidth: 750 }}>
-              {isUser ? (
-                <Text style={{ color: "#fff", whiteSpace: "pre-wrap" }}>
-                  {item.text}
-                </Text>
-              ) : (
-                <div className="markdown-body" style={{ fontSize: 14 }}>
-                  <ReactMarkdown
-                    remarkPlugins={[remarkGfm]}
-                    components={{
-                      code({ className, children, ...props }) {
-                        const match = /language-(\w+)/.exec(
-                          className || "",
-                        );
-                        const codeStr = String(children).replace(
-                          /\n$/,
-                          "",
-                        );
-                        if (match) {
-                          return (
-                            <CodeBlock language={match[1]}>
-                              {codeStr}
-                            </CodeBlock>
-                          );
-                        }
-                        return (
-                          <code
-                            className={className}
-                            {...(props as Record<string, unknown>)}
-                          >
-                            {children}
-                          </code>
-                        );
-                      },
-                    }}
-                  >
-                    {item.text || ""}
-                  </ReactMarkdown>
-                </div>
-              )}
-            </div>
-          ))
+          <>
+            {textItems.length === 0 ? null : (
+              <div style={isUser ? undefined : { maxWidth: 750 }}>
+                {isUser ? (
+                  <Text style={{ color: "#fff", whiteSpace: "pre-wrap" }}>
+                    {shouldCollapseText && !isExpandedText ? previewText : textItems.map((item) => item.text || "").join("\n")}
+                  </Text>
+                ) : (
+                  <div className="markdown-body" style={{ fontSize: 14 }}>
+                    {shouldCollapseText && !isExpandedText ? (
+                      <Text style={{ whiteSpace: "pre-wrap", color: "#333" }}>
+                        {previewText}
+                      </Text>
+                    ) : (
+                      <ReactMarkdown
+                        remarkPlugins={[remarkGfm]}
+                        components={{
+                          code({ className, children, ...props }) {
+                            const match = /language-(\w+)/.exec(
+                              className || "",
+                            );
+                            const codeStr = String(children).replace(
+                              /\n$/,
+                              "",
+                            );
+                            if (match) {
+                              return (
+                                <CodeBlock language={match[1]}>
+                                  {codeStr}
+                                </CodeBlock>
+                              );
+                            }
+                            return (
+                              <code
+                                className={className}
+                                {...(props as Record<string, unknown>)}
+                              >
+                                {children}
+                              </code>
+                            );
+                          },
+                        }}
+                      >
+                        {textItems.map((item) => item.text || "").join("\n")}
+                      </ReactMarkdown>
+                    )}
+                  </div>
+                )}
+                {shouldCollapseText && (
+                  <div style={{ marginTop: 8 }}>
+                    <Button
+                      type="link"
+                      size="small"
+                      onClick={() => setIsExpandedText((v) => !v)}
+                      style={{ padding: 0, color: isUser ? "#fff" : undefined }}
+                    >
+                      {isExpandedText ? "Show less" : "Show more"}
+                    </Button>
+                  </div>
+                )}
+              </div>
+            )}
+          </>
         )}
 
         {/* Tool calls / results */}


### PR DESCRIPTION
## Description

Enhance the MessageBubble component by adding a message preview feature and the ability to expand or collapse long messages. This improves user experience by keeping the interface clean while allowing access to full message content when needed.

## Related Issue

Closes #511

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring / Code style cleanup
- [ ] Infrastructure / CI / Build
- [ ] Other (please describe):

## Testing

- [x] Tested locally with Docker Compose (dev)
- [ ] Backend tests pass (`pytest backend/tests/ -m "not e2e and not slow"`)
- [x] Frontend builds without errors (`npm run build`)
- [x] Manual testing completed (tested message preview and expand/collapse functionality)

## Checklist

- [x] My code follows the coding conventions of this project
- [x] I have self-reviewed my own code
- [ ] I have commented complex code sections, particularly in hard-to-understand areas
- [ ] I have updated the documentation (`docs/`) if my change affects user-facing behaviour or configuration
- [x] My changes generate no new warnings or errors
- [x] New and existing tests pass locally
- [ ] **Migration safety** (if adding/modifying a migration):
  - [ ] Migration has a valid downgrade path (not just `pass`)
  - [ ] Migration is idempotent (safe to run multiple times)
  - [ ] If ENUM change: checked table size; planned maintenance window if large
  - [ ] If DROP COLUMN/TABLE: confirmed no production data loss
  - [ ] If data backfill: tested on staging copy of production data
  - [ ] `alembic upgrade heads` tested locally (DAG has a single head)
  - [ ] `alembic downgrade -1` tested locally (rollback works)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, especially for UI changes. -->

## Additional Notes

<!-- Any other information reviewers should know? -->

